### PR TITLE
BREAKING CHANGE: SqlSetup: Refactored to speed up testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ### Fixed
 
+- SqlServerDsc
+  - The regular expression for `minor-version-bump-message` in the file
+    `GitVersion.yml` was changed to only raise minor version when the
+    commit message contain the word `add`, `adds`, `minor`, `feature`,
+    or `features`.
 - SqlSetup
   - The property `SqlTempdbLogFileGrowth` and `SqlTempdbFileGrowth` now returns
     the correct values. Previously the value of the growth was wrongly
@@ -23,6 +28,14 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - The function `Get-TargetResource` was changed so that the property
     `SQLTempDBDir` will now return the database `tempdb`'s property
     `PrimaryFilePath`.
+  - BREAKING CHANGE: Logic that was under feature flag `DetectionSharedFeatures`
+    was made the default and old logic that was used to detect shared features
+    was removed ([issue #1290](https://github.com/dsccommunity/SqlServerDsc/issues/1290)).
+    This was implemented because the previous implementation did not work
+    fully with SQL Server 2017.
+  - Much of the code was refactored into units (functions) to be easier to test.
+    Due to the size of the code the unit tests ran for an abnormal long time,
+    after this refactoring the unit tests runs much quicker.
 
 ## [13.5.0] - 2020-04-12
 
@@ -42,20 +55,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ### Fixed
 
-- SqlServerDsc
-  - The regular expression for `minor-version-bump-message` in the file
-    `GitVersion.yml` was changed to only raise minor version when the
-    commit message contain the word `add`, `adds`, `minor`, `feature`,
-    or `features`.
 - SqlSetup
-  - BREAKING CHANGE: Logic that was under feature flag `DetectionSharedFeatures`
-    was made the default and old logic that was used to detect shared features
-    was removed ([issue #1290](https://github.com/dsccommunity/SqlServerDsc/issues/1290)).
-    This was implemented because the previous implementation did not work
-    fully with SQL Server 2017.
-  - Much of the code was refactored into units (functions) to be easier to test.
-    Due to the size of the code the unit tests ran for an abnormal long time,
-    after this refactoring the unit tests runs much quicker.
   - Refresh PowerShell drive list before attempting to resolve `setup.exe` path
     ([issue #1482](https://github.com/dsccommunity/SqlServerDsc/issues/1482)).
 - SqlAG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Added
+
+- SqlSetup
+  - A read only property `IsClustered` was added that can be used to determine
+    if the instance is clustered.
+
+### Fixed
+
+- SqlSetup
+  - The property `SqlTempdbLogFileGrowth` and `SqlTempdbFileGrowth` now returns
+    the correct values. Previously the value of the growth was wrongly
+    divided by 1KB even if the value was in percent. Now the value for growth
+    is the sum of the average of MB and average of the percentage.
+  - The function `Get-TargetResource` was changed so that the property
+    `SQLTempDBDir` will now return the database `tempdb`'s property
+    `PrimaryFilePath`.
+
 ## [13.5.0] - 2020-04-12
 
 ### Added
@@ -25,7 +42,20 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ### Fixed
 
+- SqlServerDsc
+  - The regular expression for `minor-version-bump-message` in the file
+    `GitVersion.yml` was changed to only raise minor version when the
+    commit message contain the word `add`, `adds`, `minor`, `feature`,
+    or `features`.
 - SqlSetup
+  - BREAKING CHANGE: Logic that was under feature flag `DetectionSharedFeatures`
+    was made the default and old logic that was used to detect shared features
+    was removed ([issue #1290](https://github.com/dsccommunity/SqlServerDsc/issues/1290)).
+    This was implemented because the previous implementation did not work
+    fully with SQL Server 2017.
+  - Much of the code was refactored into units (functions) to be easier to test.
+    Due to the size of the code the unit tests ran for an abnormal long time,
+    after this refactoring the unit tests runs much quicker.
   - Refresh PowerShell drive list before attempting to resolve `setup.exe` path
     ([issue #1482](https://github.com/dsccommunity/SqlServerDsc/issues/1482)).
 - SqlAG

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 mode: ContinuousDelivery
 next-version: 13.3.0
 major-version-bump-message: '\s?(breaking|major|breaking\schange)'
-minor-version-bump-message: '\s?(add|feature|minor)'
+minor-version-bump-message: '(adds?|features?|minor)\b'
 patch-version-bump-message: '\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
 assembly-informational-format: '{NuGetVersionV2}+Sha.{Sha}.Date.{CommitDate}'
@@ -22,6 +22,5 @@ branches:
     source-branches: ['master']
 
 ignore:
-  # Ignore this commit to force the correct initial release.
-  sha: [601107e9fc8a337b6dadb67b63d5100381f29700]
+  sha: []
 merge-message-formats: {}

--- a/README.md
+++ b/README.md
@@ -1871,9 +1871,9 @@ with a feature flag, can be changed from one release to another, including
 having breaking changes.
 
 <!-- markdownlint-disable MD013 -->
-Feature flag | Description
+Flag | Description
 --- | ---
-DetectionSharedFeatures | A new way of detecting if the shared features is installed or not. This was implemented because the previous implementation did not work fully with SQL Server 2017.
+- | -
 <!-- markdownlint-enable MD013 -->
 
 #### Credentials for running the resource
@@ -1904,6 +1904,17 @@ If a service account username has a dollar sign at the end of the name it will
 be considered a Managed Service Account. Any password passed in
 the credential object will be ignored, meaning the account is not expected to
 need a '*SVCPASSWORD' argument in the setup arguments.
+
+#### Note about 'tempdb' properties
+
+The properties `SqlTempdbFileSize` and `SqlTempdbFileGrowth` that are
+returned from `Get-TargetResource` will return the sum of the average size
+and growth. If tempdb has data files with both percentage and megabytes the
+value returned is a sum of the average megabytes and the average percentage.
+For example is there is one data file using growth 100MB and another file
+having growth set to 10% then the returned value would be 110.
+This will be notable if there are multiple files in the filegroup `PRIMARY`
+with different sizes and growths.
 
 #### Parameters
 
@@ -2034,6 +2045,8 @@ need a '*SVCPASSWORD' argument in the setup arguments.
   Services service.
 * **`[String]` ISSvcAccountUsername** _(Read)_: Output user name for the Integration
   Services service.
+* **`[Boolean]` IsClustered** _(Read)_: Returns a boolean value of $true if the
+  instance is clustered, otherwise it returns $false.
 
 #### Examples
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -9,7 +9,7 @@
 
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
-    Pester                      = 'latest'
+    Pester                      = '4.10.1'
     Plaster                     = 'latest'
     ModuleBuilder               = '1.0.0'
     ChangelogManagement         = 'latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ trigger:
     - master
   paths:
     include:
-    - source/*
+    - source/**/*
   tags:
     include:
     - "v*"

--- a/source/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.schema.mof
+++ b/source/DSCResources/MSFT_SqlSetup/MSFT_SqlSetup.schema.mof
@@ -64,4 +64,5 @@ class MSFT_SqlSetup : OMI_BaseResource
     [Write, Description("Specifies the file growth increment of each tempdb data file in MB.")] UInt32 SqlTempdbLogFileGrowth;
     [Write, Description("The timeout, in seconds, to wait for the setup process to finish. Default value is 7200 seconds (2 hours). If the setup process does not finish before this time, and error will be thrown.")] UInt32 SetupProcessTimeout;
     [Write, Description("Feature flags are used to toggle functionality on or off. See the documentation for what additional functionality exist through a feature flag.")] String FeatureFlag[];
+    [Read, Description("Returns a boolean value of $true if the instance is clustered, otherwise it returns $false.")] Boolean IsClustered;
 };

--- a/source/DSCResources/MSFT_SqlSetup/en-US/MSFT_SqlSetup.strings.psd1
+++ b/source/DSCResources/MSFT_SqlSetup/en-US/MSFT_SqlSetup.strings.psd1
@@ -33,13 +33,10 @@ ConvertFrom-StringData @'
     EvaluateIntegrationServicesFeature = Detecting Integration Services feature.
     IntegrationServicesFeatureFound = Integration Services feature detected.
     IntegrationServicesFeatureNotFound = Integration Services feature not detected.
-    EvaluateClientConnectivityToolsFeature = Detecting Client Connectivity Tools feature ({0}).
     ClientConnectivityToolsFeatureFound = Client Connectivity Tools feature detected.
     ClientConnectivityToolsFeatureNotFound = Client Connectivity Tools feature not detected.
-    EvaluateClientConnectivityBackwardsCompatibilityToolsFeature = Detecting Client Connectivity Backwards Compatibility Tools feature ({0}).
     ClientConnectivityBackwardsCompatibilityToolsFeatureFound = Client Connectivity Backwards Compatibility Tools feature detected.
     ClientConnectivityBackwardsCompatibilityToolsFeatureNotFound = Client Connectivity Backwards Compatibility Tools feature not detected.
-    EvaluateClientToolsSdkFeature = Detecting Client Tools SDK feature ({0}).
     ClientToolsSdkFeatureFound = Client Tools SDK feature detected.
     ClientToolsSdkFeatureNotFound = Client Tools SDK feature not detected.
     FeatureNotSupported = '{0}' is not a valid value for setting 'FEATURES'.  Refer to SQL Help for more information.

--- a/source/DSCResources/MSFT_SqlSetup/sv-SE/MSFT_SqlSetup.strings.psd1
+++ b/source/DSCResources/MSFT_SqlSetup/sv-SE/MSFT_SqlSetup.strings.psd1
@@ -33,13 +33,10 @@ ConvertFrom-StringData @'
     EvaluateIntegrationServicesFeature = Letar efter Integration Services funktionen.
     IntegrationServicesFeatureFound = Integration Services funktionen hittad.
     IntegrationServicesFeatureNotFound = Integration Services funktionen hittades inte.
-    EvaluateClientConnectivityToolsFeature = Letar efter Client Connectivity Tools funktionen ({0}).
     ClientConnectivityToolsFeatureFound = Client Connectivity Tools funktionen hittad.
     ClientConnectivityToolsFeatureNotFound = Client Connectivity Tools funktionen hittades inte.
-    EvaluateClientConnectivityBackwardsCompatibilityToolsFeature = Letar efter Client Connectivity Backwards Compatibility Tools funktionen ({0}).
     ClientConnectivityBackwardsCompatibilityToolsFeatureFound = Client Connectivity Backwards Compatibility Tools funktionen hittad.
     ClientConnectivityBackwardsCompatibilityToolsFeatureNotFound = Client Connectivity Backwards Compatibility Tools funktionen hittades inte.
-    EvaluateClientToolsSdkFeature = Letar efter Client Tools SDK funktionen ({0}).
     ClientToolsSdkFeatureFound = Client Tools SDK funktionen hittad.
     ClientToolsSdkFeatureNotFound = Client Tools SDK funktionen hittades inte.
     FeatureNotSupported = '{0}' är inte ett giltigt värde för egenskapen 'FEATURES'. Titta i hjälpdokumentationen för SQL Server för mer information.

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -496,14 +496,14 @@ function Test-DscParameterState
 
 <#
     .SYNOPSIS
-        Returns the value of the provided in the Name parameter, at the registry
+        Returns the value of the provided Name parameter at the registry
         location provided in the Path parameter.
 
     .PARAMETER Path
-        String containing the path in the registry to the property name.
+        Specifies the path in the registry to the property name.
 
     .PARAMETER PropertyName
-        String containing the name of the property for which the value is returned.
+        Specifies the the name of the property to return the value for.
 #>
 function Get-RegistryPropertyValue
 {
@@ -531,7 +531,7 @@ function Get-RegistryPropertyValue
     #>
     try
     {
-        $getItemPropertyResult = (Get-ItemProperty @getItemPropertyParameters -ErrorAction Stop).$Name
+        $getItemPropertyResult = (Get-ItemProperty @getItemPropertyParameters -ErrorAction 'Stop').$Name
     }
     catch
     {

--- a/tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_SqlSetup.Integration.Tests.ps1
@@ -189,7 +189,7 @@ try
                     -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.Action                     | Should -BeNullOrEmpty
+                $resourceCurrentState.Action                     | Should -Be 'Install'
                 $resourceCurrentState.AgtSvcAccount              | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.AgtSvcStartupType          | Should -Be 'Automatic'
@@ -236,16 +236,7 @@ try
                 $resourceCurrentState.SQLSvcAccount              | Should -BeNullOrEmpty
                 $resourceCurrentState.SQLSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.SqlSvcStartupType          | Should -Be 'Automatic'
-                $resourceCurrentState.SQLSysAdminAccounts        | Should -Be @(
-                    $ConfigurationData.AllNodes.SqlAdministratorAccountUserName,
-                    $ConfigurationData.AllNodes.SqlInstallAccountUserName,
-                    "NT SERVICE\MSSQL`$$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)",
-                    "NT SERVICE\SQLAgent`$$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)",
-                    'NT SERVICE\SQLWriter',
-                    'NT SERVICE\Winmgmt',
-                    'sa'
-                )
-                $resourceCurrentState.SQLTempDBDir               | Should -BeNullOrEmpty
+                $resourceCurrentState.SQLTempDBDir               | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSQLDataDir -ChildPath "$($ConfigurationData.AllNodes.SqlServerInstanceIdPrefix).$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)\MSSQL\Data")
                 $resourceCurrentState.SqlTempDbFileCount         | Should -Be $ConfigurationData.AllNodes.SqlTempDbFileCount
                 $resourceCurrentState.SqlTempDbFileSize          | Should -Be $ConfigurationData.AllNodes.SqlTempDbFileSize
                 $resourceCurrentState.SqlTempDbFileGrowth        | Should -Be $ConfigurationData.AllNodes.SqlTempDbFileGrowth
@@ -259,6 +250,15 @@ try
                 $resourceCurrentState.SuppressReboot             | Should -BeNullOrEmpty
                 $resourceCurrentState.UpdateEnabled              | Should -BeNullOrEmpty
                 $resourceCurrentState.UpdateSource               | Should -BeNullOrEmpty
+
+                # Verify all the accounts are returned in the property SQLSysAdminAccounts.
+                $ConfigurationData.AllNodes.SqlAdministratorAccountUserName | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                $ConfigurationData.AllNodes.SqlInstallAccountUserName | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                "NT SERVICE\MSSQL`$$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)" | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                "NT SERVICE\SQLAgent`$$($ConfigurationData.AllNodes.DatabaseEngineNamedInstanceName)" | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                'NT SERVICE\SQLWriter' | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                'NT SERVICE\Winmgmt' | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                'sa' | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -337,7 +337,7 @@ try
                     -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.Action                     | Should -BeNullOrEmpty
+                $resourceCurrentState.Action                     | Should -Be 'Install'
                 $resourceCurrentState.AgtSvcAccount              | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlAgentServicePrimaryAccountUserName -Leaf))
                 $resourceCurrentState.ASServerMode               | Should -BeNullOrEmpty
@@ -379,16 +379,7 @@ try
                 $resourceCurrentState.SQLCollation               | Should -Be $ConfigurationData.AllNodes.Collation
                 $resourceCurrentState.SQLSvcAccount              | Should -BeNullOrEmpty
                 $resourceCurrentState.SQLSvcAccountUsername      | Should -Be ('.\{0}' -f (Split-Path -Path $ConfigurationData.AllNodes.SqlServicePrimaryAccountUserName -Leaf))
-                $resourceCurrentState.SQLSysAdminAccounts        | Should -Be @(
-                    $ConfigurationData.AllNodes.SqlAdministratorAccountUserName,
-                    $ConfigurationData.AllNodes.SqlInstallAccountUserName,
-                    "NT SERVICE\$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)",
-                    "NT SERVICE\SQLSERVERAGENT",
-                    'NT SERVICE\SQLWriter',
-                    'NT SERVICE\Winmgmt',
-                    'sa'
-                )
-                $resourceCurrentState.SQLTempDBDir               | Should -BeNullOrEmpty
+                $resourceCurrentState.SQLTempDBDir               | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "$($ConfigurationData.AllNodes.SqlServerInstanceIdPrefix).$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)\MSSQL\Data")
                 $resourceCurrentState.SQLTempDBLogDir            | Should -BeNullOrEmpty
                 $resourceCurrentState.SQMReporting               | Should -BeNullOrEmpty
                 $resourceCurrentState.SuppressReboot             | Should -BeNullOrEmpty
@@ -398,6 +389,15 @@ try
                 # Regression test for issue #1287
                 $resourceCurrentState.SQLUserDBDir               | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "$($ConfigurationData.AllNodes.SqlServerInstanceIdPrefix).$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)\MSSQL\DATA\")
                 $resourceCurrentState.SQLUserDBLogDir            | Should -Be (Join-Path -Path $ConfigurationData.AllNodes.InstallSharedDir -ChildPath "$($ConfigurationData.AllNodes.SqlServerInstanceIdPrefix).$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)\MSSQL\DATA\")
+
+                # Verify all the accounts are returned in the property SQLSysAdminAccounts.
+                $ConfigurationData.AllNodes.SqlAdministratorAccountUserName | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                $ConfigurationData.AllNodes.SqlInstallAccountUserName | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                "NT SERVICE\$($ConfigurationData.AllNodes.DatabaseEngineDefaultInstanceName)" | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                "NT SERVICE\SQLSERVERAGENT" | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                'NT SERVICE\SQLWriter' | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                'NT SERVICE\Winmgmt' | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
+                'sa' | Should -BeIn $resourceCurrentState.SQLSysAdminAccounts
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -476,7 +476,7 @@ try
                     -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.Action                     | Should -BeNullOrEmpty
+                $resourceCurrentState.Action                     | Should -Be 'Install'
                 $resourceCurrentState.AgtSvcAccount              | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccountUsername      | Should -BeNullOrEmpty
                 $resourceCurrentState.ASServerMode               | Should -Be $ConfigurationData.AllNodes.AnalysisServicesTabularServerMode

--- a/tests/Unit/MSFT_SqlSetup.Tests.ps1
+++ b/tests/Unit/MSFT_SqlSetup.Tests.ps1
@@ -10,7 +10,7 @@
 
 # Suppressing this rule because PlainText is required for one of the functions used in this test
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
-param()
+param ()
 
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
 
@@ -50,957 +50,186 @@ Invoke-TestSetup
 try
 {
     InModuleScope $script:dscResourceName {
-        <#
-            .SYNOPSIS
-                Used to test arguments passed to Start-SqlSetupProcess while inside and It-block.
-
-                This function must be called inside a Mock, since it depends being run inside an It-block.
-
-            .PARAMETER Argument
-                A string containing all the arguments separated with space and each argument should start with '/'.
-                Only the first string in the array is evaluated.
-
-            .PARAMETER ExpectedArgument
-                A hash table containing all the expected arguments.
-        #>
-        function Test-SetupArgument
-        {
-            param
-            (
-                [Parameter(Mandatory = $true)]
-                [System.String]
-                $Argument,
-
-                [Parameter(Mandatory = $true)]
-                [System.Collections.Hashtable]
-                $ExpectedArgument
-            )
-
-            $argumentHashTable = @{}
-
-            # Break the argument string into a hash table
-            ($Argument -split ' ?/') | ForEach-Object {
-                if ($_ -imatch '(\w+)="?([^/]+)"?')
-                {
-                    $key = $Matches[1]
-                    if ($key -in ('FailoverClusterDisks','FailoverClusterIPAddresses'))
-                    {
-                        $value = ($Matches[2] -replace '" "','; ') -replace '"',''
-                    }
-                    else
-                    {
-                        $value = ($Matches[2] -replace '" "',' ') -replace '"',''
-                    }
-
-                    $argumentHashTable.Add($key, $value)
-                }
-            }
-
-            $actualValues = $argumentHashTable.Clone()
-
-            # Limit the output in the console when everything is fine.
-            if ($actualValues.Count -ne $ExpectedArgument.Count)
-            {
-                Write-Warning -Message 'Verified the setup argument count (expected vs actual)'
-                Write-Warning -Message ('Expected: {0}' -f ($ExpectedArgument.Keys -join ','))
-                Write-Warning -Message ('Actual: {0}' -f ($actualValues.Keys -join ','))
-            }
-
-            # Start by checking whether we have the same number of parameters
-            $actualValues.Count | Should -Be $ExpectedArgument.Count `
-                -Because ('the expected arguments was: {0}' -f ($ExpectedArgument.Keys -join ','))
-
-            Write-Verbose -Message 'Verified actual setup argument values against expected setup argument values' -Verbose
-
-            foreach ($argumentKey in $ExpectedArgument.Keys)
-            {
-                $argumentKeyName = $actualValues.GetEnumerator() |
-                    Where-Object -FilterScript {
-                        $_.Name -eq $argumentKey
-                    } | Select-Object -ExpandProperty 'Name'
-
-                $argumentKeyName | Should -Be $argumentKey
-
-                $argumentValue = $actualValues.$argumentKey
-                $argumentValue | Should -Be $ExpectedArgument.$argumentKey
-            }
-        }
-
         # Testing each supported SQL Server version
         $testProductVersion = @(
-            14, # SQL Server 2017
-            13, # SQL Server 2016
-            12, # SQL Server 2014
-            11, # SQL Server 2012
+            14 # SQL Server 2017
+            13 # SQL Server 2016
+            12 # SQL Server 2014
+            11 # SQL Server 2012
             10  # SQL Server 2008 and 2008 R2
         )
 
-        $mockSqlDatabaseEngineName = 'MSSQL'
-        $mockSqlAgentName = 'SQLAgent'
-        $mockSqlFullTextName = 'MSSQLFDLauncher'
-        $mockSqlReportingName = 'ReportServer'
-        $mockSqlIntegrationName = 'MsDtsServer{0}0' # {0} will be replaced by SQL major version in runtime
-        $mockSqlAnalysisName = 'MSOLAP'
-
-        $mockSqlCollation = 'Finnish_Swedish_CI_AS'
-        $mockSqlLoginMode = 'Integrated'
-
-        $mockSqlSharedDirectory = 'C:\Program Files\Microsoft SQL Server'
-        $mockSqlSharedWowDirectory = 'C:\Program Files (x86)\Microsoft SQL Server'
-        $mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server'
-        $mockSqlSystemAdministrator = 'COMPANY\Stacy'
-
-        $mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
-        $mockSqlAnalysisAdmins = @('COMPANY\Stacy','COMPANY\SSAS Administrators')
-        $mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
-        $mockSqlAnalysisTempDirectory= 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
-        $mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
-        $mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
-        $mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
-
-        $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
-        $mockDefaultInstance_DatabaseServiceName = $mockDefaultInstance_InstanceName
-        $mockDefaultInstance_AgentServiceName = 'SQLSERVERAGENT'
-        $mockDefaultInstance_FullTextServiceName = $mockSqlFullTextName
-        $mockDefaultInstance_ReportingServiceName = $mockSqlReportingName
-        $mockDefaultInstance_IntegrationServiceName = $mockSqlIntegrationName
-        $mockDefaultInstance_AnalysisServiceName = 'MSSQLServerOLAPService'
-
-        $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
-        $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
-        $mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
-        $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
-        $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
-        $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
-
-        $mockNamedInstance_InstanceName = 'TEST'
-        $mockNamedInstance_DatabaseServiceName = "$($mockSqlDatabaseEngineName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_AgentServiceName = "$($mockSqlAgentName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_FullTextServiceName = "$($mockSqlFullTextName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_ReportingServiceName = "$($mockSqlReportingName)`$$($mockNamedInstance_InstanceName)"
-        $mockNamedInstance_IntegrationServiceName = $mockSqlIntegrationName
-        $mockNamedInstance_AnalysisServiceName = "$($mockSqlAnalysisName)`$$($mockNamedInstance_InstanceName)"
-
-        $mockNamedInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
-        $mockNamedInstance_FailoverClusterIPAddress = '10.0.0.20'
-        $mockNamedInstance_FailoverClusterGroupName = "SQL Server ($mockNamedInstance_InstanceName)"
-
-        $mockmockSetupCredentialUserName = "COMPANY\sqladmin"
-
-        $mockmockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
-        $mockSetupCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockmockSetupCredentialUserName, $mockmockSetupCredentialPassword)
-
-        $mockSqlServiceAccount = 'COMPANY\SqlAccount'
-        $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
-        $mockSQLServiceCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockSqlServiceAccount,($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-        $mockAgentServiceAccount = 'COMPANY\AgentAccount'
-        $mockAgentServicePassword = 'Ag3ntP@ssw0rd'
-        $mockSQLAgentCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockAgentServiceAccount,($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-        $mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
-        $mockAnalysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
-        $mockAnalysisServiceCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockAnalysisServiceAccount,($mockAnalysisServicePassword | ConvertTo-SecureString -AsPlainText -Force))
-
-        $mockAgtSvcStartupMode = 'Auto'
-        $mockAsSvcStartupMode = 'Auto'
-        $mockIsSvcStartupMode = 'Auto'
-        $mockRsSvcStartupMode = 'Auto'
-
-        $mockClusterNodes = @($env:COMPUTERNAME,'SQL01','SQL02')
-
-        $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
-        $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
-        $mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
-        $mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
-        $mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
-        $mockSqlBackupPath = 'O:\MSSQL\Backup'
-
-        $mockClusterDiskMap = {
-            @{
-                SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
-                UserData = Split-Path -Path $mockDynamicSqlUserDatabasePath -Qualifier
-                UserLogs = Split-Path -Path $mockDynamicSqlUserDatabaseLogPath -Qualifier
-                TempDbData = Split-Path -Path $mockDynamicSqlTempDatabasePath -Qualifier
-                TempDbLogs = Split-Path -Path $mockDynamicSqlTempDatabaseLogPath -Qualifier
-                Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
-            }
-        }
-
-        $mockCSVClusterDiskMap = @{
-            SysData = @{Path='C:\ClusterStorage\SysData';Name="Cluster Virtual Disk (SQL System Data Disk)"}
-            UserData = @{Path='C:\ClusterStorage\SQLData';Name="Cluster Virtual Disk (SQL Data Disk)"}
-            UserLogs = @{Path='C:\ClusterStorage\SQLLogs';Name="Cluster Virtual Disk (SQL Log Disk)"}
-            TempDbData = @{Path='C:\ClusterStorage\TempDBData';Name="Cluster Virtual Disk (SQL TempDBData Disk)"}
-            TempDbLogs = @{Path='C:\ClusterStorage\TempDBLogs';Name="Cluster Virtual Disk (SQL TempDBLog Disk)"}
-            Backup = @{Path='C:\ClusterStorage\SQLBackup';Name="Cluster Virtual Disk (SQL Backup Disk)"}
-        }
-
-        $mockClusterSites = @(
-            @{
-                Name = 'SiteA'
-                Address = $mockDefaultInstance_FailoverClusterIPAddress
-                Mask = '255.255.255.0'
-            },
-            @{
-                Name = 'SiteB'
-                Address = $mockDefaultInstance_FailoverClusterIPAddress_SecondSite
-                Mask = '255.255.255.0'
-            }
-        )
-
-        #region Function mocks
-        $mockGetSqlMajorVersion = {
-            return $mockSqlMajorVersion
-        }
-
-        $mockEmptyHashtable = {
-            return @()
-        }
-
-        $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber = '{72AB7E6F-BC24-481E-8C45-1AB5B3DD795D}'
-        $mockSqlServerManagementStudio2012_ProductIdentifyingNumber = '{A7037EB2-F953-4B12-B843-195F4D988DA1}'
-        $mockSqlServerManagementStudio2014_ProductIdentifyingNumber = '{75A54138-3B98-4705-92E4-F619825B121F}'
-        $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber = '{B5FE23CC-0151-4595-84C3-F1DE6F44FE9B}'
-        $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber = '{7842C220-6E9A-4D5A-AE70-0E138271F883}'
-        $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber = '{B5ECFA5C-AC4F-45A4-A12E-A76ABDD9CCBA}'
-
-        $mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
-
-        $mockGetItemProperty_UninstallProducts2008R2 = {
-            return @(
-                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber,  # Mock product SSMS 2008 and SSMS 2008 R2
-                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber  # Mock product ADV_SSMS 2012
-            )
-        }
-
-        $mockGetItemProperty_UninstallProducts2012 = {
-            return @(
-                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber,    # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber    # Mock product SSMS 2014
-            )
-        }
-
-        $mockGetItemProperty_UninstallProducts2014 = {
-            return @(
-                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber,    # Mock product SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber     # Mock product ADV_SSMS 2014
-            )
-        }
-
-        $mockGetItemProperty_UninstallProducts = {
-            return @(
-                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber,  # Mock product SSMS 2008 and SSMS 2008 R2
-                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber,    # Mock product ADV_SSMS 2008 and ADV_SSMS 2008 R2
-                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber,    # Mock product SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber,  # Mock product ADV_SSMS 2012
-                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber,    # Mock product SSMS 2014
-                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber     # Mock product ADV_SSMS 2014
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_DatabaseService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_AgentService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockAgtSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_FullTextService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_ReportingService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_IntegrationService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_DefaultInstance_AnalysisService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetService_DefaultInstance = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockAgtSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockRsSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockIsSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockAsSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_DatabaseService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_AgentService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockAgtSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_FullTextService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_ReportingService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockRsSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_IntegrationService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockIsSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_NamedInstance_AnalysisService = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockAsSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetService_NamedInstance = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockSqlSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockAgtSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockRsSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockIsSvcStartupMode -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockAsSvcStartupMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_InstanceId_ConfigurationState = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'SQL_Replication_Core_Inst' -Value 1 -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_DQFeature = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                    Add-Member -MemberType NoteProperty -Name 'DQ_Components' -Value 1 -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_SqlVersion_ConfigurationState = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                    Add-Member -MemberType NoteProperty -Name 'SQL_BOL_Components' -Value 1 -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'SQL_DQ_CLIENT_Full' -Value 1 -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'MDSCoreFeature' -Value 1 -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_ClientComponentsFull_FeatureList = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value 'Connectivity_Full=3 SQL_SSMS_Full=3 Tools_Legacy_Full=3 Connectivity_FNS=3 SQL_Tools_Standard_FNS=3 Tools_Legacy_FNS=3 SDK_Full=3 SDK_FNS=3' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'FeatureList' -Value '' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_SQL = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_SharedDirectory = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedDirectory -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItem_SharedDirectory = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_SharedWowDirectory = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name '28A1158CDF9ED6B41B2B7358982D4BA8' -Value $mockSqlSharedWowDirectory -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItem_SharedWowDirectory = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Property' -Value '28A1158CDF9ED6B41B2B7358982D4BA8' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_Setup = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'SqlProgramDir' -Value $mockSqlProgramDirectory -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetItemProperty_ServicesAnalysis = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'ImagePath' -Value ('"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory) -PassThru -Force
-                )
-            )
-        }
-
-        $mockConnectSQL = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-                        Add-Member -MemberType ScriptProperty -Name Logins -Value {
-                            return @( ( New-Object -TypeName Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name ListMembers -Value {
-                                        return @('sysadmin')
-                                    } -PassThru -Force
-                                ) )
-                        } -PassThru -Force
-                )
-            )
-        }
-
-        $mockConnectSQLCluster = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'LoginMode' -Value $mockSqlLoginMode -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'Collation' -Value $mockSqlCollation -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'InstallDataDirectory' -Value $mockSqlInstallPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'BackupDirectory' -Value $mockDynamicSqlBackupPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBDir' -Value $mockDynamicSqlTempDatabasePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'SQLTempDBLogDir' -Value $mockDynamicSqlTempDatabaseLogPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultFile' -Value $mockSqlDefaultDatabaseFilePath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'DefaultLog' -Value $mockSqlDefaultDatabaseLogPath -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'IsClustered' -Value $true -PassThru |
-                        Add-Member -MemberType ScriptProperty -Name Logins -Value {
-                            return @( ( New-Object -TypeName Object |
-                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockSqlSystemAdministrator -PassThru |
-                                    Add-Member -MemberType ScriptMethod -Name ListMembers -Value {
-                                        return @('sysadmin')
-                                    } -PassThru -Force
-                                ) )
-                        } -PassThru -Force
-                )
-            )
-        }
-
-        $mockConnectSQLAnalysis = {
-            return @(
-                (
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType ScriptProperty -Name ServerProperties -Value {
-                            return @{
-                                'CollationName' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force )
-                                'DataDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force )
-                                'TempDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force )
-                                'LogDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force )
-                                'BackupDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force )
-                            }
-                        } -PassThru |
-                        Add-Member -MemberType ScriptProperty -Name Roles -Value {
-                            return @{
-                                'Administrators' = @( New-Object -TypeName Object |
-                                    Add-Member -MemberType ScriptProperty -Name Members -Value {
-                                        return New-Object -TypeName Object |
-                                            Add-Member -MemberType ScriptProperty -Name Name -Value {
-                                                return $mockDynamicSqlAnalysisAdmins
-                                            } -PassThru -Force
-                                    } -PassThru -Force
-                                ) }
-                        } -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'ServerMode' -Value $mockDynamicAnalysisServerMode -PassThru -Force
-                )
-            )
-        }
-
-        $mockSourcePathUNCWithoutLeaf = '\\server\share'
-        $mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
-
-        $mockNewTemporaryFolder = {
-            return $mockSourcePathUNC
-        }
-
-        $mockGetCimInstance_MSClusterResource = {
-            return @(
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockCurrentInstanceName)" -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{
-                            InstanceName = $mockCurrentInstanceName
-                        } -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage = {
-            return @(
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
-            return @(
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
-            return @(
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Name}) -PassThru -Force
-                ),
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Path}) -PassThru -Force |
-                        Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Name}) -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimInstance_MSClusterNetwork = {
-            return @(
-                (
-                    $mockClusterSites | ForEach-Object {
-                        $network = $_
-
-                        New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance = {
-            return @(
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FailoverClusterGroupName -PassThru -Force
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance = {
-            return @(
-                (
-                    @('Network Name','IP Address') | ForEach-Object {
-                        $resourceType = $_
-
-                        $propertyValue = @{
-                            MemberType = 'NoteProperty'
-                            Name = 'PrivateProperties'
-                            Value = $null
-                        }
-
-                        switch ($resourceType)
-                        {
-                            'Network Name'
-                            {
-                                $propertyValue.Value = @{
-                                    DnsName = $mockDefaultInstance_FailoverClusterNetworkName
-                                }
-                            }
-
-                            'IP Address'
-                            {
-                                $propertyValue.Value = @{
-                                    Address = $mockDefaultInstance_FailoverClusterIPAddress
-                                }
-                            }
-                        }
-
-                        return New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource', 'root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Type' -Value $resourceType -PassThru -Force |
-                            Add-Member @propertyValue -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        # Mock to return physical disks that are part of the "Available Storage" cluster role
-        $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
-            return @(
-                (
-                    # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
-                    (& $mockClusterDiskMap).Keys | ForEach-Object {
-                        $diskName = $_
-                        New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
-                            Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner = {
-            return @(
-                (
-                    $mockClusterNodes | ForEach-Object {
-                        $node = $_
-                        New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Node', 'root/MSCluster' |
-                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
-                    }
-                )
-            )
-        }
-
-        $mockGetCimAssociatedInstance_MSCluster_DiskPartition = {
-            $clusterDiskName = $InputObject.Name
-
-            # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
-            $clusterDiskPath = (& $mockClusterDiskMap).$clusterDiskName
-
-            return @(
-                (
-                    New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition','root/MSCluster' |
-                        Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
-                )
-            )
-        }
-
-        <#
-        Needed a way to see into the Set-method for the arguments the Set-method is building and sending to 'setup.exe', and fail
-        the test if the arguments is different from the expected arguments.
-        Solved this by dynamically set the expected arguments before each It-block. If the arguments differs the mock of
-        Start-SqlSetupProcess throws an error message, similar to what Pester would have reported (expected -> but was).
-        #>
-        $mockStartSqlSetupProcessExpectedArgument = @{}
-
-        $mockStartSqlSetupProcessExpectedArgumentClusterDefault = @{
-            IAcceptSQLServerLicenseTerms = 'True'
-            Quiet = 'True'
-            InstanceName = 'MSSQLSERVER'
-            Features = 'SQLENGINE'
-            SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
-            FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
-        }
-
-        $mockStartSqlSetupProcess = {
-            Test-SetupArgument -Argument $ArgumentList -ExpectedArgument $mockStartSqlSetupProcessExpectedArgument
-
-            return 0
-        }
-
-        $mockDynamicSetupProcessExitCode = 0
-        $mockStartSqlSetupProcess_WithDynamicExitCode = {
-            return $mockDynamicSetupProcessExitCode
-        }
-        #endregion Function mocks
-
-        <#
-            These are written with both lower-case and upper-case to make sure we support that.
-            The feature list must be written in the order it is returned by the function Get-TargetResource.
-        #>
-        $mockDefaultFeatures = 'SQLEngine,Replication,Dq,Dqc,FullText,Rs,As,Is,Bol,Conn,Bc,Sdk,Mds,Ssms,Adv_Ssms'
-
-        # Default parameters that are used for the It-blocks
-        $mockDefaultParameters = @{
-            Features = $mockDefaultFeatures
-        }
-
-        $MockSqlSvcStartupType = 'Automatic'
-        $MockAgtSvcStartupType = 'Automatic'
-        $MockAsSvcStartupType = 'Automatic'
-        $MockIsSvcStartupType = 'Automatic'
-        $MockRsSvcStartupType = 'Automatic'
-
-        $mockDefaultClusterParameters = @{
-            SQLSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
-
-            # Feature support is tested elsewhere, so just include the minimum.
-            Features = 'SQLEngine'
-        }
-
         Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
-            #region Setting up TestDrive:\
-
-            # Local path to TestDrive:\
-            $mockSourcePath = $TestDrive.FullName
-
-            # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
-            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-
-            #endregion Setting up TestDrive:\
-
             BeforeAll {
+                #region Setting up TestDrive:\
+                # Local path to TestDrive:\
+                $mockSourcePath = $TestDrive.FullName
+
+                # UNC path to TestDrive:\
+                $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
+                $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
+                #endregion Setting up TestDrive:\
+
+                <#
+                    These are written with both lower-case and upper-case to make sure we support that.
+                    The feature list must be written in the order it is returned by the function Get-TargetResource.
+                #>
+                $mockDefaultFeatures = 'SQLEngine,Replication,Dq,Dqc,FullText,Rs,As,Is,Bol,Conn,Bc,Sdk,Mds,Ssms,Adv_Ssms'
+
+                # Default parameters that are used for the It-blocks
+                $mockDefaultParameters = @{
+                    Features = $mockDefaultFeatures
+                }
+
+                $mockStartMode = 'Auto'
+
+                $mockSetupCredentialUserName = "COMPANY\sqladmin"
+                $mockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
+                $mockSetupCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockSetupCredentialUserName, $mockSetupCredentialPassword)
+
+                $mockSqlDatabaseEngineName = 'MSSQL'
+                $mockSqlAgentName = 'SQLAgent'
+                $mockSqlFullTextName = 'MSSQLFDLauncher'
+                $mockSqlReportingName = 'ReportServer'
+                $mockSqlIntegrationName = 'MsDtsServer{0}0' # {0} will be replaced by SQL major version in runtime
+                $mockSqlAnalysisName = 'MSOLAP'
+
+                $mockSqlCollation = 'Finnish_Swedish_CI_AS'
+                $mockSqlLoginMode = 'Windows'
+
+                $mockSqlSharedDirectory = 'C:\Program Files\Microsoft SQL Server'
+                $mockSqlSharedWowDirectory = 'C:\Program Files (x86)\Microsoft SQL Server'
+                $mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server'
+                $mockSqlSystemAdministrator = 'COMPANY\Stacy'
+
+                $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
+                $mockDefaultInstance_DatabaseServiceName = $mockDefaultInstance_InstanceName
+                $mockDefaultInstance_AgentServiceName = 'SQLSERVERAGENT'
+                $mockDefaultInstance_FullTextServiceName = $mockSqlFullTextName
+                $mockDefaultInstance_ReportingServiceName = $mockSqlReportingName
+                $mockDefaultInstance_IntegrationServiceName = $mockSqlIntegrationName
+                $mockDefaultInstance_AnalysisServiceName = 'MSSQLServerOLAPService'
+
+                $mockSqlAnalysisCollation = 'Finnish_Swedish_CI_AS'
+                $mockSqlAnalysisAdmins = @('COMPANY\Stacy','COMPANY\SSAS Administrators')
+                $mockSqlAnalysisDataDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Data'
+                $mockSqlAnalysisTempDirectory= 'C:\Program Files\Microsoft SQL Server\OLAP\Temp'
+                $mockSqlAnalysisLogDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Log'
+                $mockSqlAnalysisBackupDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Backup'
+                $mockSqlAnalysisConfigDirectory = 'C:\Program Files\Microsoft SQL Server\OLAP\Config'
+
+                $mockGetService_NoServices = {
+                    return @()
+                }
+
+                $mockGetService_DefaultInstance = {
+                    return @(
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_DatabaseServiceName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AgentServiceName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_FullTextServiceName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_ReportingServiceName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDefaultInstance_AnalysisServiceName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                        )
+                    )
+                }
+
+                $mockConnectSQLAnalysis = {
+                    return @(
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType ScriptProperty -Name ServerProperties -Value {
+                                    return @{
+                                        'CollationName' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisCollation -PassThru -Force )
+                                        'DataDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisDataDirectory -PassThru -Force )
+                                        'TempDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisTempDirectory -PassThru -Force )
+                                        'LogDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisLogDirectory -PassThru -Force )
+                                        'BackupDir' = @( New-Object -TypeName Object | Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockSqlAnalysisBackupDirectory -PassThru -Force )
+                                    }
+                                } -PassThru |
+                                Add-Member -MemberType ScriptProperty -Name Roles -Value {
+                                    return @{
+                                        'Administrators' = @( New-Object -TypeName Object |
+                                            Add-Member -MemberType ScriptProperty -Name Members -Value {
+                                                return New-Object -TypeName Object |
+                                                    Add-Member -MemberType ScriptProperty -Name Name -Value {
+                                                        return $mockDynamicSqlAnalysisAdmins
+                                                    } -PassThru -Force
+                                            } -PassThru -Force
+                                        ) }
+                                } -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'ServerMode' -Value $mockDynamicAnalysisServerMode -PassThru -Force
+                        )
+                    )
+                }
+
+                $mockGetSqlMajorVersion = {
+                    return $mockSqlMajorVersion
+                }
+
                 # General mocks
-                Mock -CommandName Get-PSDrive -Verifiable
-                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
-                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -and
-                    ($Name -eq $mockDefaultInstance_InstanceName -or $Name -eq $mockNamedInstance_InstanceName)
-                } -MockWith $mockGetItemProperty_SQL -Verifiable
+                Mock -CommandName Get-PSDrive
+                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion
 
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    (
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockDefaultInstance_AnalysisServiceName" -or
-                        $Path -eq "HKLM:\SYSTEM\CurrentControlSet\Services\$mockNamedInstance_AnalysisServiceName"
-                    ) -and
+                Mock -CommandName Get-RegistryPropertyValue -ParameterFilter {
                     $Name -eq 'ImagePath'
-                } -MockWith $mockGetItemProperty_ServicesAnalysis -Verifiable
+                } -MockWith {
+                    <#
+                        Example for a named instance for SQL Server 2017:
+                        '"C:\Program Files\Microsoft SQL Server\MSAS14.INSTANCE\OLAP\bin\msmdsrv.exe" -s "C:\Program Files\Microsoft SQL Server\MSAS14.INSTANCE\OLAP\Config"'
+                    #>
+                    return '"C:\Program Files\Microsoft SQL Server\OLAP\bin\msmdsrv.exe" -s "{0}"' -f $mockSqlAnalysisConfigDirectory
+                }
 
-                # Mocking SharedDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                } -MockWith $mockGetItemProperty_SharedDirectory -Verifiable
+                # Mocking SharedDirectory and SharedWowDirectory
+                Mock -Commandname Get-SqlSharedPaths -MockWith {
+                    return @{
+                        InstallSharedDir = $mockSqlSharedDirectory
+                        InstallSharedWOWDir = $mockSqlSharedWowDirectory
+                    }
+                }
 
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
-                } -MockWith $mockGetItem_SharedDirectory -Verifiable
+                Mock -CommandName Get-FullInstanceId -ParameterFilter {
+                    $InstanceName -eq $mockDefaultInstance_InstanceName
+                } -MockWith {
+                    return $mockDefaultInstance_InstanceId
+                }
 
-                # Mocking SharedWowDirectory
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItemProperty_SharedWowDirectory -Verifiable
+                Mock -CommandName Get-FullInstanceId -ParameterFilter {
+                    $InstanceName -eq $mockNamedInstance_InstanceName
+                } -MockWith {
+                    return $mockNamedInstance_InstanceId
+                }
 
-                Mock -CommandName Get-Item -ParameterFilter {
-                    $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\A79497A344129F64CA7D69C56F5DD8B4'
-                } -MockWith $mockGetItem_SharedWowDirectory -Verifiable
-
-                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                } -MockWith $mockGetItemProperty_ClientComponentsFull_FeatureList -Verifiable
+                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis
 
                 <#
                     This make sure the mock for Connect-SQLAnalysis get the correct
@@ -1011,15 +240,11 @@ try
             }
 
             BeforeEach {
-                Mock -CommandName Connect-SQLAnalysis -MockWith $mockConnectSQLAnalysis -Verifiable
-
                 $testParameters = $mockDefaultParameters.Clone()
             }
 
-            foreach ($version in $testProductVersion)
+            foreach ($mockSqlMajorVersion in $testProductVersion)
             {
-                $mockSqlMajorVersion = $version
-
                 $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
 
                 $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
@@ -1033,6 +258,28 @@ try
                 $mockDynamicSqlAnalysisAdmins = $mockSqlAnalysisAdmins
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
+                    BeforeAll {
+                        Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Connect-UncPath
+                        Mock -CommandName Disconnect-UncPath
+                        Mock -CommandName Get-Service -MockWith $mockGetService_NoServices
+
+                        Mock -CommandName Test-IsDQComponentInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters += @{
@@ -1040,54 +287,6 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016 and 2017
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                        }
-                        else
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockEmptyHashtable -Verifiable
-                        }
-
-                        Mock -CommandName Connect-UncPath -Verifiable
-                        Mock -CommandName Disconnect-UncPath -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -1097,31 +296,11 @@ try
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-InstanceProgramPath -Exactly -Times 0 -Scope It
 
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsAdvancedInstalled -Exactly -Times 1 -Scope It
                     }
 
                     It 'Should not return any names of installed features' {
@@ -1162,220 +341,219 @@ try
 
                 if ($mockSqlMajorVersion -in (14))
                 {
-                    Context 'When using feature flag DetectionSharedFeatures' {
-                        Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
-                            BeforeEach {
-                                $testParameters.Remove('Features')
-                                $testParameters += @{
-                                    InstanceName = $mockDefaultInstance_InstanceName
-                                    SourceCredential = $null
-                                    SourcePath = $mockSourcePath
-                                    FeatureFlag = @('DetectionSharedFeatures')
+                    Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
+                        BeforeAll {
+                            Mock -CommandName Get-InstalledSharedFeatures -MockWith {
+                                return @(
+                                    'DQC'
+                                    'BOL'
+                                    'CONN'
+                                    'BC'
+                                    'SDK'
+                                    'MDS'
+                                )
+                            }
+
+                            Mock -CommandName Connect-UncPath
+                            Mock -CommandName Disconnect-UncPath
+                            Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance
+
+                            Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                                return $false
+                            }
+
+                            Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                                return $false
+                            }
+
+                            Mock -CommandName Get-SqlEngineProperties -MockWith {
+                                return @{
+                                    SQLSvcAccountUsername = $mockSqlServiceAccount
+                                    AgtSvcAccountUsername = $mockAgentServiceAccount
+                                    SqlSvcStartupType = $mockStartMode
+                                    AgtSvcStartupType = $mockStartMode
+                                    SQLCollation = $mockSqlCollation
+                                    IsClustered = $false
+                                    InstallSQLDataDir = $mockSqlInstallPath
+                                    SQLUserDBDir = $mockSqlDefaultDatabaseFilePath
+                                    SQLUserDBLogDir = $mockSqlDefaultDatabaseFilePath
+                                    SQLBackupDir = $mockDynamicSqlBackupPath
+                                    SecurityMode = $mockSqlLoginMode
                                 }
-
-                                Mock -CommandName Get-InstalledSharedFeatures -MockWith {
-                                    return @(
-                                        'DQC'
-                                        'BOL'
-                                        'CONN'
-                                        'BC'
-                                        'SDK'
-                                        'MDS'
-                                    )
-                                } -Verifiable
-
-                                Mock -CommandName Connect-UncPath -Verifiable
-                                Mock -CommandName Disconnect-UncPath -Verifiable
-                                Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                                #region Mock Get-CimInstance
-                                Mock -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                                } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                                Mock -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                                } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                                Mock -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                                } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                                Mock -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                                } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                                Mock -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                                } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                                Mock -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                                } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                                } -MockWith $mockGetItemProperty_InstanceId_ConfigurationState -Verifiable
-
-                                # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                                Mock -CommandName Get-CimInstance -MockWith {
-                                    throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                                } -Verifiable
-                                #endregion Mock Get-CimInstance
-
-                                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                                } -MockWith $mockGetItemProperty_InstanceId_ConfigurationState -Verifiable
-
-                                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                                } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                                Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                                } -MockWith $mockGetItemProperty_Setup -Verifiable
                             }
 
