### PR TITLE
SqlSetup: Refresh PowerShell drive list before resolving setup.exe path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Replaced Microsoft-hosted agent (build image) `win1803` with `windows-2019`
     ([issue #1466](https://github.com/dsccommunity/SqlServerDsc/issues/1466)).
 
+- SqlSetup
+  - Refresh PowerShell drive list before attempting to resolve `setup.exe` path
+    ([issue #1482](https://github.com/dsccommunity/SqlServerDsc/issues/1482)).
+
 ## [13.4.0] - 2020-03-18
 
 ### Added

--- a/source/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
+++ b/source/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.psm1
@@ -94,6 +94,9 @@ function Get-TargetResource
 
     $InstanceName = $InstanceName.ToUpper()
 
+    # Force drive list update, to pick up any newly mounted volumes
+    $null = Get-PSDrive
+
     $SourcePath = [Environment]::ExpandEnvironmentVariables($SourcePath)
 
     if ($SourceCredential)
@@ -1032,6 +1035,9 @@ function Set-TargetResource
     {
         $FailoverClusterGroupName = 'SQL Server ({0})' -f $InstanceName
     }
+
+    # Force drive list update, to pick up any newly mounted volumes
+    $null = Get-PSDrive
 
     $getTargetResourceParameters = @{
         Action = $Action

--- a/tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -964,6 +964,7 @@ try
 
             BeforeAll {
                 # General mocks
+                Mock -CommandName Get-PSDrive -Verifiable
                 Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
                 Mock -CommandName Get-ItemProperty -ParameterFilter {
@@ -1095,6 +1096,7 @@ try
 
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -1246,6 +1248,7 @@ try
 
                                 Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 0 -Scope It
                                 Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 0 -Scope It
+                                Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                                 Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                                 Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                                 Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -1436,6 +1439,7 @@ try
 
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -1712,6 +1716,7 @@ try
 
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -1958,6 +1963,7 @@ try
 
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -2141,6 +2147,7 @@ try
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should -Be $testParameters.InstanceName
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -2304,6 +2311,7 @@ try
                         $result = Get-TargetResource @testParameters
                         $result.InstanceName | Should -Be $testParameters.InstanceName
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
@@ -2442,6 +2450,7 @@ try
                     It 'Should not attempt to collect cluster information for a standalone instance' {
                         $currentState = Get-TargetResource @testParameters
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
@@ -2496,6 +2505,7 @@ try
                     It 'Should collect information for a clustered instance' {
                         $currentState = Get-TargetResource @testParameters
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
                         Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
@@ -2762,6 +2772,7 @@ try
 
             BeforeAll {
                 # General mocks
+                Mock -CommandName Get-PSDrive -Verifiable
                 Mock -CommandName Import-SQLPSModule
                 Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
 
@@ -2925,6 +2936,7 @@ try
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Invoke-InstallationMediaCopy -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
@@ -2980,6 +2992,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3003,6 +3016,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3045,6 +3059,7 @@ try
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Invoke-InstallationMediaCopy -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
@@ -3081,6 +3096,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3098,6 +3114,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3142,6 +3159,7 @@ try
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Invoke-InstallationMediaCopy -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
@@ -3179,6 +3197,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3196,6 +3215,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3246,6 +3266,7 @@ try
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
@@ -3281,6 +3302,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3298,6 +3320,7 @@ try
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                         }
@@ -3716,6 +3739,7 @@ try
 
                         { Set-TargetResource @testParameters } | Should -Not -Throw
 
+                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
 


### PR DESCRIPTION
…resolve setup.exe path

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!
    
    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Execute `Get-PSDrive` to refresh PowerShell drive list before attempting to resolve full path to `setup.exe`.

#### This Pull Request (PR) fixes the following issues
- Fixes #1482 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1483)
<!-- Reviewable:end -->
