### PR TITLE
SqlAgListener: Fix v6 IPs failing Test-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,5 +51,5 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - SqlAlwaysOnService
   - When failing to enable AlwaysOn the resource should now fail with an
     error ([issue #1190](https://github.com/dsccommunity/SqlServerDsc/issues/1190)).
-- Changes to SqlAgListener
+- SqlAgListener
   - Fix IPv6 addresses failing Test-TargetResource after listener creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,5 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - SqlAlwaysOnService
   - When failing to enable AlwaysOn the resource should now fail with an
     error ([issue #1190](https://github.com/dsccommunity/SqlServerDsc/issues/1190)).
+- Changes to SqlAgListener
+  - Fix IPv6 addresses failing Test-TargetResource after listener creation.

--- a/source/DSCResources/MSFT_SqlAGListener/MSFT_SqlAGListener.psm1
+++ b/source/DSCResources/MSFT_SqlAGListener/MSFT_SqlAGListener.psm1
@@ -69,7 +69,14 @@ function Get-TargetResource
             $ipAddress = @()
             foreach ($currentIpAddress in $presentIpAddress)
             {
-                $ipAddress += "$($currentIpAddress.IPAddress)/$($currentIpAddress.SubnetMask)"
+                if ($currentIpAddress.SubnetMask)
+                {
+                    $ipAddress += "$($currentIpAddress.IPAddress)/$($currentIpAddress.SubnetMask)"
+                }
+                else
+                {
+                    $ipAddress += "$($currentIpAddress.IPAddress)"
+                }
             }
         }
         else

--- a/tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -438,7 +438,6 @@ try
                             ),
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
-                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
                                     Add-Member -MemberType NoteProperty -Name IPAddress -Value 'f00::ba12' -PassThru
                             )
                         )

--- a/tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -438,6 +438,7 @@ try
                             ),
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
                                     Add-Member -MemberType NoteProperty -Name IPAddress -Value 'f00::ba12' -PassThru
                             )
                         )

--- a/tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -435,6 +435,11 @@ try
                                     Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
                                     Add-Member -MemberType NoteProperty -Name IPAddress -Value '192.168.0.1' -PassThru |
                                     Add-Member -MemberType NoteProperty -Name SubnetMask -Value '255.255.255.0' -PassThru
+                            ),
+                            # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
+                            (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
+                                    Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value 'f000::ba7' -PassThru
                             )
                         )
                     } -PassThru -Force
@@ -442,7 +447,7 @@ try
 
                 It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
                     $testParameters['Ensure'] = 'Present'
-                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0', 'f000::ba7')
                     $testParameters['Port'] = 5030
                     $testParameters['DHCP'] = $false
 
@@ -453,7 +458,7 @@ try
                 }
 
                 It 'Should return that desired state is present when IP address is the only set parameter' {
-                    $testParameters['IpAddress'] = '192.168.0.1/255.255.255.0'
+                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0', 'f000::ba7')
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true

--- a/tests/Unit/MSFT_SqlAGListener.Tests.ps1
+++ b/tests/Unit/MSFT_SqlAGListener.Tests.ps1
@@ -439,7 +439,7 @@ try
                             # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddressCollection
                             (New-Object -TypeName Object |    # TypeName: Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress
                                     Add-Member -MemberType NoteProperty -Name IsDHCP -Value $false -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value 'f000::ba7' -PassThru
+                                    Add-Member -MemberType NoteProperty -Name IPAddress -Value 'f00::ba12' -PassThru
                             )
                         )
                     } -PassThru -Force
@@ -447,7 +447,7 @@ try
 
                 It 'Should return that desired state is present when wanted desired state is to be Present, without DHCP' {
                     $testParameters['Ensure'] = 'Present'
-                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0', 'f000::ba7')
+                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0', 'f00::ba12')
                     $testParameters['Port'] = 5030
                     $testParameters['DHCP'] = $false
 
@@ -458,7 +458,7 @@ try
                 }
 
                 It 'Should return that desired state is present when IP address is the only set parameter' {
-                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0', 'f000::ba7')
+                    $testParameters['IpAddress'] = @('192.168.0.1/255.255.255.0', 'f00::ba12')
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $true


### PR DESCRIPTION
#### Pull Request (PR) description

This fixes Get-TargetResource to correctly format IPv4 and IPv6 addresses in Test-TargetResource.

Because v6 addresses are input without a subnet mask, any v6 addresses had '/' appended to the end of the address with an empty subnet.

DSC would fail any run after the listener was created as the desired v6 IP would be 'f000::ba7' but the test would be expecting 'f000::ba7/'

#### This Pull Request (PR) fixes the following issues

None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sqlserverdsc/1444)
<!-- Reviewable:end -->