-                            It 'Should return the same values as passed as parameters' {
-                                $result = Get-TargetResource @testParameters
-                                $result.InstanceName | Should -Be $testParameters.InstanceName
-
-                                Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 0 -Scope It
-                                Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 0 -Scope It
-                                Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                                Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                                Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
-                                Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                                Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                                } -Exactly -Times 1 -Scope It
-
-                                Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                    $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                                } -Exactly -Times 1 -Scope It
-
-                                Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                    $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                    $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                    $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                    $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                    $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                    $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                                } -Exactly -Times 0 -Scope It
-
-                                #region Assert Get-CimInstance
-                                Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                                } -Exactly -Times 1 -Scope It
-
-                                Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                                } -Exactly -Times 1 -Scope It
-
-                                Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                                } -Exactly -Times 1 -Scope It
-
-                                Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                                } -Exactly -Times 1 -Scope It
-
-                                Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                                } -Exactly -Times 1 -Scope It
-
-                                Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                                    $ClassName -eq 'Win32_Service' -and
-                                    $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                                } -Exactly -Times 1 -Scope It
-                                #endregion Assert Get-CimInstance
+                            Mock -CommandName Get-ServiceProperties -MockWith {
+                                return @{
+                                    UserName = $mockSqlServiceAccount
+                                    StartupType = $mockStartMode
+                                }
                             }
 
-                            It 'Should return correct names of installed features' {
-                                $result = Get-TargetResource @testParameters
-
-                                $result.Features | Should -Be 'SQLENGINE,REPLICATION,DQ,FULLTEXT,RS,AS,IS,DQC,BOL,CONN,BC,SDK,MDS'
+                            Mock -CommandName Test-IsReplicationFeatureInstalled -MockWith {
+                                return $true
                             }
 
-                            It 'Should return the correct values in the hash table' {
-                                $result = Get-TargetResource @testParameters
-                                $result.SourcePath | Should -Be $mockSourcePath
-                                $result.InstanceName | Should -Be $mockDefaultInstance_InstanceName
-                                $result.InstanceID | Should -Be $mockDefaultInstance_InstanceName
-                                $result.InstallSharedDir | Should -Be $mockSqlSharedDirectory
-                                $result.InstallSharedWOWDir | Should -Be $mockSqlSharedWowDirectory
-                                $result.SQLSvcAccountUsername | Should -Be $mockSqlServiceAccount
-                                $result.AgtSvcAccountUsername | Should -Be $mockAgentServiceAccount
-                                $result.SqlCollation | Should -Be $mockSqlCollation
-                                $result.SQLSysAdminAccounts | Should -Be $mockSqlSystemAdministrator
-                                $result.SecurityMode | Should -Be 'Windows'
-                                $result.InstallSQLDataDir | Should -Be $mockSqlInstallPath
-                                $result.SQLUserDBDir | Should -Be $mockSqlDefaultDatabaseFilePath
-                                $result.SQLUserDBLogDir | Should -Be $mockSqlDefaultDatabaseLogPath
-                                $result.SQLBackupDir | Should -Be $mockDynamicSqlBackupPath
-                                $result.FTSvcAccountUsername | Should -Be $mockSqlServiceAccount
-                                $result.RSSvcAccountUsername | Should -Be $mockSqlServiceAccount
-                                $result.ASSvcAccountUsername | Should -Be $mockSqlServiceAccount
-                                $result.ASCollation | Should -Be $mockSqlAnalysisCollation
-                                $result.ASSysAdminAccounts | Should -Be $mockSqlAnalysisAdmins
-                                $result.ASDataDir | Should -Be $mockSqlAnalysisDataDirectory
-                                $result.ASLogDir | Should -Be $mockSqlAnalysisLogDirectory
-                                $result.ASBackupDir | Should -Be $mockSqlAnalysisBackupDirectory
-                                $result.ASTempDir | Should -Be $mockSqlAnalysisTempDirectory
-                                $result.ASConfigDir | Should -Be $mockSqlAnalysisConfigDirectory
-                                $result.ASServerMode | Should -Be 'MULTIDIMENSIONAL'
-                                $result.ISSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                            # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
+                            Mock -CommandName Get-CimInstance -MockWith {
+                                throw "Mock Get-CimInstance without a parameter filter should not be calle. It was called with unexpected parameters; ClassName=$ClassName, Filter=$Filter"
+                            }
+                            #endregion Mock Get-CimInstance
+
+                            Mock -CommandName Test-IsDQComponentInstalled -MockWith {
+                                return $true
                             }
 
-                            $mockDynamicAnalysisServerMode = 'POWERPIVOT'
-
-                            It 'Should return the correct values in the hash table' {
-                                $result = Get-TargetResource @testParameters
-                                $result.ASServerMode | Should -Be 'POWERPIVOT'
+                            Mock -CommandName Get-InstanceProgramPath -MockWith {
+                                return $mockSqlProgramDirectory
                             }
 
-                            $mockDynamicAnalysisServerMode = 'TABULAR'
-
-                            It 'Should return the correct values in the hash table' {
-                                $result = Get-TargetResource @testParameters
-                                $result.ASServerMode | Should -Be 'TABULAR'
+                            Mock -CommandName Get-TempDbProperties -MockWith {
+                                return @{
+                                    SQLTempDBDir = $mockSqlTempDatabasePath
+                                    SqlTempdbFileCount = 1
+                                    SqlTempdbFileSize = 200
+                                    SqlTempdbFileGrowth = 10
+                                    SqlTempdbLogFileSize = 20
+                                    SqlTempdbLogFileGrowth = 10
+                                }
                             }
 
-                            # Return the state to the default for all other tests.
-                            $mockDynamicAnalysisServerMode = 'MULTIDIMENSIONAL'
-
-                            <#
-                                This is a regression test for issue #691.
-                                This sets administrators to only one for mock Connect-SQLAnalysis.
-                            #>
-
-                            $mockSqlAnalysisSingleAdministrator = 'COMPANY\AnalysisAdmin'
-                            $mockDynamicSqlAnalysisAdmins = $mockSqlAnalysisSingleAdministrator
-
-                            It 'Should return the correct type and value for property ASSysAdminAccounts' {
-                                $result = Get-TargetResource @testParameters
-                                Write-Output -NoEnumerate $result.ASSysAdminAccounts | Should -BeOfType [System.String[]]
-                                $result.ASSysAdminAccounts | Should -Be $mockSqlAnalysisSingleAdministrator
+                            Mock -CommandName Get-SqlRoleMembers -MockWith {
+                                return @($mockSqlSystemAdministrator)
                             }
-
-                            # Setting back the default administrators for mock Connect-SQLAnalysis.
-                            $mockDynamicSqlAnalysisAdmins = $mockSqlAnalysisAdmins
                         }
+
+                        BeforeEach {
+                            $testParameters.Remove('Features')
+                            $testParameters += @{
+                                InstanceName = $mockDefaultInstance_InstanceName
+                                SourceCredential = $null
+                                SourcePath = $mockSourcePath
+                                FeatureFlag = @()
+                            }
+                        }
+
+                        It 'Should return the same values as passed as parameters' {
+                            $result = Get-TargetResource @testParameters
+                            $result.InstanceName | Should -Be $testParameters.InstanceName
+
+                            Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-IsReplicationFeatureInstalled -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Get-InstanceProgramPath -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-IsSsmsInstalled -Exactly -Times 1 -Scope It
+                            Assert-MockCalled -CommandName Test-IsSsmsAdvancedInstalled -Exactly -Times 1 -Scope It
+                        }
+
+                        It 'Should return correct names of installed features' {
+                            $result = Get-TargetResource @testParameters
+
+                            $result.Features | Should -Be 'SQLENGINE,REPLICATION,DQ,FULLTEXT,RS,AS,IS,DQC,BOL,CONN,BC,SDK,MDS'
+                        }
+
+                        It 'Should return the correct values in the hash table' {
+                            $result = Get-TargetResource @testParameters
+                            $result.SourcePath | Should -Be $mockSourcePath
+                            $result.InstanceName | Should -Be $mockDefaultInstance_InstanceName
+                            $result.InstanceID | Should -Be $mockDefaultInstance_InstanceName
+                            $result.InstallSharedDir | Should -Be $mockSqlSharedDirectory
+                            $result.InstallSharedWOWDir | Should -Be $mockSqlSharedWowDirectory
+                            $result.SQLSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                            $result.AgtSvcAccountUsername | Should -Be $mockAgentServiceAccount
+                            $result.SqlCollation | Should -Be $mockSqlCollation
+                            $result.SQLSysAdminAccounts | Should -Be $mockSqlSystemAdministrator
+                            $result.SecurityMode | Should -Be 'Windows'
+                            $result.InstallSQLDataDir | Should -Be $mockSqlInstallPath
+                            $result.SQLUserDBDir | Should -Be $mockSqlDefaultDatabaseFilePath
+                            $result.SQLUserDBLogDir | Should -Be $mockSqlDefaultDatabaseLogPath
+                            $result.SQLBackupDir | Should -Be $mockDynamicSqlBackupPath
+                            $result.FTSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                            $result.RSSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                            $result.ASSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                            $result.ASCollation | Should -Be $mockSqlAnalysisCollation
+                            $result.ASSysAdminAccounts | Should -Be $mockSqlAnalysisAdmins
+                            $result.ASDataDir | Should -Be $mockSqlAnalysisDataDirectory
+                            $result.ASLogDir | Should -Be $mockSqlAnalysisLogDirectory
+                            $result.ASBackupDir | Should -Be $mockSqlAnalysisBackupDirectory
+                            $result.ASTempDir | Should -Be $mockSqlAnalysisTempDirectory
+                            $result.ASConfigDir | Should -Be $mockSqlAnalysisConfigDirectory
+                            $result.ASServerMode | Should -Be 'MULTIDIMENSIONAL'
+                            $result.ISSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                            $result.SQLTempDBDir | Should -Be $mockSqlTempDatabasePath
+                            $result.SqlTempdbFileCount | Should -Be 1
+                            $result.SqlTempdbFileSize | Should -Be 200
+                            $result.SqlTempdbFileGrowth | Should -Be 10
+                            $result.SqlTempdbLogFileSize | Should -Be 20
+                            $result.SqlTempdbLogFileGrowth | Should -Be 10
+                        }
+
+                        $mockDynamicAnalysisServerMode = 'POWERPIVOT'
+
+                        It 'Should return the correct values when Analysis Services mode is POWERPIVOT' {
+                            $result = Get-TargetResource @testParameters
+                            $result.ASServerMode | Should -Be 'POWERPIVOT'
+                        }
+
+                        $mockDynamicAnalysisServerMode = 'TABULAR'
+
+                        It 'Should return the correct values when Analysis Services mode is TABULAR' {
+                            $result = Get-TargetResource @testParameters
+                            $result.ASServerMode | Should -Be 'TABULAR'
+                        }
+
+                        # Return the state to the default for all other tests.
+                        $mockDynamicAnalysisServerMode = 'MULTIDIMENSIONAL'
+
+                        <#
+                            This is a regression test for issue #691.
+                            This sets administrators to only one for mock Connect-SQLAnalysis.
+                        #>
+
+                        $mockSqlAnalysisSingleAdministrator = 'COMPANY\AnalysisAdmin'
+                        $mockDynamicSqlAnalysisAdmins = $mockSqlAnalysisSingleAdministrator
+
+                        It 'Should return the correct type and value for property ASSysAdminAccounts' {
+                            $result = Get-TargetResource @testParameters
+                            Write-Output -NoEnumerate $result.ASSysAdminAccounts | Should -BeOfType [System.String[]]
+                            $result.ASSysAdminAccounts | Should -Be $mockSqlAnalysisSingleAdministrator
+                        }
+
+                        # Setting back the default administrators for mock Connect-SQLAnalysis.
+                        $mockDynamicSqlAnalysisAdmins = $mockSqlAnalysisAdmins
                     }
                 }
 
                 Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for default instance" {
+                    BeforeAll {
+                        Mock -CommandName Get-TempDbProperties -MockWith {
+                            return @{
+                                SQLTempDBDir = $mockSqlTempDatabasePath
+                                SqlTempdbFileCount = 1
+                                SqlTempdbFileSize = 200
+                                SqlTempdbFileGrowth = 10
+                                SqlTempdbLogFileSize = 20
+                                SqlTempdbLogFileGrowth = 10
+                            }
+                        }
+
+                        Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Connect-UncPath
+                        Mock -CommandName Disconnect-UncPath
+                        Mock -CommandName Get-Service -MockWith $mockGetService_NoServices
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters += @{
@@ -1383,54 +561,6 @@ try
                             SourceCredential = $mockSetupCredential
                             SourcePath = $mockSourcePathUNC
                         }
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            # Mock all SSMS products here to make sure we don't return any when testing SQL Server 2016
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                        }
-                        else
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockEmptyHashtable -Verifiable
-                        }
-
-                        Mock -CommandName Connect-UncPath -Verifiable
-                        Mock -CommandName Disconnect-UncPath -Verifiable
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -1440,43 +570,13 @@ try
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-InstanceProgramPath -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsAdvancedInstalled -Exactly -Times 1 -Scope It
                     }
 
                     It 'Should not return any names of installed features' {
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -Verifiable
-
                         $result = Get-TargetResource @testParameters
                         $result.Features | Should -Be ''
                     }
@@ -1512,6 +612,76 @@ try
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for features 'CONN', 'SDK' and 'BC'" {
+                    BeforeAll {
+                        Mock -CommandName Get-TempDbProperties -MockWith {
+                            return @{
+                                SQLTempDBDir = $mockSqlTempDatabasePath
+                                SqlTempdbFileCount = 1
+                                SqlTempdbFileSize = 200
+                                SqlTempdbFileGrowth = 10
+                                SqlTempdbLogFileSize = 20
+                                SqlTempdbLogFileGrowth = 10
+                            }
+                        }
+
+                        Mock -CommandName Get-SqlRoleMembers -MockWith {
+                            return @($mockSqlSystemAdministrator)
+                        }
+
+                        Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Connect-UncPath
+                        Mock -CommandName Disconnect-UncPath
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance
+
+                        Mock -CommandName Get-SqlEngineProperties -MockWith {
+                            return @{
+                                SQLSvcAccountUsername = $mockSqlServiceAccount
+                                AgtSvcAccountUsername = $mockAgentServiceAccount
+                                SqlSvcStartupType = $mockStartMode
+                                AgtSvcStartupType = $mockStartMode
+                                SQLCollation = $mockSqlCollation
+                                SecurityMode = $mockSqlLoginMode
+                            }
+                        }
+
+                        Mock -CommandName Get-ServiceProperties -MockWith {
+                            return @{
+                                UserName = $mockSqlServiceAccount
+                                StartupType = $mockStartMode
+                            }
+                        }
+
+                        Mock -CommandName Test-IsReplicationFeatureInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsDQComponentInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Get-InstalledSharedFeatures -MockWith {
+                            return @(
+                                'DQC'
+                                'BOL'
+                                'CONN'
+                                'BC'
+                                'SDK'
+                                'MDS'
+                            )
+                        }
+
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters += @{
@@ -1519,107 +689,117 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName Connect-UncPath -Verifiable
-                        Mock -CommandName Disconnect-UncPath -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_InstanceId_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_SqlVersion_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -MockWith $mockGetItemProperty_ClientComponentsFull_EmptyFeatureList -Verifiable
                     }
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $result.Features | Should -Be 'SQLENGINE,REPLICATION,DQ,DQC,FULLTEXT,RS,AS,IS,BOL,MDS'
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
                         }
                         else
                         {
-                            $result.Features | Should -Be 'SQLENGINE,REPLICATION,DQ,DQC,FULLTEXT,RS,AS,IS,BOL,MDS,SSMS,ADV_SSMS'
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
+                            $result.Features | Should -Match 'SSMS\b'
+                            $result.Features | Should -Match 'ADV_SSMS\b'
                         }
                     }
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
+                    BeforeAll {
+                        Mock -CommandName Get-TempDbProperties -MockWith {
+                            return @{
+                                SQLTempDBDir = $mockSqlTempDatabasePath
+                                SqlTempdbFileCount = 1
+                                SqlTempdbFileSize = 200
+                                SqlTempdbFileGrowth = 10
+                                SqlTempdbLogFileSize = 20
+                                SqlTempdbLogFileGrowth = 10
+                            }
+                        }
+
+                        Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Connect-UncPath
+                        Mock -CommandName Disconnect-UncPath
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance
+
+                        Mock -CommandName Get-SqlEngineProperties -MockWith {
+                            return @{
+                                SQLSvcAccountUsername = $mockSqlServiceAccount
+                                AgtSvcAccountUsername = $mockAgentServiceAccount
+                                SqlSvcStartupType = $mockStartMode
+                                AgtSvcStartupType = $mockStartMode
+                                SQLCollation = $mockSqlCollation
+                                IsClustered = $false
+                                InstallSQLDataDir = $mockSqlInstallPath
+                                SQLUserDBDir = $mockSqlDefaultDatabaseFilePath
+                                SQLUserDBLogDir = $mockSqlDefaultDatabaseFilePath
+                                SQLBackupDir = $mockDynamicSqlBackupPath
+                                SecurityMode = $mockSqlLoginMode
+                            }
+                        }
+
+                        Mock -CommandName Get-ServiceProperties -MockWith {
+                            return @{
+                                UserName = $mockSqlServiceAccount
+                                StartupType = $mockStartMode
+                            }
+                        }
+
+                        Mock -CommandName Test-IsReplicationFeatureInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsDQComponentInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+
+                        Mock -CommandName Get-InstalledSharedFeatures -MockWith {
+                            return @(
+                                'DQC'
+                                'BOL'
+                                'CONN'
+                                'BC'
+                                'SDK'
+                                'MDS'
+                            )
+                        }
+
+                        Mock -CommandName Get-SqlRoleMembers -MockWith {
+                            return @($mockSqlSystemAdministrator)
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters += @{
@@ -1627,87 +807,6 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName Connect-UncPath -Verifiable
-                        Mock -CommandName Disconnect-UncPath -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_InstanceId_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_SqlVersion_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -1717,87 +816,48 @@ try
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 1 -Scope It
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 0 -Scope It
-                        }
-                        else
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 2 -Scope It
-                        }
-
-                        #region Assert Get-CimInstance
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -Exactly -Times 1 -Scope It
-                        #endregion Assert Get-CimInstance
+                        Assert-MockCalled -CommandName Test-IsReplicationFeatureInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-InstanceProgramPath -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsAdvancedInstalled -Exactly -Times 1 -Scope It
                     }
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
-                            $result.Features | Should -Be $featuresForSqlServer2016
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
+                            $result.Features | Should -Match 'CONN\b'
+                            $result.Features | Should -Match 'BC\b'
+                            $result.Features | Should -Match 'SDK\b'
                         }
                         else
                         {
-                            $result.Features | Should -Be $mockDefaultParameters.Features.ToUpper()
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
+                            $result.Features | Should -Match 'CONN\b'
+                            $result.Features | Should -Match 'BC\b'
+                            $result.Features | Should -Match 'SDK\b'
+                            $result.Features | Should -Match 'SSMS\b'
+                            $result.Features | Should -Match 'ADV_SSMS\b'
                         }
                     }
 
@@ -1867,6 +927,81 @@ try
                 }
 
                 Context "When using SourceCredential parameter and SQL Server version is $mockSqlMajorVersion and the system is in the desired state for default instance" {
+                    BeforeAll {
+                        Mock -CommandName Get-TempDbProperties -MockWith {
+                            return @{
+                                SQLTempDBDir = $mockSqlTempDatabasePath
+                                SqlTempdbFileCount = 1
+                                SqlTempdbFileSize = 200
+                                SqlTempdbFileGrowth = 10
+                                SqlTempdbLogFileSize = 20
+                                SqlTempdbLogFileGrowth = 10
+                            }
+                        }
+
+                        Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Connect-UncPath
+                        Mock -CommandName Disconnect-UncPath
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance
+
+                        Mock -CommandName Get-SqlEngineProperties -MockWith {
+                            return @{
+                                SQLSvcAccountUsername = $mockSqlServiceAccount
+                                AgtSvcAccountUsername = $mockAgentServiceAccount
+                                SqlSvcStartupType = $mockStartMode
+                                AgtSvcStartupType = $mockStartMode
+                                SQLCollation = $mockSqlCollation
+                                IsClustered = $false
+                                InstallSQLDataDir = $mockSqlInstallPath
+                                SQLUserDBDir = $mockSqlDefaultDatabaseFilePath
+                                SQLUserDBLogDir = $mockSqlDefaultDatabaseFilePath
+                                SQLBackupDir = $mockDynamicSqlBackupPath
+                                SecurityMode = $mockSqlLoginMode
+                            }
+                        }
+
+                        Mock -CommandName Get-ServiceProperties -MockWith {
+                            return @{
+                                UserName = $mockSqlServiceAccount
+                                StartupType = $mockStartMode
+                            }
+                        }
+
+                        Mock -CommandName Test-IsReplicationFeatureInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsDQComponentInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+
+                        Mock -CommandName Get-InstalledSharedFeatures -MockWith {
+                            return @(
+                                'DQC'
+                                'BOL'
+                                'CONN'
+                                'BC'
+                                'SDK'
+                                'MDS'
+                            )
+                        }
+
+                        Mock -CommandName Get-SqlRoleMembers -MockWith {
+                            return @($mockSqlSystemAdministrator)
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters += @{
@@ -1874,87 +1009,6 @@ try
                             SourceCredential = $mockSetupCredential
                             SourcePath = $mockSourcePathUNC
                         }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName Connect-UncPath -Verifiable
-                        Mock -CommandName Disconnect-UncPath -Verifiable
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_DefaultInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_InstanceId_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_SqlVersion_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -1964,87 +1018,48 @@ try
                         Assert-MockCalled -CommandName Connect-UncPath -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Disconnect-UncPath -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockDefaultInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 1 -Scope It
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 0 -Scope It
-                        }
-                        else
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 2 -Scope It
-                        }
-
-                        #region Assert Get-CimInstance
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_DatabaseServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AgentServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_FullTextServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_ReportingServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockDefaultInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockDefaultInstance_AnalysisServiceName'"
-                        } -Exactly -Times 1 -Scope It
-                        #endregion Assert Get-CimInstance
+                        Assert-MockCalled -CommandName Test-IsReplicationFeatureInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-InstanceProgramPath -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsAdvancedInstalled -Exactly -Times 1 -Scope It
                     }
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
-                            $result.Features | Should -Be $featuresForSqlServer2016
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
+                            $result.Features | Should -Match 'CONN\b'
+                            $result.Features | Should -Match 'BC\b'
+                            $result.Features | Should -Match 'SDK\b'
                         }
                         else
                         {
-                            $result.Features | Should -Be $mockDefaultParameters.Features.ToUpper()
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
+                            $result.Features | Should -Match 'CONN\b'
+                            $result.Features | Should -Match 'BC\b'
+                            $result.Features | Should -Match 'SDK\b'
+                            $result.Features | Should -Match 'SSMS\b'
+                            $result.Features | Should -Match 'ADV_SSMS\b'
                         }
                     }
 
@@ -2078,16 +1093,36 @@ try
                     }
                 }
 
-                $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-
-                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
-                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
-                $mockDynamicSqlTempDatabasePath = ''
-                $mockDynamicSqlTempDatabaseLogPath = ''
-                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for named instance" {
+                    BeforeAll {
+                        $mockNamedInstance_InstanceName = 'TEST'
+                        $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
+
+                        $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
+                        $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
+                        $mockDynamicSqlTempDatabasePath = ''
+                        $mockDynamicSqlTempDatabaseLogPath = ''
+                        $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+                        $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+
+                        Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Get-Service -MockWith $mockGetService_NoServices
+                        Mock -CommandName Test-IsDQComponentInstalled -MockWith {
+                            return $false
+                        }
+
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters += @{
@@ -2095,52 +1130,6 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            # Mock this here to make sure we don't return any older components (<=2014) when testing SQL Server 2016
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts -Verifiable
-                        }
-                        else
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockEmptyHashtable -Verifiable
-                        }
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-CimInstance -MockWith $mockEmptyHashtable -Verifiable
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -2148,42 +1137,13 @@ try
                         $result.InstanceName | Should -Be $testParameters.InstanceName
 
                         Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 0 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 0 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                        } -Exactly -Times 6 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Get-InstanceProgramPath -Exactly -Times 0 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsAdvancedInstalled -Exactly -Times 1 -Scope It
                     }
 
                     It 'Should not return any names of installed features' {
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -Verifiable
-
                         $result = Get-TargetResource @testParameters
                         $result.Features | Should -Be ''
                     }
@@ -2219,6 +1179,126 @@ try
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for named instance" {
+                    BeforeAll {
+                        $mockNamedInstance_InstanceName = 'TEST'
+                        $mockNamedInstance_DatabaseServiceName = "$($mockSqlDatabaseEngineName)`$$($mockNamedInstance_InstanceName)"
+                        $mockNamedInstance_AgentServiceName = "$($mockSqlAgentName)`$$($mockNamedInstance_InstanceName)"
+                        $mockNamedInstance_FullTextServiceName = "$($mockSqlFullTextName)`$$($mockNamedInstance_InstanceName)"
+                        $mockNamedInstance_ReportingServiceName = "$($mockSqlReportingName)`$$($mockNamedInstance_InstanceName)"
+                        $mockNamedInstance_IntegrationServiceName = $mockSqlIntegrationName
+                        $mockNamedInstance_AnalysisServiceName = "$($mockSqlAnalysisName)`$$($mockNamedInstance_InstanceName)"
+
+                        $mockGetService_NamedInstance = {
+                            return @(
+                                (
+                                    New-Object -TypeName Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_DatabaseServiceName -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                                ),
+                                (
+                                    New-Object -TypeName Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AgentServiceName -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockAgentServiceAccount -PassThru -Force |
+                                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                                ),
+                                (
+                                    New-Object -TypeName Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_FullTextServiceName -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force
+                                ),
+                                (
+                                    New-Object -TypeName Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_ReportingServiceName -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                                ),
+                                (
+                                    New-Object -TypeName Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value ($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion) -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                                ),
+                                (
+                                    New-Object -TypeName Object |
+                                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockNamedInstance_AnalysisServiceName -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockSqlServiceAccount -PassThru -Force |
+                                        Add-Member -MemberType NoteProperty -Name 'StartMode' -Value $mockStartMode -PassThru -Force
+                                )
+                            )
+                        }
+
+                        Mock -CommandName Get-Service -MockWith $mockGetService_NamedInstance
+                        Mock -CommandName Get-TempDbProperties -MockWith {
+                            return @{
+                                SQLTempDBDir = $mockSqlTempDatabasePath
+                                SqlTempdbFileCount = 1
+                                SqlTempdbFileSize = 200
+                                SqlTempdbFileGrowth = 10
+                                SqlTempdbLogFileSize = 20
+                                SqlTempdbLogFileGrowth = 10
+                            }
+                        }
+
+                        Mock -CommandName Test-IsSsmsInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsSsmsAdvancedInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Get-SqlEngineProperties -MockWith {
+                            return @{
+                                SQLSvcAccountUsername = $mockSqlServiceAccount
+                                AgtSvcAccountUsername = $mockAgentServiceAccount
+                                SqlSvcStartupType = $mockStartMode
+                                AgtSvcStartupType = $mockStartMode
+                                SQLCollation = $mockSqlCollation
+                                IsClustered = $false
+                                InstallSQLDataDir = $mockSqlInstallPath
+                                SQLUserDBDir = $mockSqlDefaultDatabaseFilePath
+                                SQLUserDBLogDir = $mockSqlDefaultDatabaseFilePath
+                                SQLBackupDir = $mockDynamicSqlBackupPath
+                                SecurityMode = $mockSqlLoginMode
+                            }
+                        }
+
+                        Mock -CommandName Get-ServiceProperties -MockWith {
+                            return @{
+                                UserName = $mockSqlServiceAccount
+                                StartupType = $mockStartMode
+                            }
+                        }
+
+                        Mock -CommandName Test-IsReplicationFeatureInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Test-IsDQComponentInstalled -MockWith {
+                            return $true
+                        }
+
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+
+                        Mock -CommandName Get-InstalledSharedFeatures -MockWith {
+                            return @(
+                                'DQC'
+                                'BOL'
+                                'CONN'
+                                'BC'
+                                'SDK'
+                                'MDS'
+                            )
+                        }
+
+                        Mock -CommandName Get-SqlRoleMembers -MockWith {
+                            return @($mockSqlSystemAdministrator)
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters += @{
@@ -2226,85 +1306,6 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-
-                        if ($mockSqlMajorVersion -eq 10)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2008R2 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 11)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2012 -Verifiable
-                        }
-
-                        if ($mockSqlMajorVersion -eq 12)
-                        {
-                            Mock -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -MockWith $mockGetItemProperty_UninstallProducts2014 -Verifiable
-                        }
-
-                        Mock -CommandName Get-Service -MockWith $mockGetService_NamedInstance -Verifiable
-
-                        #region Mock Get-CimInstance
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_DatabaseService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_AgentService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_FullTextService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_ReportingService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_IntegrationService -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
-                        } -MockWith $mockGetCimInstance_NamedInstance_AnalysisService -Verifiable
-
-                        # If Get-CimInstance is used in any other way than those mocks with a ParameterFilter, then throw and error
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            throw "Mock Get-CimInstance was called with unexpected parameters. ClassName=$ClassName, Filter=$Filter"
-                        } -Verifiable
-                        #endregion Mock Get-CimInstance
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_InstanceId_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\DQ\*"
-                        } -MockWith $mockGetItemProperty_DQFeature -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\ConfigurationState"
-                        } -MockWith $mockGetItemProperty_SqlVersion_ConfigurationState -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -MockWith $mockGetItemProperty_Setup -Verifiable
                     }
 
                     It 'Should return the same values as passed as parameters' {
@@ -2312,87 +1313,48 @@ try
                         $result.InstanceName | Should -Be $testParameters.InstanceName
 
                         Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQLAnalysis -Exactly -Times 1 -Scope It
                         Assert-MockCalled -CommandName Get-Service -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\ConfigurationState"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$mockNamedInstance_InstanceId\Setup" -and $Name -eq 'SqlProgramDir'
-                        } -Exactly -Times 1 -Scope It
-
-                        if ($mockSqlMajorVersion -in (13,14))
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 0 -Scope It
-                        }
-                        else
-                        {
-                            Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber) -or
-                                $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
-                            } -Exactly -Times 2 -Scope It
-                        }
-
-                        #region Assert Get-CimInstance
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_DatabaseServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AgentServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_FullTextServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_ReportingServiceName'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$(($mockNamedInstance_IntegrationServiceName -f $mockSqlMajorVersion))'"
-                        } -Exactly -Times 1 -Scope It
-
-                        Assert-MockCalled -CommandName Get-CimInstance -ParameterFilter {
-                            $ClassName -eq 'Win32_Service' -and
-                            $Filter -eq "Name = '$mockNamedInstance_AnalysisServiceName'"
-                        } -Exactly -Times 1 -Scope It
-                        #endregion Assert Get-CimInstance
+                        Assert-MockCalled -CommandName Test-IsReplicationFeatureInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Get-InstanceProgramPath -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsInstalled -Exactly -Times 1 -Scope It
+                        Assert-MockCalled -CommandName Test-IsSsmsAdvancedInstalled -Exactly -Times 1 -Scope It
                     }
 
                     It 'Should return correct names of installed features' {
                         $result = Get-TargetResource @testParameters
                         if ($mockSqlMajorVersion -in (13,14))
                         {
-                            $featuresForSqlServer2016 = (($mockDefaultParameters.Features.ToUpper()) -replace 'SSMS,','') -replace ',ADV_SSMS',''
-                            $result.Features | Should -Be $featuresForSqlServer2016
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
+                            $result.Features | Should -Match 'CONN\b'
+                            $result.Features | Should -Match 'BC\b'
+                            $result.Features | Should -Match 'SDK\b'
                         }
                         else
                         {
-                            $result.Features | Should -Be $mockDefaultParameters.Features.ToUpper()
+                            $result.Features | Should -Match 'SQLENGINE\b'
+                            $result.Features | Should -Match 'REPLICATION\b'
+                            $result.Features | Should -Match 'DQ\b'
+                            $result.Features | Should -Match 'DQC\b'
+                            $result.Features | Should -Match 'FULLTEXT\b'
+                            $result.Features | Should -Match 'RS\b'
+                            $result.Features | Should -Match 'AS\b'
+                            $result.Features | Should -Match 'IS\b'
+                            $result.Features | Should -Match 'BOL\b'
+                            $result.Features | Should -Match 'MDS\b'
+                            $result.Features | Should -Match 'CONN\b'
+                            $result.Features | Should -Match 'BC\b'
+                            $result.Features | Should -Match 'SDK\b'
+                            $result.Features | Should -Match 'SSMS\b'
+                            $result.Features | Should -Match 'ADV_SSMS\b'
                         }
                     }
 
@@ -2427,6 +1389,30 @@ try
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a clustered default instance" {
+                    BeforeAll {
+                        Mock -CommandName Get-TempDbProperties -MockWith {
+                            return @{
+                                SQLTempDBDir = $mockSqlTempDatabasePath
+                                SqlTempdbFileCount = 1
+                                SqlTempdbFileSize = 200
+                                SqlTempdbFileGrowth = 10
+                                SqlTempdbLogFileSize = 20
+                                SqlTempdbLogFileGrowth = 10
+                            }
+                        }
+
+                        Mock -CommandName Get-SqlRoleMembers -MockWith {
+                            return @($mockSqlSystemAdministrator)
+                        }
+
+                        Mock -CommandName Get-CimInstance
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
+
+                        Mock -CommandName Get-Service -MockWith $mockGetService_NoServices
+                    }
+
                     BeforeEach {
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters.Remove('Features')
@@ -2435,25 +1421,10 @@ try
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
-
-                        Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-
-                        Mock -CommandName Get-CimInstance -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -Verifiable
-
-                        Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockEmptyHashtable -Verifiable
                     }
 
                     It 'Should not attempt to collect cluster information for a standalone instance' {
                         $currentState = Get-TargetResource @testParameters
-
-                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 0 -Scope It
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 0 -Scope It
 
                         $currentState.FailoverClusterGroupName | Should -BeNullOrEmpty
                         $currentState.FailoverClusterNetworkName | Should -BeNullOrEmpty
@@ -2462,72 +1433,82 @@ try
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is in the desired state for a clustered default instance" {
-
-                    BeforeEach {
-                        $testParameters = $mockDefaultParameters.Clone()
-                        $testParameters.Remove('Features')
-                        $testParameters += @{
+                    BeforeAll {
+                        $mockTestParameters = @{
                             InstanceName = $mockDefaultInstance_InstanceName
                             SourceCredential = $null
                             SourcePath = $mockSourcePath
                         }
 
-                        $mockCurrentInstanceName = $mockDefaultInstance_InstanceName
+                        $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
+                        $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
+                        $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
 
-                        Mock -CommandName Connect-SQL -MockWith $mockConnectSQLCluster -Verifiable
+                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance
 
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource -Verifiable -ParameterFilter {
-                            $Filter -eq "Type = 'SQL Server'"
+                        Mock -CommandName Get-TempDbProperties -MockWith {
+                            return @{
+                                SQLTempDBDir = $mockSqlTempDatabasePath
+                                SqlTempdbFileCount = 1
+                                SqlTempdbFileSize = 200
+                                SqlTempdbFileGrowth = 10
+                                SqlTempdbLogFileSize = 20
+                                SqlTempdbLogFileGrowth = 10
+                            }
                         }
 
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSClusterResource_DefaultInstance -Verifiable -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-
-                        Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty_Setup -Verifiable
-
-                        Mock -CommandName Get-Service -MockWith $mockGetService_DefaultInstance -Verifiable
-                    }
-
-                    It 'Should throw the correct error message when failover cluster resource cannot be found' {
-                        Mock -CommandName Get-CimInstance -MockWith {
-                            return $null
-                        } -Verifiable -ParameterFilter {
-                            $Filter -eq "Type = 'SQL Server'"
+                        Mock -CommandName Get-SqlRoleMembers -MockWith {
+                            return @($mockSqlSystemAdministrator)
                         }
 
-                        { Get-TargetResource @testParameters } | Should -Throw 'Could not locate a SQL Server cluster resource for instance MSSQLSERVER.'
+                        Mock -CommandName Get-SqlClusterProperties -MockWith {
+                            return @{
+                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                                FailoverClusterGroupName   = $mockDefaultInstance_FailoverClusterGroupName
+                                FailoverClusterIPAddress   = $mockDefaultInstance_FailoverClusterIPAddress
+                            }
+                        }
 
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-                    }
+                        Mock -CommandName Get-InstanceProgramPath -MockWith {
+                            return $mockSqlProgramDirectory
+                        }
 
-                    It 'Should collect information for a clustered instance' {
-                        $currentState = Get-TargetResource @testParameters
-
-                        Assert-MockCalled -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                        Assert-MockCalled -CommandName Get-CimInstance -Exactly -Times 1 -Scope It -ParameterFilter { $Filter -eq "Type = 'SQL Server'" }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 1 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_ResourceGroup' }
-                        Assert-MockCalled -CommandName Get-CimAssociatedInstance -Exactly -Times 2 -Scope It -ParameterFilter { $ResultClassName -eq 'MSCluster_Resource' }
-
-                        $currentState.InstanceName | Should -Be $testParameters.InstanceName
+                        Mock -CommandName Get-SqlEngineProperties -MockWith {
+                            return @{
+                                IsClustered = $true
+                            }
+                        }
                     }
 
                     It 'Should return correct cluster information' {
-                        $currentState = Get-TargetResource @testParameters
+                        $currentState = Get-TargetResource @mockTestParameters
 
+                        $currentState.InstanceName | Should -Be $mockTestParameters.InstanceName
                         $currentState.FailoverClusterGroupName | Should -Be $mockDefaultInstance_FailoverClusterGroupName
                         $currentState.FailoverClusterIPAddress | Should -Be $mockDefaultInstance_FailoverClusterIPAddress
                         $currentSTate.FailoverClusterNetworkName | Should -Be $mockDefaultInstance_FailoverClusterNetworkName
                     }
                 }
             }
-
-            Assert-VerifiableMock
         }
 
-        Describe "SqlSetup\Test-TargetResource" -Tag 'Test' {
+        Describe 'SqlSetup\Test-TargetResource' -Tag 'Test' {
+            BeforeAll {
+                <#
+                    These are written with both lower-case and upper-case to make sure we support that.
+                    The feature list must be written in the order it is returned by the function Get-TargetResource.
+                #>
+                $mockDefaultFeatures = 'SQLEngine,Replication,Dq,Dqc,FullText,Rs,As,Is,Bol,Conn,Bc,Sdk,Mds,Ssms,Adv_Ssms'
+
+                # Default parameters that are used for the It-blocks
+                $mockDefaultParameters = @{
+                    Features = $mockDefaultFeatures
+                }
+
+                $mockNamedInstance_InstanceName = 'TEST'
+                $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
+            }
+
             Context 'When the system is not in the desired state' {
                 Context 'When no features are installed' {
                     BeforeAll {
@@ -2542,7 +1523,7 @@ try
                             return @{
                                 Features = ''
                             }
-                        } -Verifiable
+                        }
                     }
 
                     It 'Should return $false' {
@@ -2572,7 +1553,7 @@ try
                                 FailoverClusterNetworkName = $null
                                 FailoverClusterIPAddress = $null
                             }
-                        } -Verifiable
+                        }
                     }
 
                     It 'Should return $false' {
@@ -2598,12 +1579,12 @@ try
 
                         Mock -CommandName Get-TargetResource -MockWith {
                             return @{
-                                    Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
-                                    FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
-                                    FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
-                                    FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
-                                }
-                        } -Verifiable
+                                Features = 'SQLENGINE' # Must be upper-case since Get-TargetResource returns upper-case.
+                                FailoverClusterGroupName = $mockDefaultInstance_FailoverClusterGroupName
+                                FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
+                                FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
+                            }
+                        }
                     }
 
                     # This is a test for regression testing of issue #432
@@ -2630,7 +1611,7 @@ try
                             return @{
                                 Features = $mockDefaultFeatures
                             }
-                        } -Verifiable
+                        }
                     }
 
                     It 'Should return $true' {
@@ -2643,6 +1624,10 @@ try
 
                 Context 'When the correct clustered instance was found' {
                     BeforeAll {
+                        $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
+                        $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
+                        $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
+
                         $testParameters = $mockDefaultParameters.Clone()
                         $testParameters += @{
                             InstanceName = $mockDefaultInstance_InstanceName
@@ -2660,7 +1645,25 @@ try
                                 FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                                 FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             }
-                        } -Verifiable
+                        }
+
+                        $mockClusterDiskMap = {
+                            @{
+                                SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
+                                UserData = Split-Path -Path $mockDynamicSqlUserDatabasePath -Qualifier
+                                UserLogs = Split-Path -Path $mockDynamicSqlUserDatabaseLogPath -Qualifier
+                                TempDbData = Split-Path -Path $mockDynamicSqlTempDatabasePath -Qualifier
+                                TempDbLogs = Split-Path -Path $mockDynamicSqlTempDatabaseLogPath -Qualifier
+                                Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
+                            }
+                        }
+
+                        $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
+                        $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
+                        $mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
+                        $mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
+                        $mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
+                        $mockSqlBackupPath = 'O:\MSSQL\Backup'
                     }
 
                     It 'Should return $true' {
@@ -2710,7 +1713,7 @@ try
                                 FailoverClusterIPAddress = $mockDefaultInstance_FailoverClusterIPAddress
                                 FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                             }
-                        } -Verifiable
+                        }
                     }
 
                     It 'Should return $true' {
@@ -2726,72 +1729,418 @@ try
         }
 
         Describe "SqlSetup\Set-TargetResource" -Tag 'Set' {
-            #region Setting up TestDrive:\
-
-            # Local path to TestDrive:\
-            $mockSourcePath = $TestDrive.FullName
-
-            # UNC path to TestDrive:\
-            $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
-            $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
-
-            <#
-                Mocking folder structure. This takes the leaf from the $mockSourcePath (the Guid in this case) and
-                uses that to create a mock folder to mimic the temp folder that would be created in, for example,
-                temp folder 'C:\Windows\Temp'.
-                This folder is used when SourcePath is called with a leaf, for example '\\server\share\folder'.
-            #>
-            $mediaTempSourcePathWithLeaf = (Join-Path -Path $mockSourcePath -ChildPath (Split-Path -Path $mockSourcePath -Leaf))
-            if (-not (Test-Path $mediaTempSourcePathWithLeaf))
-            {
-                New-Item -Path $mediaTempSourcePathWithLeaf -ItemType Directory
-            }
-
-            <#
-                Mocking folder structure. This takes the leaf from the New-Guid mock and uses that
-                to create a mock folder to mimic the temp folder that would be created in, for example,
-                temp folder 'C:\Windows\Temp'.
-                This folder is used when SourcePath is called without a leaf, for example '\\server\share'.
-            #>
-            $mediaTempSourcePathWithoutLeaf = (Join-Path -Path $mockSourcePath -ChildPath $mockSourcePathGuid)
-            if (-not (Test-Path $mediaTempSourcePathWithoutLeaf))
-            {
-                New-Item -Path $mediaTempSourcePathWithoutLeaf -ItemType Directory
-            }
-
-            # Mocking executable setup.exe which will be used for tests without parameter SourceCredential
-            Set-Content (Join-Path -Path $mockSourcePath -ChildPath 'setup.exe') -Value 'Mock exe file'
-
-            # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path with leaf
-            Set-Content (Join-Path -Path $mediaTempSourcePathWithLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-
-            # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path without leaf
-            Set-Content (Join-Path -Path $mediaTempSourcePathWithoutLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
-
-            #endregion Setting up TestDrive:\
-
             BeforeAll {
-                # General mocks
-                Mock -CommandName Get-PSDrive -Verifiable
-                Mock -CommandName Import-SQLPSModule
-                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
+                #region Setting up TestDrive:\
 
-                # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
-                Mock -CommandName Get-ItemProperty -Verifiable
+                # Local path to TestDrive:\
+                $mockSourcePath = $TestDrive.FullName
 
-                Mock -CommandName Start-SqlSetupProcess -MockWith $mockStartSqlSetupProcess -Verifiable
-                Mock -CommandName Test-TargetResource -MockWith {
-                    return $true
-                } -Verifiable
+                # UNC path to TestDrive:\
+                $testDrive_DriveShare = (Split-Path -Path $mockSourcePath -Qualifier) -replace ':','$'
+                $mockSourcePathUNC = Join-Path -Path "\\localhost\$testDrive_DriveShare" -ChildPath (Split-Path -Path $mockSourcePath -NoQualifier)
 
-                Mock -CommandName Test-PendingRestart -MockWith {
-                    return $false
+                <#
+                    Mocking folder structure. This takes the leaf from the $mockSourcePath (the Guid in this case) and
+                    uses that to create a mock folder to mimic the temp folder that would be created in, for example,
+                    temp folder 'C:\Windows\Temp'.
+                    This folder is used when SourcePath is called with a leaf, for example '\\server\share\folder'.
+                #>
+                $mediaTempSourcePathWithLeaf = (Join-Path -Path $mockSourcePath -ChildPath (Split-Path -Path $mockSourcePath -Leaf))
+                if (-not (Test-Path $mediaTempSourcePathWithLeaf))
+                {
+                    New-Item -Path $mediaTempSourcePathWithLeaf -ItemType Directory
                 }
+
+                <#
+                    Mocking folder structure. This takes the leaf from the New-Guid mock and uses that
+                    to create a mock folder to mimic the temp folder that would be created in, for example,
+                    temp folder 'C:\Windows\Temp'.
+                    This folder is used when SourcePath is called without a leaf, for example '\\server\share'.
+                #>
+                $mediaTempSourcePathWithoutLeaf = (Join-Path -Path $mockSourcePath -ChildPath $mockSourcePathGuid)
+                if (-not (Test-Path $mediaTempSourcePathWithoutLeaf))
+                {
+                    New-Item -Path $mediaTempSourcePathWithoutLeaf -ItemType Directory
+                }
+
+                # Mocking executable setup.exe which will be used for tests without parameter SourceCredential
+                Set-Content (Join-Path -Path $mockSourcePath -ChildPath 'setup.exe') -Value 'Mock exe file'
+
+                # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path with leaf
+                Set-Content (Join-Path -Path $mediaTempSourcePathWithLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
+
+                # Mocking executable setup.exe which will be used for tests with parameter SourceCredential and an UNC path without leaf
+                Set-Content (Join-Path -Path $mediaTempSourcePathWithoutLeaf -ChildPath 'setup.exe') -Value 'Mock exe file'
+
+                #endregion Setting up TestDrive:\
+
+                <#
+                    .SYNOPSIS
+                        Used to test arguments passed to Start-SqlSetupProcess while inside and It-block.
+
+                        This function must be called inside a Mock, since it depends being run inside an It-block.
+
+                    .PARAMETER Argument
+                        A string containing all the arguments separated with space and each argument should start with '/'.
+                        Only the first string in the array is evaluated.
+
+                    .PARAMETER ExpectedArgument
+                        A hash table containing all the expected arguments.
+                #>
+                function Test-SetupArgument
+                {
+                    param
+                    (
+                        [Parameter(Mandatory = $true)]
+                        [System.String]
+                        $Argument,
+
+                        [Parameter(Mandatory = $true)]
+                        [System.Collections.Hashtable]
+                        $ExpectedArgument
+                    )
+
+                    $argumentHashTable = @{}
+
+                    # Break the argument string into a hash table
+                    ($Argument -split ' ?/') | ForEach-Object {
+                        if ($_ -imatch '(\w+)="?([^/]+)"?')
+                        {
+                            $key = $Matches[1]
+                            if ($key -in ('FailoverClusterDisks','FailoverClusterIPAddresses'))
+                            {
+                                $value = ($Matches[2] -replace '" "','; ') -replace '"',''
+                            }
+                            else
+                            {
+                                $value = ($Matches[2] -replace '" "',' ') -replace '"',''
+                            }
+
+                            $argumentHashTable.Add($key, $value)
+                        }
+                    }
+
+                    $actualValues = $argumentHashTable.Clone()
+
+                    # Limit the output in the console when everything is fine.
+                    if ($actualValues.Count -ne $ExpectedArgument.Count)
+                    {
+                        Write-Warning -Message 'Verified the setup argument count (expected vs actual)'
+                        Write-Warning -Message ('Expected: {0}' -f ($ExpectedArgument.Keys -join ','))
+                        Write-Warning -Message ('Actual: {0}' -f ($actualValues.Keys -join ','))
+                    }
+
+                    # Start by checking whether we have the same number of parameters
+                    $actualValues.Count | Should -Be $ExpectedArgument.Count `
+                        -Because ('the expected arguments was: {0}' -f ($ExpectedArgument.Keys -join ','))
+
+                    Write-Verbose -Message 'Verified actual setup argument values against expected setup argument values' -Verbose
+
+                    foreach ($argumentKey in $ExpectedArgument.Keys)
+                    {
+                        $argumentKeyName = $actualValues.GetEnumerator() |
+                            Where-Object -FilterScript {
+                                $_.Name -eq $argumentKey
+                            } | Select-Object -ExpandProperty 'Name'
+
+                        $argumentKeyName | Should -Be $argumentKey
+
+                        $argumentValue = $actualValues.$argumentKey
+                        $argumentValue | Should -Be $ExpectedArgument.$argumentKey
+                    }
+                }
+
+                <#
+                    These are written with both lower-case and upper-case to make sure we support that.
+                    The feature list must be written in the order it is returned by the function Get-TargetResource.
+                #>
+                $mockDefaultFeatures = 'SQLEngine,Replication,Dq,Dqc,FullText,Rs,As,Is,Bol,Conn,Bc,Sdk,Mds,Ssms,Adv_Ssms'
+
+                # Default parameters that are used for the It-blocks
+                $mockDefaultParameters = @{
+                    Features = $mockDefaultFeatures
+                }
+
+                $mockNamedInstance_InstanceName = 'TEST'
+                $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
+                $mockSqlDatabaseEngineName = 'MSSQL'
+
+                $mockServiceStartupType = 'Automatic'
+
+                $mockDynamicSetupProcessExitCode = 0
+                $mockStartSqlSetupProcess_WithDynamicExitCode = {
+                    return $mockDynamicSetupProcessExitCode
+                }
+
+                $mockSourcePathUNCWithoutLeaf = '\\server\share'
+                $mockSourcePathGuid = 'cc719562-0f46-4a16-8605-9f8a47c70402'
+
+                $mockNewTemporaryFolder = {
+                    return $mockSourcePathUNC
+                }
+
+                $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
+                $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
+                $mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
+                $mockSqlTempDatabasePath = 'M:\MSSQL\TempDb\Data'
+                $mockSqlTempDatabaseLogPath = 'N:\MSSQL\TempDb\Logs'
+                $mockSqlBackupPath = 'O:\MSSQL\Backup'
+
+                $mockSetupCredentialUserName = "COMPANY\sqladmin"
+                $mockSetupCredentialPassword = "dummyPassw0rd" | ConvertTo-SecureString -asPlainText -Force
+                $mockSetupCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockSetupCredentialUserName, $mockSetupCredentialPassword)
+                $mockSqlServiceAccount = 'COMPANY\SqlAccount'
+                $mockSqlServicePassword = 'Sqls3v!c3P@ssw0rd'
+                $mockSQLServiceCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockSqlServiceAccount,($mockSQLServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+                $mockAgentServiceAccount = 'COMPANY\AgentAccount'
+                $mockAgentServicePassword = 'Ag3ntP@ssw0rd'
+                $mockSQLAgentCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockAgentServiceAccount,($mockAgentServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+                $mockAnalysisServiceAccount = 'COMPANY\AnalysisAccount'
+                $mockAnalysisServicePassword = 'Analysiss3v!c3P@ssw0rd'
+                $mockAnalysisServiceCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($mockAnalysisServiceAccount,($mockAnalysisServicePassword | ConvertTo-SecureString -AsPlainText -Force))
+
+                $mockClusterNodes = @($env:COMPUTERNAME,'SQL01','SQL02')
+
+                $mockDefaultInstance_FailoverClusterNetworkName = 'TestDefaultCluster'
+                $mockDefaultInstance_FailoverClusterIPAddress = '10.0.0.10'
+                $mockDefaultInstance_FailoverClusterGroupName = "SQL Server ($mockDefaultInstance_InstanceName)"
+                $mockDefaultInstance_FailoverClusterIPAddress_SecondSite = '10.0.10.100'
+                $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite = 'IPV4;10.0.0.10;SiteA_Prod;255.255.255.0'
+                $mockDefaultInstance_FailoverClusterIPAddressParameter_MultiSite = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0; IPv4;10.0.10.100;SiteB_Prod;255.255.255.0'
 
                 # Mock PsDscRunAsCredential context.
                 $PsDscContext = @{
                     RunAsUser = $mockSetupCredential.UserName
                 }
+
+                $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner = {
+                    return @(
+                        (
+                            $mockClusterNodes | ForEach-Object {
+                                $node = $_
+                                New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Node', 'root/MSCluster' |
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $node -PassThru -Force
+                            }
+                        )
+                    )
+                }
+
+                $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage = {
+                    return @(
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ResourceGroup', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value 'Available Storage' -PassThru -Force
+                        )
+                    )
+                }
+
+                $mockGetCIMInstance_MSCluster_ClusterSharedVolume = {
+                    return @(
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['SysData'].Path -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserData'].Path -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['UserLogs'].Path -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBData'].Path -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['TempDBLogs'].Path -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockCSVClusterDiskMap['Backup'].Path -PassThru -Force
+                        )
+                    )
+                }
+
+                $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource = {
+                    return @(
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Path}) -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['SysData'].Name}) -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Path}) -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserData'].Name}) -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Path}) -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['UserLogs'].Name}) -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Path}) -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBData'].Name}) -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Path}) -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['TempDBLogs'].Name}) -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_ClusterSharedVolume', 'root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name GroupComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Path}) -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name PartComponent -Value (New-Object -TypeName PSObject -Property @{Name=$mockCSVClusterDiskMap['Backup'].Name}) -PassThru -Force
+                        )
+                    )
+                }
+
+                $mockGetCimInstance_MSClusterNetwork = {
+                    return @(
+                        (
+                            $mockClusterSites | ForEach-Object {
+                                $network = $_
+
+                                New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Network', 'root/MSCluster' |
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value "$($network.Name)_Prod" -PassThru -Force |
+                                    Add-Member -MemberType NoteProperty -Name 'Role' -Value 2 -PassThru -Force |
+                                    Add-Member -MemberType NoteProperty -Name 'Address' -Value $network.Address -PassThru -Force |
+                                    Add-Member -MemberType NoteProperty -Name 'AddressMask' -Value $network.Mask -PassThru -Force
+                            }
+                        )
+                    )
+                }
+
+                # Mock to return physical disks that are part of the "Available Storage" cluster role
+                $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource = {
+                    return @(
+                        (
+                            # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
+                            (& $mockClusterDiskMap).Keys | ForEach-Object {
+                                $diskName = $_
+                                New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_Resource','root/MSCluster' |
+                                    Add-Member -MemberType NoteProperty -Name 'Name' -Value $diskName -PassThru -Force |
+                                    Add-Member -MemberType NoteProperty -Name 'State' -Value 2 -PassThru -Force |
+                                    Add-Member -MemberType NoteProperty -Name 'Type' -Value 'Physical Disk' -PassThru -Force
+                            }
+                        )
+                    )
+                }
+
+                $mockGetCimAssociatedInstance_MSCluster_DiskPartition = {
+                    $clusterDiskName = $InputObject.Name
+
+                    # $mockClusterDiskMap contains variables that are assigned dynamically (during runtime) before each test.
+                    $clusterDiskPath = (& $mockClusterDiskMap).$clusterDiskName
+
+                    return @(
+                        (
+                            New-Object -TypeName Microsoft.Management.Infrastructure.CimInstance 'MSCluster_DiskPartition','root/MSCluster' |
+                                Add-Member -MemberType NoteProperty -Name 'Path' -Value $clusterDiskPath -PassThru -Force
+                        )
+                    )
+                }
+
+                $mockClusterDiskMap = {
+                    @{
+                        SysData = Split-Path -Path $mockDynamicSqlDataDirectoryPath -Qualifier
+                        UserData = Split-Path -Path $mockDynamicSqlUserDatabasePath -Qualifier
+                        UserLogs = Split-Path -Path $mockDynamicSqlUserDatabaseLogPath -Qualifier
+                        TempDbData = Split-Path -Path $mockDynamicSqlTempDatabasePath -Qualifier
+                        TempDbLogs = Split-Path -Path $mockDynamicSqlTempDatabaseLogPath -Qualifier
+                        Backup = Split-Path -Path $mockDynamicSqlBackupPath -Qualifier
+                    }
+                }
+
+                $mockCSVClusterDiskMap = @{
+                    SysData = @{Path='C:\ClusterStorage\SysData';Name="Cluster Virtual Disk (SQL System Data Disk)"}
+                    UserData = @{Path='C:\ClusterStorage\SQLData';Name="Cluster Virtual Disk (SQL Data Disk)"}
+                    UserLogs = @{Path='C:\ClusterStorage\SQLLogs';Name="Cluster Virtual Disk (SQL Log Disk)"}
+                    TempDbData = @{Path='C:\ClusterStorage\TempDBData';Name="Cluster Virtual Disk (SQL TempDBData Disk)"}
+                    TempDbLogs = @{Path='C:\ClusterStorage\TempDBLogs';Name="Cluster Virtual Disk (SQL TempDBLog Disk)"}
+                    Backup = @{Path='C:\ClusterStorage\SQLBackup';Name="Cluster Virtual Disk (SQL Backup Disk)"}
+                }
+
+                $mockClusterSites = @(
+                    @{
+                        Name = 'SiteA'
+                        Address = $mockDefaultInstance_FailoverClusterIPAddress
+                        Mask = '255.255.255.0'
+                    },
+                    @{
+                        Name = 'SiteB'
+                        Address = $mockDefaultInstance_FailoverClusterIPAddress_SecondSite
+                        Mask = '255.255.255.0'
+                    }
+                )
+
+                <#
+                    Needed a way to see into the Set-method for the arguments the Set-method
+                    is building and sending to 'setup.exe', and fail the test if the arguments
+                    is different from the expected arguments. Solved this by dynamically set
+                    the expected arguments before each It-block. If the arguments differs the
+                    mock of Start-SqlSetupProcess throws an error message, similar to what
+                    Pester would have reported (expected -> but was).
+                #>
+                $mockStartSqlSetupProcessExpectedArgument = @{}
+
+                $mockStartSqlSetupProcessExpectedArgumentClusterDefault = @{
+                    IAcceptSQLServerLicenseTerms = 'True'
+                    Quiet = 'True'
+                    InstanceName = 'MSSQLSERVER'
+                    Features = 'SQLENGINE'
+                    SQLSysAdminAccounts = 'COMPANY\sqladmin COMPANY\SQLAdmins COMPANY\User1'
+                    FailoverClusterGroup = 'SQL Server (MSSQLSERVER)'
+                }
+
+                $mockStartSqlSetupProcess = {
+                    Test-SetupArgument -Argument $ArgumentList -ExpectedArgument $mockStartSqlSetupProcessExpectedArgument
+
+                    return 0
+                }
+
+                $mockDefaultClusterParameters = @{
+                    SQLSysAdminAccounts = 'COMPANY\User1','COMPANY\SQLAdmins'
+
+                    # Feature support is tested elsewhere, so just include the minimum.
+                    Features = 'SQLEngine'
+                }
+
+                $mockGetSqlMajorVersion = {
+                    return $mockSqlMajorVersion
+                }
+
+                # General mocks
+                Mock -CommandName Get-PSDrive
+                Mock -CommandName Import-SQLPSModule
+                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion
+
+                # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
+                Mock -CommandName Get-ItemProperty
+
+                Mock -CommandName Start-SqlSetupProcess -MockWith $mockStartSqlSetupProcess
+                Mock -CommandName Test-TargetResource -MockWith {
+                    return $true
+                }
+
+                Mock -CommandName Test-PendingRestart -MockWith {
+                    return $false
+                }
+
+                $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
+
+                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
+                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
+                $mockDynamicSqlTempDatabasePath = ''
+                $mockDynamicSqlTempDatabaseLogPath = ''
+                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
+
+                # This sets administrators dynamically in the mock Connect-SQLAnalysis.
+                $mockDynamicSqlAnalysisAdmins = $mockSqlAnalysisAdmins
             }
 
             BeforeEach {
@@ -2804,27 +2153,17 @@ try
 
             foreach ($mockSqlMajorVersion in $testProductVersion)
             {
-                $mockDefaultInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockDefaultInstance_InstanceName)"
-
-                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL"
-                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\Backup"
-                $mockDynamicSqlTempDatabasePath = ''
-                $mockDynamicSqlTempDatabaseLogPath = ''
-                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockDefaultInstance_InstanceId)\MSSQL\DATA\"
-
-                # This sets administrators dynamically in the mock Connect-SQLAnalysis.
-                $mockDynamicSqlAnalysisAdmins = $mockSqlAnalysisAdmins
-
                 Context "When setup process fails with exit code " {
-                    BeforeEach {
-                        Mock -CommandName Start-SqlSetupProcess -MockWith $mockStartSqlSetupProcess_WithDynamicExitCode -Verifiable
+                    BeforeAll {
+                        Mock -CommandName Start-SqlSetupProcess -MockWith $mockStartSqlSetupProcess_WithDynamicExitCode
                         Mock -CommandName Get-TargetResource -MockWith {
                             return @{
                                 Features = ''
                             }
-                        } -Verifiable
+                        }
+                    }
 
+                    BeforeEach {
                         $testParameters += @{
                             InstanceName = $mockDefaultInstance_InstanceName
                             SourceCredential = $null
@@ -2860,12 +2199,12 @@ try
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
-                    BeforeEach {
+                    BeforeAll {
                         Mock -CommandName Get-TargetResource -MockWith {
                             return @{
                                 Features = ''
                             }
-                        } -Verifiable
+                        }
 
                         Mock -CommandName Invoke-InstallationMediaCopy -MockWith $mockNewTemporaryFolder
                     }
@@ -2888,11 +2227,11 @@ try
                             UpdateSource = 'C:\Updates\' # Regression test for issue #720
                             ASServerMode = 'TABULAR'
                             RSInstallMode = 'DefaultNativeMode'
-                            SqlSvcStartupType = $mockSqlSvcStartupType
-                            AgtSvcStartupType = $mockAgtSvcStartupType
-                            AsSvcStartupType = $mockAsSvcStartupType
-                            IsSvcStartupType = $mockIsSvcStartupType
-                            RsSvcStartupType = $mockRsSvcStartupType
+                            SqlSvcStartupType = $mockServiceStartupType
+                            AgtSvcStartupType = $mockServiceStartupType
+                            AsSvcStartupType = $mockServiceStartupType
+                            IsSvcStartupType = $mockServiceStartupType
+                            RsSvcStartupType = $mockServiceStartupType
                             SqlTempDbFileCount = 2
                             SqlTempDbFileSize = 128
                             SqlTempDbFileGrowth = 128
@@ -2922,11 +2261,11 @@ try
                             UpdateSource = 'C:\Updates' # Regression test for issue #720
                             ASServerMode = 'TABULAR'
                             RSInstallMode = 'DefaultNativeMode'
-                            SqlSvcStartupType = $mockSqlSvcStartupType
-                            AgtSvcStartupType = $mockAgtSvcStartupType
-                            AsSvcStartupType = $mockAsSvcStartupType
-                            IsSvcStartupType = $mockIsSvcStartupType
-                            RsSvcStartupType = $mockRsSvcStartupType
+                            SqlSvcStartupType = $mockServiceStartupType
+                            AgtSvcStartupType = $mockServiceStartupType
+                            AsSvcStartupType = $mockServiceStartupType
+                            IsSvcStartupType = $mockServiceStartupType
+                            RsSvcStartupType = $mockServiceStartupType
                             SqlTempDbFileCount = 2
                             SqlTempDbFileSize = 128
                             SqlTempDbFileGrowth = 128
@@ -3024,6 +2363,16 @@ try
                 }
 
                 Context "When using SourceCredential parameter, and using a UNC path with a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = ''
+                            }
+                        }
+
+                        Mock -CommandName Invoke-InstallationMediaCopy -MockWith $mockNewTemporaryFolder
+                    }
+
                     BeforeEach {
                         $testParameters += @{
                             InstanceName = $mockDefaultInstance_InstanceName
@@ -3035,14 +2384,6 @@ try
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
-
-                        Mock -CommandName Get-TargetResource -MockWith {
-                            return @{
-                                Features = ''
-                            }
-                        } -Verifiable
-
-                        Mock -CommandName Invoke-InstallationMediaCopy -MockWith $mockNewTemporaryFolder -Verifiable
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
@@ -3065,7 +2406,7 @@ try
                         Assert-MockCalled -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
                     }
 
-                    if( $mockSqlMajorVersion -in (13,14) )
+                    if ($mockSqlMajorVersion -in (13,14))
                     {
                         It 'Should throw when feature parameter contains ''SSMS'' when installing SQL Server 2016 and 2017' {
                             $testParameters.Features = 'SSMS'
@@ -3122,6 +2463,16 @@ try
                 }
 
                 Context "When using SourceCredential parameter, and using a UNC path without a leaf, and SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a default instance" {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = ''
+                            }
+                        }
+
+                        Mock -CommandName Invoke-InstallationMediaCopy -MockWith $mockNewTemporaryFolder
+                    }
+
                     BeforeEach {
                         $testParameters += @{
                             InstanceName = $mockDefaultInstance_InstanceName
@@ -3135,14 +2486,6 @@ try
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
-
-                        Mock -CommandName Get-TargetResource -MockWith {
-                            return @{
-                                Features = ''
-                            }
-                        } -Verifiable
-
-                        Mock -CommandName Invoke-InstallationMediaCopy -MockWith $mockNewTemporaryFolder -Verifiable
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
@@ -3222,16 +2565,24 @@ try
                     }
                 }
 
-                $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
-
-                $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
-                $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
-                $mockDynamicSqlTempDatabasePath = ''
-                $mockDynamicSqlTempDatabaseLogPath = ''
-                $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-                $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
-
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state for a named instance" {
+                    BeforeAll {
+                        $mockNamedInstance_InstanceId = "$($mockSqlDatabaseEngineName)$($mockSqlMajorVersion).$($mockNamedInstance_InstanceName)"
+
+                        $mockSqlInstallPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL"
+                        $mockDynamicSqlBackupPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\Backup"
+                        $mockDynamicSqlTempDatabasePath = ''
+                        $mockDynamicSqlTempDatabaseLogPath = ''
+                        $mockSqlDefaultDatabaseFilePath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+                        $mockSqlDefaultDatabaseLogPath = "C:\Program Files\Microsoft SQL Server\$($mockNamedInstance_InstanceId)\MSSQL\DATA\"
+
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = ''
+                            }
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters += @{
                             InstanceName = $mockNamedInstance_InstanceName
@@ -3244,12 +2595,6 @@ try
                         {
                             $testParameters.Features = $testParameters.Features -replace ',SSMS,ADV_SSMS',''
                         }
-
-                        Mock -CommandName Get-TargetResource -MockWith {
-                            return @{
-                                Features = ''
-                            }
-                        } -Verifiable
                     }
 
                     It 'Should set the system in the desired state when feature is SQLENGINE' {
@@ -3329,6 +2674,14 @@ try
 
                 # For testing AddNode action
                 Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is AddNode" {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = ''
+                            }
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters = $mockDefaultClusterParameters.Clone()
                         $testParameters['Features'] += 'AS'
@@ -3341,12 +2694,6 @@ try
                             ASSvcAccount = $mockAnalysisServiceCredential
                             FailoverClusterNetworkName = $mockDefaultInstance_FailoverClusterNetworkName
                         }
-
-                        Mock -CommandName Get-TargetResource -MockWith {
-                            return @{
-                                Features = ''
-                            }
-                        } -Verifiable
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -3370,6 +2717,42 @@ try
 
                 # For testing InstallFailoverCluster action
                 Context "When SQL Server version is $mockSQLMajorVersion and the system is not in the desired state and the action is InstallFailoverCluster" {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = ''
+                            }
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+                            $Filter -eq "Name = 'Available Storage'"
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+                            $ResultClassName -eq 'MSCluster_DiskPartition'
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        }
+                    }
+
                     BeforeEach {
                         $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
                         $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
@@ -3395,40 +2778,6 @@ try
                             SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
                             SQLBackupDir = $mockDynamicSqlBackupPath
                         }
-
-                        Mock -CommandName Get-TargetResource -MockWith {
-                            return @{
-                                Features = ''
-                            }
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-                            $Filter -eq "Name = 'Available Storage'"
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-                            $ResultClassName -eq 'MSCluster_DiskPartition'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Verifiable
                     }
 
                     It 'Should pass proper parameters to setup' {
@@ -3569,7 +2918,6 @@ try
                     }
 
                     It 'Should build a valid IP address string for a single address' {
-
                         $mockStartSqlSetupProcessExpectedArgument = $mockStartSqlSetupProcessExpectedArgumentClusterDefault.Clone()
                         $mockStartSqlSetupProcessExpectedArgument += @{
                             FailoverClusterIPAddresses = $mockDefaultInstance_FailoverClusterIPAddressParameter_SingleSite
@@ -3681,6 +3029,36 @@ try
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is PrepareFailoverCluster" {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = ''
+                            }
+                        }
+
+                        Mock -CommandName Invoke-InstallationMediaCopy -MockWith $mockNewTemporaryFolder
+
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                            $ResultClass -eq 'MSCluster_DiskPartition'
+                        }
+
+                        Mock -CommandName Get-CimInstance -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        }
+                    }
+
                     BeforeEach {
                         $testParameters.Remove('Features')
                         $testParameters.Remove('SourceCredential')
@@ -3692,40 +3070,6 @@ try
                             SourcePath = $mockSourcePath
                             Action = 'PrepareFailoverCluster'
                         }
-
-                        Mock -CommandName Get-TargetResource -MockWith {
-                            return @{
-                                Features = ''
-                            }
-                        } -Verifiable
-
-                        Mock -CommandName Invoke-InstallationMediaCopy -MockWith $mockNewTemporaryFolder -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_ResourceGroup') -and ($Filter -eq "Name = 'Available Storage'")
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
-                            $ResultClass -eq 'MSCluster_DiskPartition'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Verifiable
-                    }
-
-                    BeforeEach {
-                        Mock -CommandName Get-ItemProperty -ParameterFilter {
-                            $Path -eq "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($mockSqlMajorVersion)0\Tools\Setup\Client_Components_Full"
-                        } -Verifiable
                     }
 
                     It 'Should pass correct arguments to the setup process' {
@@ -3766,6 +3110,42 @@ try
                 }
 
                 Context "When SQL Server version is $mockSqlMajorVersion and the system is not in the desired state and the action is CompleteFailoverCluster." {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Features = ''
+                            }
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
+                            $Filter -eq "Name = 'Available Storage'"
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
+                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
+                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
+                        }
+
+                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
+                            $ResultClassName -eq 'MSCluster_DiskPartition'
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
+                        }
+
+                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
+                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
+                        }
+                    }
+
                     BeforeEach {
                         $mockDynamicSqlDataDirectoryPath = $mockSqlDataDirectoryPath
                         $mockDynamicSqlUserDatabasePath = $mockSqlUserDatabasePath
@@ -3791,40 +3171,6 @@ try
                             SQLTempDbLogDir = $mockDynamicSqlTempDatabaseLogPath
                             SQLBackupDir = $mockDynamicSqlBackupPath
                         }
-
-                        Mock -CommandName Get-TargetResource -MockWith {
-                            return @{
-                                Features = ''
-                            }
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResourceGroup_AvailableStorage -ParameterFilter {
-                            $Filter -eq "Name = 'Available Storage'"
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceGroupToResource -ParameterFilter {
-                            ($Association -eq 'MSCluster_ResourceGroupToResource') -and ($ResultClassName -eq 'MSCluster_Resource')
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_ResourceToPossibleOwner -ParameterFilter {
-                            $Association -eq 'MSCluster_ResourceToPossibleOwner'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimAssociatedInstance -MockWith $mockGetCimAssociatedInstance_MSCluster_DiskPartition -ParameterFilter {
-                            $ResultClassName -eq 'MSCluster_DiskPartition'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
-                            ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolume -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolume'
-                        } -Verifiable
-
-                        Mock -CommandName Get-CimInstance -MockWith $mockGetCIMInstance_MSCluster_ClusterSharedVolumeToResource -ParameterFilter {
-                            $ClassName -eq 'MSCluster_ClusterSharedVolumeToResource'
-                        } -Verifiable
                     }
 
                     It 'Should throw an error when one or more paths are not resolved to clustered storage' {
@@ -3969,8 +3315,6 @@ try
                     }
                 }
             }
-
-            Assert-VerifiableMock
         }
 
         Describe 'Get-ServiceAccountParameters' -Tag 'Helper' {
@@ -4055,11 +3399,11 @@ try
                                     Add-Member -MemberType NoteProperty -Name 'UnknownKey' -Value 1 -PassThru -Force
                             )
                         )
-                    } -Verifiable
+                    }
                 }
 
                 It 'Should return an empty array' {
-                    $getInstalledSharedFeaturesResult = Get-InstalledSharedFeatures -SqlVersion $mockSqlMajorVersion
+                    $getInstalledSharedFeaturesResult = Get-InstalledSharedFeatures -SqlServerMajorVersion $mockSqlMajorVersion
 
                     $getInstalledSharedFeaturesResult | Should -HaveCount 0
                 }
@@ -4083,11 +3427,11 @@ try
                                     Add-Member -MemberType NoteProperty -Name 'MDSCoreFeature' -Value 1 -PassThru -Force
                             )
                         )
-                    } -Verifiable
+                    }
                 }
 
                 It 'Should return the correct array with installed shared features' {
-                    $getInstalledSharedFeaturesResult = Get-InstalledSharedFeatures -SqlVersion $mockSqlMajorVersion
+                    $getInstalledSharedFeaturesResult = Get-InstalledSharedFeatures -SqlServerMajorVersion $mockSqlMajorVersion
 
                     $getInstalledSharedFeaturesResult | Should -HaveCount 6
                     $getInstalledSharedFeaturesResult | Should -Contain 'DQC'
@@ -4103,20 +3447,1124 @@ try
         Describe 'Test-FeatureFlag' -Tag 'Helper' {
             Context 'When no feature flags was provided' {
                 It 'Should return $false' {
-                    Test-FeatureFlag -FeatureFlag $null -TestFlag 'MyFlag' | Should -Be $false
+                    Test-FeatureFlag -FeatureFlag $null -TestFlag 'MyFlag' | Should -BeFalse
                 }
             }
 
             Context 'When feature flags was provided' {
                 It 'Should return $true' {
-                    Test-FeatureFlag -FeatureFlag @('FirstFlag','SecondFlag') -TestFlag 'SecondFlag' | Should -Be $true
+                    Test-FeatureFlag -FeatureFlag @('FirstFlag','SecondFlag') -TestFlag 'SecondFlag' | Should -BeTrue
                 }
             }
 
             Context 'When feature flags was provided, but missing' {
                 It 'Should return $false' {
-                    Test-FeatureFlag -FeatureFlag @('MyFlag2') -TestFlag 'MyFlag' | Should -Be $false
+                    Test-FeatureFlag -FeatureFlag @('MyFlag2') -TestFlag 'MyFlag' | Should -BeFalse
                 }
+            }
+        }
+
+        Describe 'Get-FullInstanceId' -Tag 'Helper' {
+            BeforeAll {
+                $mockNamedInstance_InstanceName = 'TEST'
+                $mockDefaultInstance_InstanceName = 'MSSQLSERVER'
+
+                $mockGetItemProperty_SQL = {
+                    return @(
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name $mockDefaultInstance_InstanceName -Value $mockDefaultInstance_InstanceId -PassThru -Force
+                        ),
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name $mockNamedInstance_InstanceName -Value $mockNamedInstance_InstanceId -PassThru -Force
+                        )
+                    )
+                }
+            }
+
+            Context 'When getting the full instance ID from the default instance' {
+                BeforeAll {
+                    $mockInstanceName = 'MSSQLSERVER'
+                    $mockDefaultInstance_InstanceId = 'MSSQL14.{0}' -f $mockInstanceName
+
+                    Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                        return $mockDefaultInstance_InstanceId
+                    }
+                }
+
+                It 'Should return the correct full instance id' {
+                    $result = Get-FullInstanceId -InstanceName $mockInstanceName
+                    $result | Should -Be $mockDefaultInstance_InstanceId
+
+                    Assert-MockCalled -CommandName Get-RegistryPropertyValue -ParameterFilter {
+                        $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' `
+                        -and $Name -eq $mockInstanceName
+                    } -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When getting the full instance ID for a named instance' {
+                BeforeAll {
+                    $mockInstanceName = 'NAMED'
+                    $mockDefaultInstance_InstanceId = 'MSSQL14.{0}' -f $mockInstanceName
+
+                    Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                        return $mockDefaultInstance_InstanceId
+                    }
+                }
+
+                It 'Should return the correct full instance id' {
+                    $result = Get-FullInstanceId -InstanceName $mockInstanceName
+                    $result | Should -Be $mockDefaultInstance_InstanceId
+
+                    Assert-MockCalled -CommandName Get-RegistryPropertyValue -ParameterFilter {
+                        $Path -eq 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' `
+                        -and $Name -eq $mockInstanceName
+                    } -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+
+        Describe 'Get-SqlEngineProperties' -Tag 'Helper' {
+            Context 'When getting properties for a default instance' {
+                BeforeAll {
+                    $mockInstanceName = 'MSSQLSERVER'
+                    $mockDatabaseServiceName = 'MSSQLSERVER'
+                    $mockAgentServiceName = 'SQLSERVERAGENT'
+                    $mockSqlServiceAccount = 'COMPANY\SqlAccount'
+                    $mockAgentServiceAccount = 'COMPANY\AgentAccount'
+                    $mockStartMode = 'Automatic'
+                    $mockStartMode = 'Automatic'
+                    $mockCollation = 'Finnish_Swedish_CI_AS'
+                    $mockSqlDataDirectoryPath = 'E:\MSSQL\Data'
+                    $mockSqlUserDatabasePath = 'K:\MSSQL\Data'
+                    $mockSqlUserDatabaseLogPath = 'L:\MSSQL\Logs'
+                    $mockSqlBackupPath = 'O:\MSSQL\Backup'
+
+                    Mock -CommandName Get-ServiceProperties -ParameterFilter {
+                        $ServiceName -eq $mockDatabaseServiceName
+                    } -MockWith {
+                        return @{
+                            UserName = $mockSqlServiceAccount
+                            StartupType = $mockStartMode
+                        }
+                    }
+
+                    Mock -CommandName Get-ServiceProperties -ParameterFilter {
+                        $ServiceName -eq $mockAgentServiceName
+                    } -MockWith {
+                        return @{
+                            UserName = $mockAgentServiceAccount
+                            StartupType = $mockStartMode
+                        }
+                    }
+
+                    $mockConnectSQL = {
+                        return New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Collation' -Value $mockCollation -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'IsClustered' -Value $true -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'InstallDataDirectory' -Value $mockSqlDataDirectoryPath -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'DefaultFile' -Value $mockSqlUserDatabasePath -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'DefaultLog' -Value $mockSqlUserDatabaseLogPath -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'BackupDirectory' -Value $mockSqlBackupPath -PassThru |
+                            # This value is set dynamically in BeforeEach-blocks.
+                            Add-Member -MemberType 'NoteProperty' -Name 'LoginMode' -Value $mockDynamicSqlLoginMode -PassThru -Force
+                    }
+
+                    Mock -CommandName Connect-SQL -MockWith $mockConnectSQL
+                }
+
+                It 'Should return the correct property values' {
+                    $getFeatureSqlEnginePropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = $mockInstanceName
+                    }
+
+                    $result = Get-SqlEngineProperties @getFeatureSqlEnginePropertiesParameters
+
+                    $result.SQLSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                    $result.AgtSvcAccountUsername | Should -Be $mockAgentServiceAccount
+                    $result.SqlSvcStartupType | Should -Be 'Automatic'
+                    $result.AgtSvcStartupType | Should -Be 'Automatic'
+                    $result.SQLCollation | Should -Be $mockCollation
+                    $result.IsClustered | Should -BeTrue
+                    $result.InstallSQLDataDir | Should -Be $mockSqlDataDirectoryPath
+                    $result.SQLUserDBDir | Should -Be $mockSqlUserDatabasePath
+                    $result.SQLUserDBLogDir | Should -Be $mockSqlUserDatabaseLogPath
+                    $result.SQLBackupDir | Should -Be $mockSqlBackupPath
+                    $result.SecurityMode | Should -Be 'Windows'
+                }
+
+                Context 'When the Login mode is set to Integrated mode' {
+                    BeforeEach {
+                        $mockDynamicSqlLoginMode = 'Integrated'
+                    }
+
+                    It 'Should return the correct property value' {
+                        $getFeatureSqlEnginePropertiesParameters = @{
+                            ServerName = 'localhost'
+                            InstanceName = $mockInstanceName
+                        }
+
+                        $result = Get-SqlEngineProperties @getFeatureSqlEnginePropertiesParameters
+
+                        $result.SecurityMode | Should -BeExactly 'Windows'
+                    }
+                }
+
+                Context 'When the Login mode is set to Mixed mode' {
+                    BeforeEach {
+                        $mockDynamicSqlLoginMode = 'Mixed'
+                    }
+
+                    It 'Should return the correct property value' {
+                        $getFeatureSqlEnginePropertiesParameters = @{
+                            ServerName = 'localhost'
+                            InstanceName = $mockInstanceName
+                        }
+
+                        $result = Get-SqlEngineProperties @getFeatureSqlEnginePropertiesParameters
+
+                        $result.SecurityMode | Should -BeExactly 'SQL'
+                    }
+                }
+            }
+
+            Context 'When getting properties for a named instance' {
+                BeforeAll {
+                    $mockInstanceName = 'TEST'
+                    $mockDatabaseServiceName = 'MSSQL${0}' -f $mockInstanceName
+                    $mockAgentServiceName = 'SQLAgent${0}' -f $mockInstanceName
+                    $mockSqlServiceAccount = 'COMPANY\SqlAccount'
+                    $mockAgentServiceAccount = 'COMPANY\AgentAccount'
+                    $mockStartMode = 'Automatic'
+                    $mockStartMode = 'Automatic'
+
+                    Mock -CommandName Get-ServiceProperties -ParameterFilter {
+                        $ServiceName -eq $mockDatabaseServiceName
+                    } -MockWith {
+                        return @{
+                            UserName = $mockSqlServiceAccount
+                            StartupType = $mockStartMode
+                        }
+                    }
+
+                    Mock -CommandName Get-ServiceProperties -ParameterFilter {
+                        $ServiceName -eq $mockAgentServiceName
+                    } -MockWith {
+                        return @{
+                            UserName = $mockAgentServiceAccount
+                            StartupType = $mockStartMode
+                        }
+                    }
+
+                    <#
+                        Just mock without testing any actual values. We already did that
+                        in the previous test.
+                    #>
+                    Mock -CommandName Connect-SQL
+                }
+
+                It 'Should return the correct property values' {
+                    $getFeatureSqlEnginePropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = $mockInstanceName
+                    }
+
+                    $result = Get-SqlEngineProperties @getFeatureSqlEnginePropertiesParameters
+
+                    $result.SQLSvcAccountUsername | Should -Be $mockSqlServiceAccount
+                    $result.AgtSvcAccountUsername | Should -Be $mockAgentServiceAccount
+                    $result.SqlSvcStartupType | Should -Be 'Automatic'
+                    $result.AgtSvcStartupType | Should -Be 'Automatic'
+                }
+            }
+        }
+
+        Describe 'Test-IsReplicationFeatureInstalled' -Tag 'Helper' {
+            Context 'When replication feature is installed' {
+                BeforeAll {
+                    Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                        return 1
+                    }
+                }
+
+                It 'Should return $true' {
+                    Test-IsReplicationFeatureInstalled -InstanceName 'MSSQLSERVER' |
+                        Should -BeTrue
+                }
+            }
+
+            Context 'When replication feature is installed' {
+                BeforeAll {
+                    Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                        return $null
+                    }
+                }
+
+                It 'Should return $false' {
+                    Test-IsReplicationFeatureInstalled -InstanceName 'MSSQLSERVER' |
+                        Should -BeFalse
+                }
+            }
+        }
+
+        Describe 'Test-IsDQComponentInstalled' -Tag 'Helper' {
+            Context 'When Data Quality Services (DQ) feature is installed' {
+                BeforeAll {
+                    $mockGetItemProperty = {
+                        return @(
+                            (
+                                New-Object -TypeName Object |
+                                    Add-Member -MemberType NoteProperty -Name 'DQ_Components' -Value 1 -PassThru -Force
+                            )
+                        )
+                    }
+
+                    Mock -CommandName Get-ItemProperty -MockWith $mockGetItemProperty
+                }
+
+                It 'Should return $true' {
+                    Test-IsDQComponentInstalled -InstanceName 'MSSQLSERVER' -SqlServerMajorVersion '14' |
+                        Should -BeTrue
+                }
+            }
+
+            Context 'When replication feature is installed' {
+                BeforeAll {
+                    Mock -CommandName Get-ItemProperty
+                }
+
+                It 'Should return $false' {
+                    Test-IsDQComponentInstalled -InstanceName 'MSSQLSERVER' -SqlServerMajorVersion '14' |
+                        Should -BeFalse
+                }
+            }
+        }
+
+        Describe 'Get-InstanceProgramPath' -Tag 'Helper' {
+            BeforeAll {
+                # Ending the path on purpose to make sure the function removes it.
+                $mockSqlProgramDirectory = 'C:\Program Files\Microsoft SQL Server\'
+
+                Mock -CommandName Get-RegistryPropertyValue -MockWith {
+                    return $mockSqlProgramDirectory
+                }
+            }
+
+            It 'Should return the correct program path' {
+                Get-InstanceProgramPath -InstanceName 'MSSQLSERVER' | Should -Be $mockSqlProgramDirectory.Trim('\')
+            }
+        }
+
+        Describe 'Get-ServiceNamesForInstance' -Tag 'Helper' {
+            Context 'When the instance is the default instance' {
+                It 'Should return the correct service names' {
+                    $result = Get-ServiceNamesForInstance -InstanceName 'MSSQLSERVER' -SqlServerMajorVersion 14
+
+                    $result.DatabaseService | Should -Be 'MSSQLSERVER'
+                    $result.AgentService | Should -Be 'SQLSERVERAGENT'
+                    $result.FullTextService | Should -Be 'MSSQLFDLauncher'
+                    $result.ReportService | Should -Be 'ReportServer'
+                    $result.AnalysisService | Should -Be 'MSSQLServerOLAPService'
+                    $result.IntegrationService | Should -Be 'MsDtsServer140'
+                }
+            }
+
+            Context 'When the instance is a named instance' {
+                BeforeAll {
+                    $mockInstanceName = 'TEST'
+                }
+
+                It 'Should return the correct service names' {
+                    $result = Get-ServiceNamesForInstance -InstanceName $mockInstanceName
+
+                    $result.DatabaseService | Should -Be ('MSSQL${0}' -f $mockInstanceName)
+                    $result.AgentService | Should -Be ('SQLAgent${0}' -f $mockInstanceName)
+                    $result.FullTextService | Should -Be ('MSSQLFDLauncher${0}' -f $mockInstanceName)
+                    $result.ReportService | Should -Be ('ReportServer${0}' -f $mockInstanceName)
+                    $result.AnalysisService | Should -Be ('MSOLAP${0}' -f $mockInstanceName)
+                }
+            }
+
+            Context 'When the SqlServerMajorVersion is not passed' {
+                It 'Should return $null as the Integration Service service name' {
+                    $result = Get-ServiceNamesForInstance -InstanceName 'MSSQLSERVER'
+
+                    $result.IntegrationService | Should -BeNullOrEmpty
+                }
+            }
+        }
+
+        Describe 'Get-TempDbProperties' -Tag 'Helper' {
+            BeforeAll {
+                $mockPrimaryFilePath = 'H:\MSSQL\Temp'
+
+                $mockConnectSQL = {
+                    return New-Object -TypeName 'Object' |
+                        Add-Member -MemberType 'ScriptProperty' -Name 'Databases' -Value {
+                            return @{
+                                tempdb = (
+                                        New-Object -TypeName 'Object' |
+                                            Add-Member -MemberType 'NoteProperty' -Name 'PrimaryFilePath' -Value $mockPrimaryFilePath -PassThru |
+                                            Add-Member -MemberType 'ScriptProperty' -Name 'FileGroups' -Value {
+                                                return @{
+                                                    PRIMARY = (
+                                                        New-Object -TypeName 'Object' |
+                                                            Add-Member -MemberType 'ScriptProperty' -Name 'Files' -Value {
+                                                                <#
+                                                                    This will return the array that is set in each
+                                                                    BeforeEach-block prior to the It-block is run.
+                                                                #>
+                                                                return [PSCustomObject] $mockDynamicDataFiles
+                                                            } -PassThru -Force
+                                                    )
+                                                }
+                                            } -PassThru |
+                                            Add-Member -MemberType 'ScriptProperty' -Name 'LogFiles' -Value {
+                                                <#
+                                                    This will return the array that is set in each
+                                                    BeforeEach-block prior to the It-block is run.
+                                                #>
+                                                return [PSCustomObject] $mockDynamicLogFiles
+                                            } -PassThru -Force
+                                )
+                            }
+                        } -PassThru -Force
+                }
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL
+            }
+
+            Context 'When there the PRIMARY filegroup contain one data file and one log file of growth type Percent' {
+                BeforeEach {
+                    $mockDynamicDataFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+
+                    $mockDynamicLogFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+                }
+
+                It 'Should return the correct property values' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                    }
+
+                    $result = Get-TempDbProperties @getTempDbPropertiesParameters
+
+                    $result.SQLTempDBDir | Should -Be $mockPrimaryFilePath
+                    $result.SqlTempdbFileCount | Should -Be 1
+                    $result.SqlTempdbFileSize | Should -Be 8
+                    $result.SqlTempdbFileGrowth | Should -Be 10
+                    $result.SqlTempdbLogFileSize | Should -Be 8
+                    $result.SqlTempdbLogFileGrowth | Should -Be 10
+                }
+            }
+
+            Context 'When there the PRIMARY filegroup contain one data file and one log file of growth type KB' {
+                BeforeEach {
+                    $mockDynamicDataFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 102400 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+
+                    $mockDynamicLogFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 102400 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+                    )
+                }
+
+                It 'Should return the correct property values' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                    }
+
+                    $result = Get-TempDbProperties @getTempDbPropertiesParameters
+
+                    $result.SQLTempDBDir | Should -Be $mockPrimaryFilePath
+                    $result.SqlTempdbFileCount | Should -Be 1
+                    $result.SqlTempdbFileSize | Should -Be 8
+                    $result.SqlTempdbFileGrowth | Should -Be 100
+                    $result.SqlTempdbLogFileSize | Should -Be 0.75
+                    $result.SqlTempdbLogFileGrowth | Should -Be 100
+                }
+            }
+
+            Context 'When there the PRIMARY filegroup contain two data files with the same file and growth size and type Percent' {
+                BeforeEach {
+                    $mockDynamicDataFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+
+                    $mockDynamicLogFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+                    )
+                }
+
+                It 'Should return the correct property values' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                    }
+
+                    $result = Get-TempDbProperties @getTempDbPropertiesParameters
+
+                    $result.SQLTempDBDir | Should -Be $mockPrimaryFilePath
+                    $result.SqlTempdbFileCount | Should -Be 2
+                    $result.SqlTempdbFileSize | Should -Be 8
+                    $result.SqlTempdbFileGrowth | Should -Be 10
+                    $result.SqlTempdbLogFileSize | Should -Be 0.75
+                    $result.SqlTempdbLogFileGrowth | Should -Be 10
+                }
+            }
+
+            Context 'When there the PRIMARY filegroup contain two data files with the same file and growth size and type KB' {
+                BeforeEach {
+                    $mockDynamicDataFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 102400 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 102400 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+
+                    $mockDynamicLogFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 102400 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 102400 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+                    )
+                }
+
+                It 'Should return the correct property values' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                    }
+
+                    $result = Get-TempDbProperties @getTempDbPropertiesParameters
+
+                    $result.SQLTempDBDir | Should -Be $mockPrimaryFilePath
+                    $result.SqlTempdbFileCount | Should -Be 2
+                    $result.SqlTempdbFileSize | Should -Be 8
+                    $result.SqlTempdbFileGrowth | Should -Be 100
+                    $result.SqlTempdbLogFileSize | Should -Be 0.75
+                    $result.SqlTempdbLogFileGrowth | Should -Be 100
+                }
+            }
+
+            Context 'When there the PRIMARY filegroup contain two data files with different file and growth sizes with growth type Percent' {
+                BeforeEach {
+                    $mockDynamicDataFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 32768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 25 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+
+                    $mockDynamicLogFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 25 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 1024 -PassThru -Force
+                    )
+                }
+
+                It 'Should return the correct property values' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                    }
+
+                    $result = Get-TempDbProperties @getTempDbPropertiesParameters
+
+                    $result.SQLTempDBDir | Should -Be $mockPrimaryFilePath
+                    $result.SqlTempdbFileCount | Should -Be 2
+                    $result.SqlTempdbFileSize | Should -Be 20
+                    $result.SqlTempdbFileGrowth | Should -Be 17.5
+                    $result.SqlTempdbLogFileSize | Should -Be 0.875
+                    $result.SqlTempdbLogFileGrowth | Should -Be 17.5
+                }
+            }
+
+            Context 'When there the PRIMARY filegroup contain two data files with different file and growth sizes with growth type KB' {
+                BeforeEach {
+                    $mockDynamicDataFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 1024 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 32768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 2048 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+
+                    $mockDynamicLogFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 1024 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 2048 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 1024 -PassThru -Force
+                    )
+                }
+
+                It 'Should return the correct property values' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                    }
+
+                    $result = Get-TempDbProperties @getTempDbPropertiesParameters
+
+                    $result.SQLTempDBDir | Should -Be $mockPrimaryFilePath
+                    $result.SqlTempdbFileCount | Should -Be 2
+                    $result.SqlTempdbFileSize | Should -Be 20
+                    $result.SqlTempdbFileGrowth | Should -Be 1.5
+                    $result.SqlTempdbLogFileSize | Should -Be 0.875
+                    $result.SqlTempdbLogFileGrowth | Should -Be 1.5
+                }
+            }
+
+            Context 'When there the PRIMARY filegroup contain two data files with different growth types' {
+                BeforeEach {
+                    $mockDynamicDataFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 32768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 102400 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 8192 -PassThru -Force
+                    )
+
+                    $mockDynamicLogFiles = @(
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 10 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'Percent' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 768 -PassThru -Force
+
+                        New-Object -TypeName 'Object' |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Growth' -Value 2048 -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'GrowthType' -Value 'KB' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Size' -Value 1024 -PassThru -Force
+                    )
+                }
+
+                It 'Should return the correct property values' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                    }
+
+                    $result = Get-TempDbProperties @getTempDbPropertiesParameters
+
+                    $result.SQLTempDBDir | Should -Be $mockPrimaryFilePath
+                    $result.SqlTempdbFileCount | Should -Be 2
+                    $result.SqlTempdbFileSize | Should -Be 20
+                    $result.SqlTempdbFileGrowth | Should -Be 110
+                    $result.SqlTempdbLogFileSize | Should -Be 0.875
+                    $result.SqlTempdbLogFileGrowth | Should -Be 12
+                }
+            }
+        }
+
+        Describe 'Get-SqlRoleMembers' -Tag 'Helper' {
+            BeforeAll {
+                $mockConnectSQL = {
+                    return New-Object -TypeName 'Object' |
+                        Add-Member -MemberType 'ScriptProperty' -Name 'Roles' -Value {
+                            return @{
+                                sysadmin = (
+                                        New-Object -TypeName 'Object' |
+                                            Add-Member -MemberType 'ScriptMethod' -Name 'EnumMemberNames' -Value {
+                                                return $mockDynamicMembers
+                                            } -PassThru -Force
+                                )
+                            }
+                        } -PassThru -Force
+                }
+
+                Mock -CommandName Connect-SQL -MockWith $mockConnectSQL
+            }
+
+            Context 'When the there is only one member in the sysadmin role' {
+                BeforeEach {
+                    $mockDynamicMembers = @(
+                        'sa'
+                    )
+                }
+
+                It 'Should return the correct type and have the correct member' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                        RoleName = 'sysadmin'
+                    }
+
+                    $result = Get-SqlRoleMembers @getTempDbPropertiesParameters
+
+                    $result -is [System.Object[]] | Should -BeTrue
+                    $result | Should -HaveCount 1
+                    $result[0] | Should -Be 'sa'
+                }
+            }
+
+            Context 'When the there is only one member in the sysadmin role' {
+                BeforeEach {
+                    $mockDynamicMembers = @(
+                        'sa'
+                        'COMPUTER\SqlInstall'
+                    )
+                }
+
+                It 'Should return the correct type and have the correct member' {
+                    $getTempDbPropertiesParameters = @{
+                        ServerName = 'localhost'
+                        InstanceName = 'INSTANCE'
+                        RoleName = 'sysadmin'
+                    }
+
+                    $result = Get-SqlRoleMembers @getTempDbPropertiesParameters
+
+                    $result -is [System.Object[]] | Should -BeTrue
+                    $result | Should -HaveCount 2
+                    $result[0] | Should -Be 'sa'
+                    $result[1] | Should -Be 'COMPUTER\SqlInstall'
+                }
+            }
+        }
+
+        Describe 'Get-SqlClusterProperties' -Tag 'Helper' {
+            BeforeAll {
+                $mockInstanceName = 'TEST'
+                $mockResourceGroupName = 'TESTCLU01A'
+                $mockDnsName = 'TESTCLU01A'
+                $mockIpAddress = '10.0.0.10'
+
+                $mockGetCimInstance_MSClusterResource = {
+                    return @(
+                        (
+                            New-Object -TypeName 'Microsoft.Management.Infrastructure.CimInstance' -ArgumentList @('MSCluster_Resource', 'root/MSCluster') |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value "SQL Server ($mockInstanceName)" -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'Type' -Value 'SQL Server' -TypeName 'String' -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'PrivateProperties' -Value @{
+                                    InstanceName = $mockInstanceName
+                                } -PassThru -Force
+                        )
+                    )
+                }
+
+                Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterResource
+
+                $mockGetCimAssociatedInstance_MSClusterResourceGroup = {
+                    return @(
+                        (
+                            New-Object -TypeName 'Microsoft.Management.Infrastructure.CimInstance' -ArgumentList @('MSCluster_ResourceGroup', 'root/MSCluster') |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockResourceGroupName -PassThru -Force
+                        )
+                    )
+                }
+
+                Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                    $ResultClassName -eq 'MSCluster_ResourceGroup'
+                } -MockWith $mockGetCimAssociatedInstance_MSClusterResourceGroup
+
+                $mockGetCimAssociatedInstance_MSClusterResource = {
+                    return @(
+                        New-Object -TypeName 'Microsoft.Management.Infrastructure.CimInstance' -ArgumentList @('MSCluster_Resource', 'root/MSCluster') |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Type' -Value 'Network Name' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'PrivateProperties' -Value @{
+                                DnsName = $mockDnsName
+                            } -PassThru -Force
+
+                        New-Object -TypeName 'Microsoft.Management.Infrastructure.CimInstance' -ArgumentList @('MSCluster_Resource', 'root/MSCluster') |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Type' -Value 'IP Address' -PassThru |
+                            Add-Member -MemberType 'NoteProperty' -Name 'PrivateProperties' -Value @{
+                                Address = $mockIpAddress
+                            } -PassThru -Force
+                    )
+                }
+
+                Mock -CommandName Get-CimAssociatedInstance -ParameterFilter {
+                    $ResultClassName -eq 'MSCluster_Resource'
+                } -MockWith $mockGetCimAssociatedInstance_MSClusterResource
+            }
+
+            It 'Should return the correct cluster values' {
+                $result = Get-SqlClusterProperties -InstanceName $mockInstanceName
+
+                $result.FailoverClusterNetworkName | Should -Be $mockDnsName
+                $result.FailoverClusterGroupName | Should -Be $mockResourceGroupName
+                $result.FailoverClusterIPAddress | Should -Be $mockIpAddress
+            }
+
+            It 'Should throw the correct error when cluster group for SQL instance cannot be found' {
+                $errorMessage = $script:localizedData.FailoverClusterResourceNotFound -f 'MSSQLSERVER'
+
+                { Get-SqlClusterProperties -InstanceName 'MSSQLSERVER' } | Should -Throw $errorMessage
+            }
+
+        }
+
+        Describe 'Get-ServiceProperties' -Tag 'Helper' {
+            BeforeAll {
+                $mockServiceName = 'MSSQL$SQL2014'
+                $mockUserName = 'COMPANY\SqlAccount'
+
+                $mockGetCimInstance = {
+                    return @(
+                        (
+                            New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockServiceName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StartName' -Value $mockUserName -PassThru -Force |
+                                Add-Member -MemberType NoteProperty -Name 'StartMode' -Value 'Auto' -PassThru -Force
+                        )
+                    )
+                }
+
+                Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance
+            }
+
+            It 'Should return the correct property values' {
+                $result = Get-ServiceProperties -ServiceName $mockServiceName
+
+                $result.UserName | Should -Be $mockUserName
+                $result.StartupType | Should -Be 'Automatic'
+            }
+        }
+
+        Describe 'Test-IsSsmsInstalled' -Tag 'Helper' {
+            Context 'When called with an unsupported major version' {
+                BeforeAll {
+                    Mock -CommandName Get-ItemProperty
+                }
+
+                It 'Should return $false' {
+                    Test-IsSsmsInstalled -SqlServerMajorVersion 99 | Should -BeFalse
+
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 0 -Scope It
+                }
+            }
+
+            Context 'When SQL Server Management Studio is not installed' {
+                BeforeAll {
+                    Mock -CommandName Get-ItemProperty
+                }
+
+                It 'Should return $false' {
+                    Test-IsSsmsInstalled -SqlServerMajorVersion 10 | Should -BeFalse
+
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When SQL Server Management Studio is installed' {
+                BeforeAll {
+                    $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber = '{72AB7E6F-BC24-481E-8C45-1AB5B3DD795D}'
+                    $mockSqlServerManagementStudio2012_ProductIdentifyingNumber = '{A7037EB2-F953-4B12-B843-195F4D988DA1}'
+                    $mockSqlServerManagementStudio2014_ProductIdentifyingNumber = '{75A54138-3B98-4705-92E4-F619825B121F}'
+
+                    $mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+                }
+
+                Context 'When SQL Server major version is 10 (2008 or 2008 R2)' {
+                    BeforeAll {
+                        Mock -CommandName Get-ItemProperty -MockWith {
+                            return @(
+                                # Mock product SSMS 2008 and SSMS 2008 R2.
+                                $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber
+                            )
+                        }
+                    }
+
+                    It 'Should return $true' {
+                        Test-IsSsmsInstalled -SqlServerMajorVersion 10 | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2008R2_ProductIdentifyingNumber)
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When SQL Server major version is 11 (2012)' {
+                    BeforeAll {
+                        Mock -CommandName Get-ItemProperty -MockWith {
+                            return @(
+                                # Mock product SSMS 2012.
+                                $mockSqlServerManagementStudio2012_ProductIdentifyingNumber
+                            )
+                        }
+                    }
+
+                    It 'Should return $true' {
+                        Test-IsSsmsInstalled -SqlServerMajorVersion 11 | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2012_ProductIdentifyingNumber)
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When SQL Server major version is 12 (2014)' {
+                    BeforeAll {
+                        Mock -CommandName Get-ItemProperty -MockWith {
+                            return @(
+                                # Mock product SSMS 2014.
+                                $mockSqlServerManagementStudio2014_ProductIdentifyingNumber
+                            )
+                        }
+                    }
+
+                    It 'Should return $true' {
+                        Test-IsSsmsInstalled -SqlServerMajorVersion 12 | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudio2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+        }
+
+        Describe 'Test-IsSsmsAdvancedInstalled' -Tag 'Helper' {
+            Context 'When called with an unsupported major version' {
+                BeforeAll {
+                    Mock -CommandName Get-ItemProperty
+                }
+
+                It 'Should return $false' {
+                    Test-IsSsmsAdvancedInstalled -SqlServerMajorVersion 99 | Should -BeFalse
+
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 0 -Scope It
+                }
+            }
+
+            Context 'When SQL Server Management Studio Advanced is not installed' {
+                BeforeAll {
+                    Mock -CommandName Get-ItemProperty
+                }
+
+                It 'Should return $false' {
+                    Test-IsSsmsAdvancedInstalled -SqlServerMajorVersion 10 | Should -BeFalse
+
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When SQL Server Management Studio Advanced is installed' {
+                BeforeAll {
+                    $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber = '{B5FE23CC-0151-4595-84C3-F1DE6F44FE9B}'
+                    $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber = '{7842C220-6E9A-4D5A-AE70-0E138271F883}'
+                    $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber = '{B5ECFA5C-AC4F-45A4-A12E-A76ABDD9CCBA}'
+
+                    $mockRegistryUninstallProductsPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+                }
+
+                Context 'When SQL Server major version is 10 (2008 or 2008 R2)' {
+                    BeforeAll {
+                        Mock -CommandName Get-ItemProperty -MockWith {
+                            return @(
+                                # Mock product SSMS 2008 and SSMS 2008 R2.
+                                $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber
+                            )
+                        }
+                    }
+
+                    It 'Should return $true' {
+                        Test-IsSsmsAdvancedInstalled -SqlServerMajorVersion 10 | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2008R2_ProductIdentifyingNumber)
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When SQL Server major version is 11 (2012)' {
+                    BeforeAll {
+                        Mock -CommandName Get-ItemProperty -MockWith {
+                            return @(
+                                # Mock product SSMS 2012.
+                                $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber
+                            )
+                        }
+                    }
+
+                    It 'Should return $true' {
+                        Test-IsSsmsAdvancedInstalled -SqlServerMajorVersion 11 | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2012_ProductIdentifyingNumber)
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When SQL Server major version is 12 (2014)' {
+                    BeforeAll {
+                        Mock -CommandName Get-ItemProperty -MockWith {
+                            return @(
+                                # Mock product SSMS 2014.
+                                $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber
+                            )
+                        }
+                    }
+
+                    It 'Should return $true' {
+                        Test-IsSsmsAdvancedInstalled -SqlServerMajorVersion 12 | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-ItemProperty -ParameterFilter {
+                            $Path -eq (Join-Path -Path $mockRegistryUninstallProductsPath -ChildPath $mockSqlServerManagementStudioAdvanced2014_ProductIdentifyingNumber)
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+        }
+
+        Describe 'Get-SqlSharedPaths' -Tag 'Helper' {
+            BeforeAll {
+                $mockSqlSharedPath = 'C:\Program Files\Microsoft SQL Server'
+                $mockSqlSharedWowPath = 'C:\Program Files (x86)\Microsoft SQL Server'
+                $mockRegistryKeySharedDir = 'FEE2E540D20152D4597229B6CFBC0A69'
+                $mockRegistryKeySharedWOWDir = 'A79497A344129F64CA7D69C56F5DD8B4'
+
+                Mock -CommandName Get-FirstPathValueFromRegistryPath -ParameterFilter {
+                    $Path -match $mockRegistryKeySharedDir
+                } -MockWith {
+                    return $mockSqlSharedPath
+                }
+
+                Mock -CommandName Get-FirstPathValueFromRegistryPath -ParameterFilter {
+                    $Path -match $mockRegistryKeySharedWOWDir
+                } -MockWith {
+                    return $mockSqlSharedWowPath
+                }
+            }
+
+            $testCases = @(
+                @{
+                    SqlServerMajorVersion = 10
+                }
+
+                @{
+                    SqlServerMajorVersion = 11
+                }
+
+                @{
+                    SqlServerMajorVersion = 12
+                }
+
+                @{
+                    SqlServerMajorVersion = 13
+                }
+
+                @{
+                    SqlServerMajorVersion = 14
+                }
+            )
+
+            It 'Should return the correct property values for SQL Server major version <SqlServerMajorVersion>' -TestCases $testCases {
+                param
+                (
+                    [Parameter()]
+                    [System.Int32]
+                    $SqlServerMajorVersion
+                )
+
+                $result = Get-SqlSharedPaths -SqlServerMajorVersion $SqlServerMajorVersion
+
+                $result.InstallSharedDir | Should -Be $mockSqlSharedPath
+                $result.InstallSharedWOWDir | Should -Be $mockSqlSharedWowPath
+            }
+        }
+
+        Describe 'Get-FirstPathValueFromRegistryPath' -Tag 'Helper' {
+            BeforeAll {
+                # This path cannot use 'HKLM:\', if it does it slows the test to a crawl.
+                $mockRegistryPath = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69'
+
+                # Have on purpose a backslash at the end of the path to test the trim logic.
+                $mockFileSystemPath = 'C:\Program Files\Microsoft SQL Server\'
+
+                Mock -CommandName Get-Item -MockWith {
+                    return [PSCustomObject] @{
+                        Property = @(
+                            'DCB13571726C2A64F9E1C79C020E9EA4'
+                            '52A7B04BB8030564B8245E7101DC4D9D'
+                            '17195C960C1F3104DB7F109DB81562E3'
+                            'F07EA859E694B45439E22B819F70A40F'
+                            '3F9A28055EEA9364B97A1C6916AB3713'
+                        )
+                    }
+                }
+
+                Mock -CommandName Get-ItemProperty -MockWith {
+                    return @{
+                        'DCB13571726C2A64F9E1C79C020E9EA4' = $mockFileSystemPath
+                    }
+                }
+            }
+
+            It 'Should return the correct registry property value' {
+                $result = Get-FirstPathValueFromRegistryPath -Path $mockRegistryPath
+
+                $result | Should -Be $mockFileSystemPath.TrimEnd('\')
             }
         }
     }


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc
  - The regular expression for `minor-version-bump-message` in the file
    `GitVersion.yml` was changed to only raise minor version when the
    commit message contain the word `add`, `adds`, `minor`, `feature`,
    or `features`.
- SqlSetup
  - BREAKING CHANGE: Logic that was under feature flag `DetectionSharedFeatures`
    was made the default and old logic that was used to detect shared features
    was removed ([issue #1290](https://github.com/dsccommunity/SqlServerDsc/issues/1290)).
    This was implemented because the previous implementation did not work
    fully with SQL Server 2017.
  - Much of the code was refactored into units (functions) to be easier to test.
    Due to the size of the code the unit tests ran for an abnormal long time,
    after this refactoring the unit tests runs much quicker.
  - The property `SqlTempdbLogFileGrowth` and `SqlTempdbFileGrowth` now returns
    the correct values. Previously the value of the growth was wrongly
    divided by 1KB even if the value was in percent. Now the value for growth
    is the sum of the average of MB and average of the percentage.
  - The function `Get-TargetResource` was changed so that the property
    `SQLTempDBDir` will now return the database `tempdb`'s property
    `PrimaryFilePath`.
  - A read only property `IsClustered` was added that can be used to determine
    if the instance is clustered.

#### This Pull Request (PR) fixes the following issues

- Fixes #1290

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1493)
<!-- Reviewable:end -->
