### PR TITLE
SqlServerProtocol: New resource proposal

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,7 @@ pulls:
     - needs review
     - on hold
     - waiting for CLA pass
+    - ready for merge
 
   markComment: >
     Labeling this pull request (PR) as abandoned since it has gone 14 days or more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 ### Added
 
 - SqlServerDsc
-  - Added new resource SqlServerProtocol
+  - Added new resource SqlServerProtocol ([issue #1377](https://github.com/dsccommunity/SqlServerDsc/issues/1377)).
 - SqlSetup
   - A read only property `IsClustered` was added that can be used to determine
     if the instance is clustered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ### Added
 
+- SqlServerDsc
+  - Added new resource SqlServerProtocol
 - SqlSetup
   - A read only property `IsClustered` was added that can be used to determine
     if the instance is clustered.
@@ -18,6 +20,10 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - SqlServerDsc
   - Changed all resource prefixes from `MSFT_` to `DSC_` ([issue #1496](https://github.com/dsccommunity/SqlServerDsc/issues/1496)).
   - All resources are now using the common module DscResource.Common.
+  - When a PR is labelled with 'ready for merge' it is no longer being
+    marked as stale if the PR is not merged for 30 days (for example it is
+    dependent on something else) ([issue #1504](https://github.com/dsccommunity/SqlServerDsc/issues/1504)).
+  - Updated the CI pipeline to use latest version of the module ModuleBuilder.
 - SqlAlwaysOnService
   - BREAKING CHANGE: The parameter `ServerName` is now non-mandatory and
     defaults to `$env:COMPUTERNAME` ([issue #319](https://github.com/dsccommunity/SqlServerDsc/issues/319)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - SqlSetup
   - A read only property `IsClustered` was added that can be used to determine
     if the instance is clustered.
+- SqlServerDsc.Common
+  - The helper function `Restart-SqlService` was improved to handle Failover
+    Clusters better. Now the SQL Server service will only be taken offline
+    and back online again if the service is online to begin with.
+  - The helper function `Restart-SqlServer` learned the new parameter
+    `OwnerNode`. The parameter `OwnerNode` takes an array of Cluster node
+    names. Using this parameter the cluster group will only be taken
+    offline and back online if the cluster group owner is one specified
+    in this parameter.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ A full list of changes in each version can be found in the [change log](CHANGELO
   Protocols.
 * [**SqlServerPermission**](#sqlserverpermission) Grant or revoke permission on
   the SQL Server.
+* [**SqlServerProtocol**](#sqlserverprotocol) resource will manage the SQL Server
+  protocols for a SQL Server instance.
 * [**SqlServerReplication**](#sqlserverreplication) resource to manage SQL Replication
   distribution and publishing.
 * [**SqlServerRole**](#sqlserverrole) resource to manage SQL server roles.
@@ -1694,7 +1696,7 @@ for a SQL Server instance.
 * **`[String` PipeName** _(Write)_: Specifies the name of the named pipe.
   Only used for the Named Pipes protocol, ignored for all other protocols.
 * **`[Boolean]` SuppressRestart** _(Write)_: If set to $true then the any
-  attempt by the resource to restart the services is suppressed. The default
+  attempt by the resource to restart the service is suppressed. The default
   value is $false.
 * **`[UInt16]` RestartTimeout** _(Write)_: Timeout value for restarting
   the SQL Server services. The default value is 120 seconds.

--- a/README.md
+++ b/README.md
@@ -1651,6 +1651,64 @@ AlterAnyEndPoint and ViewServerState.
 
 All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlServerPermission).
 
+### SqlServerProtocol
+
+The `SqlServerProtocol` DSC resource will manage the SQL Server protocols
+for a SQL Server instance.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2008 R2 or later.
+* Target machine must be running SQL Server Database Engine 2008 or later.
+* Target machine must have access to the SQLPS PowerShell module or the SqlServer
+  PowerShell module.
+* If a protocol is disabled that prevents the cmdlet `Restart-SqlService` to
+  contact the instance to evaluate if it is a cluster then the parameter
+  `SuppressRestart` must be used to override the restart. Same if a protocol
+  is enabled that was previously disabled and no other protocol allows
+  connecting to the instance then the parameter `SuppressRestart` must also
+  be used.
+
+#### Parameters
+
+* **`[String]` InstanceName** _(Key)_: Specifies the name of the SQL Server
+  instance to enable the protocol for.
+* **`[String]` ProtocolName** _(Key)_: Specifies the name of network protocol
+  to be configured. { 'TcpIp' | 'NamedPipes' | 'ShareMemory' }
+* **`[String]` ServerName** _(Write)_: Specifies the host name of the SQL
+  Server to be configured. If the SQL Server belongs to a cluster or
+  availability group specify the host name for the listener or cluster group.
+  Default value is `$env:COMPUTERNAME`.
+* **`[String]` Enabled** _(Write)_: Specifies if the protocol should be
+  enabled or disabled.
+* **`[String[]]` ListenOnAllIpAddresses** _(Write)_: Specifies to listen
+  on all IP addresses. Only used for the TCP/IP protocol, ignored for all
+  other protocols.
+* **`[String[]]` KeepAlive** _(Write)_: Specifies the keep alive duration
+  in milliseconds. Only used for the TCP/IP protocol, ignored for all other
+  protocols.
+* **`[String[]]` PipeName** _(Write)_: Specifies the name of the named pipe.
+  Only used for the Named Pipes protocol, ignored for all other protocols.
+* **`[String[]]` SuppressRestart** _(Write)_: If set to $true then the any
+  attempt by the resource to restart the services is suppressed. The default
+  value is $false.
+* **`[String[]]` RestartTimeout** _(Write)_: Timeout value for restarting
+  the SQL Server services. The default value is 120 seconds.
+
+#### Read-Only Properties from Get-TargetResource
+
+* **`[String]` HasMultiIPAddresses** _(Read)_: Returns $true or $false whether
+  the instance has multiple IP addresses or not.
+
+#### Examples
+
+* [Add server permission for a login](/source/Examples/Resources/SqlServerPermission/1-AddServerPermissionForLogin.ps1)
+* [Remove server permission for a login](/source/Examples/Resources/SqlServerPermission/2-RemoveServerPermissionForLogin.ps1)
+
+#### Known issues
+
+All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlServerPermission).
+
 ### SqlServerReplication
 
 This resource manage SQL Replication distribution and publishing.

--- a/README.md
+++ b/README.md
@@ -1683,25 +1683,25 @@ for a SQL Server instance.
   Server to be configured. If the SQL Server belongs to a cluster or
   availability group specify the host name for the listener or cluster group.
   Default value is `$env:COMPUTERNAME`.
-* **`[String]` Enabled** _(Write)_: Specifies if the protocol should be
+* **`[Boolean]` Enabled** _(Write)_: Specifies if the protocol should be
   enabled or disabled.
-* **`[String[]]` ListenOnAllIpAddresses** _(Write)_: Specifies to listen
+* **`[Boolean]` ListenOnAllIpAddresses** _(Write)_: Specifies to listen
   on all IP addresses. Only used for the TCP/IP protocol, ignored for all
   other protocols.
-* **`[String[]]` KeepAlive** _(Write)_: Specifies the keep alive duration
+* **`[UInt16]` KeepAlive** _(Write)_: Specifies the keep alive duration
   in milliseconds. Only used for the TCP/IP protocol, ignored for all other
   protocols.
-* **`[String[]]` PipeName** _(Write)_: Specifies the name of the named pipe.
+* **`[String` PipeName** _(Write)_: Specifies the name of the named pipe.
   Only used for the Named Pipes protocol, ignored for all other protocols.
-* **`[String[]]` SuppressRestart** _(Write)_: If set to $true then the any
+* **`[Boolean]` SuppressRestart** _(Write)_: If set to $true then the any
   attempt by the resource to restart the services is suppressed. The default
   value is $false.
-* **`[String[]]` RestartTimeout** _(Write)_: Timeout value for restarting
+* **`[UInt16]` RestartTimeout** _(Write)_: Timeout value for restarting
   the SQL Server services. The default value is 120 seconds.
 
 #### Read-Only Properties from Get-TargetResource
 
-* **`[String]` HasMultiIPAddresses** _(Read)_: Returns $true or $false whether
+* **`[Boolean]` HasMultiIPAddresses** _(Read)_: Returns $true or $false whether
   the instance has multiple IP addresses or not.
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A full list of changes in each version can be found in the [change log](CHANGELO
   Protocols.
 * [**SqlServerPermission**](#sqlserverpermission) Grant or revoke permission on
   the SQL Server.
-* [**SqlServerProtocol**](#sqlserverprotocol) resource will manage the SQL Server
+* [**SqlServerProtocol**](#sqlserverprotocol) resource manage the SQL Server
   protocols for a SQL Server instance.
 * [**SqlServerReplication**](#sqlserverreplication) resource to manage SQL Replication
   distribution and publishing.
@@ -1655,7 +1655,7 @@ All issues are not listed here, see [here for all open issues](https://github.co
 
 ### SqlServerProtocol
 
-The `SqlServerProtocol` DSC resource will manage the SQL Server protocols
+The `SqlServerProtocol` DSC resource manage the SQL Server protocols
 for a SQL Server instance.
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -1660,8 +1660,8 @@ for a SQL Server instance.
 
 #### Requirements
 
-* Target machine must be running Windows Server 2008 R2 or later.
-* Target machine must be running SQL Server Database Engine 2008 or later.
+* Target machine must be running Windows Server 2012 or later.
+* Target machine must be running SQL Server Database Engine 2012 or later.
 * Target machine must have access to the SQLPS PowerShell module or the SqlServer
   PowerShell module.
 * If a protocol is disabled that prevents the cmdlet `Restart-SqlService` to

--- a/README.md
+++ b/README.md
@@ -1702,12 +1702,16 @@ for a SQL Server instance.
 
 #### Examples
 
-* [Add server permission for a login](/source/Examples/Resources/SqlServerPermission/1-AddServerPermissionForLogin.ps1)
-* [Remove server permission for a login](/source/Examples/Resources/SqlServerPermission/2-RemoveServerPermissionForLogin.ps1)
+* [Enable the TCP/IP protocol](/source/Examples/Resources/SqlServerProtocol/1-EnableTcpIp.ps1)
+* [Enable the Named Pipes protocol](/source/Examples/Resources/SqlServerProtocol/2-EnableNamedPipes.ps1)
+* [Enable the Shared Memory protocol](/source/Examples/Resources/SqlServerProtocol/3-EnableSharedMemory.ps1)
+* [Disable the TCP/IP protocol](/source/Examples/Resources/SqlServerProtocol/4-DisableTcpIp.ps1)
+* [Disable the Named Pipes protocol](/source/Examples/Resources/SqlServerProtocol/5-DisableNamedPipes.ps1)
+* [Disable the Shared Memory protocol](/source/Examples/Resources/SqlServerProtocol/6-DisableSharedMemory.ps1)
 
 #### Known issues
 
-All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlServerPermission).
+All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlServerProtocol).
 
 ### SqlServerReplication
 

--- a/README.md
+++ b/README.md
@@ -1668,6 +1668,10 @@ for a SQL Server instance.
   is enabled that was previously disabled and no other protocol allows
   connecting to the instance then the parameter `SuppressRestart` must also
   be used.
+* When connecting to a Failover Cluster where the account `SYSTEM` does
+  not have access then the correct credential must be provided in
+  the built-in parameter `PSDscRunAsCredential`. If not the following error
+  can appear; `An internal error occurred`.
 
 #### Parameters
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,6 +226,7 @@ stages:
                   # Group 5
                   'tests/Integration/DSC_SqlServerSecureConnection.Integration.Tests.ps1'
                   'tests/Integration/DSC_SqlScriptQuery.Integration.Tests.ps1'
+                  'DSC_SqlServerProtocol.Integration.Tests.ps1'
               )
             name: test
             displayName: 'Run Integration Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,7 +226,7 @@ stages:
                   # Group 5
                   'tests/Integration/DSC_SqlServerSecureConnection.Integration.Tests.ps1'
                   'tests/Integration/DSC_SqlScriptQuery.Integration.Tests.ps1'
-                  'DSC_SqlServerProtocol.Integration.Tests.ps1'
+                  'tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1'
               )
             name: test
             displayName: 'Run Integration Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,6 +163,7 @@ stages:
                   # Group 5
                   'tests/Integration/DSC_SqlServerSecureConnection.Integration.Tests.ps1'
                   'tests/Integration/DSC_SqlScriptQuery.Integration.Tests.ps1'
+                  'tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1'
               )
             name: test
             displayName: 'Run Integration Test'

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -329,6 +329,12 @@ function Set-TargetResource
 
             $serverProtocolProperties.Alter()
         }
+        else
+        {
+            $errorMessage = $script:localizedData.FailedToGetSqlServerProtocol
+
+            New-InvalidOperationException -Message $errorMessage
+        }
 
         if (-not $SuppressRestart -and $isRestartNeeded)
         {

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -44,7 +44,7 @@ function Get-TargetResource
         $ServerName = $env:COMPUTERNAME,
 
         [Parameter()]
-        [System.UInt16]
+        [System.Boolean]
         $SuppressRestart = $false,
 
         [Parameter()]

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -73,8 +73,12 @@ function Get-TargetResource
 
     Import-SQLPSModule
 
+    <#
+        Must connect to the local machine name because $ServerName can point
+        to a cluster instance or availability group listener.
+    #>
     $getServerProtocolObjectParameters = @{
-        ServerName   = $ServerName
+        ServerName   = $env:COMPUTERNAME
         Instance     = $InstanceName
         ProtocolName = $ProtocolName
     }
@@ -222,8 +226,12 @@ function Set-TargetResource
             $script:localizedData.SetDesiredState -f $protocolNameProperties.DisplayName, $InstanceName
         )
 
+        <#
+            Must connect to the local machine name because $ServerName can point
+            to a cluster instance or availability group listener.
+        #>
         $getServerProtocolObjectParameters = @{
-            ServerName   = $ServerName
+            ServerName   = $env:COMPUTERNAME
             Instance     = $InstanceName
             ProtocolName = $ProtocolName
         }

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -1,0 +1,770 @@
+$script:resourceModulePath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+$script:modulesFolderPath = Join-Path -Path $script:resourceModulePath -ChildPath 'Modules'
+
+$script:resourceHelperModulePath = Join-Path -Path $script:modulesFolderPath -ChildPath 'SqlServerDsc.Common'
+Import-Module -Name (Join-Path -Path $script:resourceHelperModulePath -ChildPath 'SqlServerDsc.Common.psm1')
+
+# Load localized string data
+$script:localizedData = Get-LocalizedData -ResourceName 'DSC_SqlServerProtocol'
+
+<#
+    .SYNOPSIS
+        Returns the current state of the SQL Server protocol for the specified
+        SQL Server instance.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL Server instance to enable the protocol for.
+
+    .PARAMETER ProtocolName
+        Specifies the name of network protocol to be configured. Possible values
+        are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value is
+        $env:COMPUTERNAME.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('TcpIp', 'NamedPipes', 'SharedMemory')]
+        [System.String]
+        $ProtocolName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter()]
+        [System.UInt16]
+        $SuppressRestart = $false,
+
+        [Parameter()]
+        [System.UInt16]
+        $RestartTimeout = 120
+    )
+
+    $returnValue = @{
+        InstanceName           = $InstanceName
+        ProtocolName           = $ProtocolName
+        ServerName             = $ServerName
+        SuppressRestart        = $SuppressRestart
+        RestartTimeout         = $RestartTimeout
+        Enabled                = $false
+        ListenOnAllIpAddresses = $false
+        KeepAlive              = 0
+        PipeName               = $null
+        HasMultiIPAddresses    = $false
+    }
+
+    $protocolNameProperties = Get-ProtocolNameProperties -ProtocolName $ProtocolName
+
+    Write-Verbose -Message (
+        $script:localizedData.GetCurrentState -f $protocolNameProperties.DisplayName, $InstanceName, $ServerName
+    )
+
+    Import-SQLPSModule
+
+    $getServerProtocolObjectParameters = @{
+        ServerName   = $ServerName
+        Instance     = $InstanceName
+        ProtocolName = $ProtocolName
+    }
+
+    $serverProtocolProperties = Get-ServerProtocolObject @getServerProtocolObjectParameters
+
+    if ($serverProtocolProperties)
+    {
+        # Properties that exist on all protocols.
+        $returnValue.Enabled = $serverProtocolProperties.IsEnabled
+        $returnValue.HasMultiIPAddresses = $serverProtocolProperties.HasMultiIPAddresses
+
+        # Get individual protocol properties.
+        switch ($ProtocolName)
+        {
+            'TcpIp'
+            {
+                $returnValue.ListenOnAllIpAddresses = $serverProtocolProperties.ProtocolProperties.ListenOnAllIPs
+                $returnValue.KeepAlive = $serverProtocolProperties.ProtocolProperties.KeepAlive
+            }
+
+            'NamedPipes'
+            {
+                $returnValue.PipeName = $serverProtocolProperties.ProtocolProperties.PipeName
+            }
+
+            'SharedMemory'
+            {
+                <#
+                    Left blank intentionally. There are no individual protocol
+                    properties for the protocol Shared Memory.
+                #>
+            }
+        }
+    }
+
+    return $returnValue
+}
+
+<#
+    .SYNOPSIS
+        Sets the desired state of the SQL Server protocol for the specified
+        SQL Server instance.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL Server instance to enable the protocol for.
+
+    .PARAMETER ProtocolName
+        Specifies the name of network protocol to be configured. Possible values
+        are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value is
+        $env:COMPUTERNAME.
+
+    .PARAMETER Enabled
+        Specifies if the protocol should be enabled or disabled.
+
+    .PARAMETER ListenOnAllIpAddresses
+        Specifies to listen on all IP addresses. Only used for the TCP/IP protocol,
+        ignored for all other protocols.
+
+    .PARAMETER KeepAlive
+        Specifies the keep alive duration. Only used for the TCP/IP protocol,
+        ignored for all other protocols.
+
+    .PARAMETER PipeName
+        Specifies the name of the named pipe. Only used for the Named Pipes protocol,
+        ignored for all other protocols.
+
+    .PARAMETER SuppressRestart
+        If set to $true then SQL Server and dependent services will be restarted
+        if a change to the configuration is made. The default value is $false.
+
+    .PARAMETER RestartTimeout
+        Timeout value for restarting the SQL Server services. The default value
+        is 120 seconds.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('TcpIp', 'NamedPipes', 'SharedMemory')]
+        [System.String]
+        $ProtocolName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter()]
+        [System.Boolean]
+        $Enabled,
+
+        [Parameter()]
+        [System.Boolean]
+        $ListenOnAllIpAddresses,
+
+        [Parameter()]
+        [System.UInt16]
+        $KeepAlive,
+
+        [Parameter()]
+        [System.String]
+        $PipeName,
+
+        [Parameter()]
+        [System.Boolean]
+        $SuppressRestart = $false,
+
+        [Parameter()]
+        [System.UInt16]
+        $RestartTimeout = 120
+    )
+
+    $protocolNameProperties = Get-ProtocolNameProperties -ProtocolName $ProtocolName
+
+    <#
+        Compare the current state against the desired state. Calling this will
+        also import the necessary module to later call Get-ServerProtocolObject
+        which uses the SMO class ManagedComputer.
+    #>
+    $propertyState = Compare-TargetResourceState @PSBoundParameters
+
+    # Get all properties that are not in desired state.
+    $propertiesNotInDesiredState = $propertyState.Where( { -not $_.InDesiredState })
+
+    if ($propertiesNotInDesiredState.Count -gt 0)
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SetDesiredState -f $protocolNameProperties.DisplayName, $InstanceName
+        )
+
+        $getServerProtocolObjectParameters = @{
+            ServerName   = $ServerName
+            Instance     = $InstanceName
+            ProtocolName = $ProtocolName
+        }
+
+        $serverProtocolProperties = Get-ServerProtocolObject @getServerProtocolObjectParameters
+
+        if ($serverProtocolProperties)
+        {
+            $isRestartNeeded = $false
+
+            # Check if Enable property need updating.
+            if ($propertiesNotInDesiredState.Where( { $_.ParameterName -eq 'Enabled' }))
+            {
+                $serverProtocolProperties.IsEnabled = $Enabled
+
+                if ($Enabled)
+                {
+                    Write-Verbose -Message (
+                        $script:localizedData.ProtocolHasBeenEnabled -f $protocolNameProperties.DisplayName, $InstanceName
+                    )
+                }
+                else
+                {
+                    Write-Verbose -Message (
+                        $script:localizedData.ProtocolHasBeenDisabled -f $protocolNameProperties.DisplayName, $InstanceName
+                    )
+                }
+
+                $isRestartNeeded = $true
+            }
+
+            # Set individual protocol properties.
+            switch ($ProtocolName)
+            {
+                'TcpIp'
+                {
+                    # Check if ListenOnAllIpAddresses property need updating.
+                    if ($propertiesNotInDesiredState.Where( { $_.ParameterName -eq 'ListenOnAllIpAddresses' }))
+                    {
+                        Write-Verbose -Message (
+                            $script:localizedData.ParameterHasBeenSetToNewValue -f 'ListenOnAllIpAddresses', $protocolNameProperties.DisplayName, $ListenOnAllIpAddresses
+                        )
+
+                        $serverProtocolProperties.ProtocolProperties['ListenOnAllIPs'].Value = $ListenOnAllIpAddresses
+                    }
+
+                    # Check if KeepAlive property need updating.
+                    if ($propertiesNotInDesiredState.Where( { $_.ParameterName -eq 'KeepAlive' }))
+                    {
+                        Write-Verbose -Message (
+                            $script:localizedData.ParameterHasBeenSetToNewValue -f 'KeepAlive', $protocolNameProperties.DisplayName, $KeepAlive
+                        )
+
+                        $serverProtocolProperties.ProtocolProperties['KeepAlive'].Value = $KeepAlive
+                    }
+                }
+
+                'NamedPipes'
+                {
+                    # Check if PipeName property need updating.
+                    if ($propertiesNotInDesiredState.Where( { $_.ParameterName -eq 'PipeName' }))
+                    {
+                        Write-Verbose -Message (
+                            $script:localizedData.ParameterHasBeenSetToNewValue -f 'PipeName', $protocolNameProperties.DisplayName, $PipeName
+                        )
+
+                        $serverProtocolProperties.ProtocolProperties['PipeName'].Value = $PipeName
+                    }
+                }
+
+                'SharedMemory'
+                {
+                    <#
+                        Left blank intentionally. There are no individual protocol
+                        properties for the protocol Shared Memory.
+                    #>
+                }
+            }
+
+            $serverProtocolProperties.Alter()
+        }
+
+        if (-not $SuppressRestart -and $isRestartNeeded)
+        {
+            $restartSqlServiceParameters = @{
+                ServerName   = $ServerName
+                InstanceName = $InstanceName
+                Timeout      = $RestartTimeout
+            }
+
+            $enabledPropertyState = $propertyState.Where( { $_.ParameterName -eq 'Enabled' })
+
+            if ($enabledPropertyState)
+            {
+                if ($enabledPropertyState.Actual -eq $false -and $Enabled -eq $true)
+                {
+                    <#
+                        If the protocol was disabled and now being enabled, is not possible
+                        to connect to the instance to evaluate if it is a clustered instance.
+                        This is being tracked in issue #1174.
+                    #>
+                    $restartSqlServiceParameters['SkipClusterCheck'] = $true
+                }
+            }
+
+            <#
+                If the parameter Enabled is specified and set to $false,
+                or if the parameter Enabled is _not_ specified and the current
+                state of the protocol is disabled then skip waiting for the
+                server to come back online after restart.
+            #>
+            if ((
+                    $PSBoundParameters.ContainsKey('Enabled') `
+                        -and $Enabled -eq $false
+                ) -or (
+                    -not $PSBoundParameters.ContainsKey('Enabled') `
+                        -and $enabledPropertyState.Actual -eq $false
+                )
+            )
+            {
+                # If the protocol is disabled it is not possible to connect to the instance.
+                $restartSqlServiceParameters['SkipWaitForOnline'] = $true
+            }
+
+            Restart-SqlService @restartSqlServiceParameters
+        }
+        elseif ($isRestartNeeded)
+        {
+            Write-Warning -Message $script:localizedData.RestartSuppressed
+        }
+    }
+    else
+    {
+        Write-Verbose -Message (
+            $script:localizedData.ProtocolIsInDesiredState -f $protocolNameProperties.DisplayName, $InstanceName
+        )
+    }
+}
+
+<#
+    .SYNOPSIS
+        Determines the desired state of the SQL Server protocol for the specified
+        SQL Server instance.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL Server instance to enable the protocol for.
+
+    .PARAMETER ProtocolName
+        Specifies the name of network protocol to be configured. Possible values
+        are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value is
+        $env:COMPUTERNAME.
+
+    .PARAMETER Enabled
+        Specifies if the protocol should be enabled or disabled.
+
+    .PARAMETER ListenOnAllIpAddresses
+        Specifies to listen on all IP addresses. Only used for the TCP/IP protocol,
+        ignored for all other protocols.
+
+    .PARAMETER KeepAlive
+        Specifies the keep alive duration. Only used for the TCP/IP protocol,
+        ignored for all other protocols.
+
+    .PARAMETER PipeName
+        Specifies the name of the named pipe. Only used for the Named Pipes protocol,
+        ignored for all other protocols.
+
+    .PARAMETER SuppressRestart
+        If set to $true then SQL Server and dependent services will be restarted
+        if a change to the configuration is made. The default value is $false.
+
+    .PARAMETER RestartTimeout
+        Timeout value for restarting the SQL Server services. The default value
+        is 120 seconds.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('TcpIp', 'NamedPipes', 'SharedMemory')]
+        [System.String]
+        $ProtocolName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter()]
+        [System.Boolean]
+        $Enabled,
+
+        [Parameter()]
+        [System.Boolean]
+        $ListenOnAllIpAddresses,
+
+        [Parameter()]
+        [System.UInt16]
+        $KeepAlive,
+
+        [Parameter()]
+        [System.String]
+        $PipeName,
+
+        [Parameter()]
+        [System.Boolean]
+        $SuppressRestart = $false,
+
+        [Parameter()]
+        [System.UInt16]
+        $RestartTimeout = 120
+    )
+
+    $protocolNameProperties = Get-ProtocolNameProperties -ProtocolName $ProtocolName
+
+    Write-Verbose -Message (
+        $script:localizedData.TestDesiredState -f $protocolNameProperties.DisplayName, $InstanceName, $ServerName
+    )
+
+    $propertyState = Compare-TargetResourceState @PSBoundParameters
+
+
+    if ($false -in $propertyState.InDesiredState)
+    {
+        $testTargetResourceReturnValue = $false
+
+        Write-Verbose -Message (
+            $script:localizedData.NotInDesiredState -f $protocolNameProperties.DisplayName, $InstanceName
+        )
+    }
+    else
+    {
+        $testTargetResourceReturnValue = $true
+
+        Write-Verbose -Message (
+            $script:localizedData.InDesiredState -f $protocolNameProperties.DisplayName, $InstanceName
+        )
+    }
+
+    return $testTargetResourceReturnValue
+}
+
+<#
+    .SYNOPSIS
+        Compares the properties in the current state with the properties of the
+        desired state and returns a hashtable with the comparison result.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL Server instance to enable the protocol for.
+
+    .PARAMETER ProtocolName
+        Specifies the name of network protocol to be configured. Possible values
+        are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value is
+        $env:COMPUTERNAME.
+
+    .PARAMETER Enabled
+        Specifies if the protocol should be enabled or disabled.
+
+    .PARAMETER ListenOnAllIpAddresses
+        Specifies to listen on all IP addresses. Only used for the TCP/IP protocol,
+        ignored for all other protocols.
+
+    .PARAMETER KeepAlive
+        Specifies the keep alive duration. Only used for the TCP/IP protocol,
+        ignored for all other protocols.
+
+    .PARAMETER PipeName
+        Specifies the name of the named pipe. Only used for the Named Pipes protocol,
+        ignored for all other protocols.
+
+    .PARAMETER RestartTimeout
+        If set to $true then SQL Server and dependent services will be restarted
+        if a change to the configuration is made. The default value is $false.
+
+    .PARAMETER RestartTimeout
+        Timeout value for restarting the SQL Server services. The default value
+        is 120 seconds.
+#>
+function Compare-TargetResourceState
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('TcpIp', 'NamedPipes', 'SharedMemory')]
+        [System.String]
+        $ProtocolName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME,
+
+        [Parameter()]
+        [System.Boolean]
+        $Enabled,
+
+        [Parameter()]
+        [System.Boolean]
+        $ListenOnAllIpAddresses,
+
+        [Parameter()]
+        [System.UInt16]
+        $KeepAlive,
+
+        [Parameter()]
+        [System.String]
+        $PipeName,
+
+        [Parameter()]
+        [System.Boolean]
+        $SuppressRestart,
+
+        [Parameter()]
+        [System.UInt16]
+        $RestartTimeout
+    )
+
+    if ($ProtocolName -eq 'SharedMemory')
+    {
+        <#
+            If the protocol is Shared Memory, assert that no other individual
+            protocol properties are passed.
+        #>
+        $assertBoundParameterParameters = @{
+            BoundParameterList     = $PSBoundParameters
+            <#
+                Since SharedMemory does not have any individual properties this
+                mandatory property is being used to compare against.
+            #>
+            MutuallyExclusiveList1 = @(
+                'ProtocolName'
+            )
+            # These must not be passed for Shared Memory.
+            MutuallyExclusiveList2 = @(
+                'KeepAlive'
+                'ListenOnAllIpAddresses'
+                'PipeName'
+            )
+        }
+    }
+    else
+    {
+        <#
+            If the protocol is set to TCP/IP or Named Pipes, assert that one or
+            more of their individual protocol properties are not passed together.
+        #>
+        $assertBoundParameterParameters = @{
+            BoundParameterList     = $PSBoundParameters
+            # Individual properties for TCP/IP.
+            MutuallyExclusiveList1 = @(
+                'KeepAlive'
+                'ListenOnAllIpAddresses'
+            )
+            # Individual properties for Named Pipes.
+            MutuallyExclusiveList2 = @(
+                'PipeName'
+            )
+        }
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    $getTargetResourceParameters = @{
+        InstanceName    = $InstanceName
+        ProtocolName    = $ProtocolName
+        ServerName      = $ServerName
+        SuppressRestart = $SuppressRestart
+        RestartTimeout  = $RestartTimeout
+    }
+
+    <#
+        We remove any parameters not passed by $PSBoundParameters so that
+        Get-TargetResource can also evaluate $PSBoundParameters correctly.
+
+        Need the @() around the Keys property to get a new array to enumerate.
+    #>
+    @($getTargetResourceParameters.Keys) | ForEach-Object {
+        if (-not $PSBoundParameters.ContainsKey($_))
+        {
+            $getTargetResourceParameters.Remove($_)
+        }
+    }
+
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+    $propertiesToEvaluate = @(
+        'Enabled'
+    )
+
+    # Get individual protocol properties to evaluate.
+    switch ($ProtocolName)
+    {
+        'TcpIp'
+        {
+            $propertiesToEvaluate += 'ListenOnAllIpAddresses'
+            $propertiesToEvaluate += 'KeepAlive'
+        }
+
+        'NamedPipes'
+        {
+            $propertiesToEvaluate += 'PipeName'
+        }
+
+        'SharedMemory'
+        {
+            <#
+                Left blank intentionally. There are no individual protocol
+                properties for the protocol Shared Memory.
+            #>
+        }
+    }
+
+    $compareTargetResourceStateParameters = @{
+        CurrentValues = $getTargetResourceResult
+        DesiredValues = $PSBoundParameters
+        Properties    = $propertiesToEvaluate
+    }
+
+    return Compare-ResourcePropertyState @compareTargetResourceStateParameters
+}
+
+<#
+    .SYNOPSIS
+        Get static name properties of he specified protocol.
+
+    .PARAMETER ProtocolName
+        Specifies the name of network protocol to return name properties for.
+        Possible values are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
+
+    .NOTES
+        The static values returned matches the values returned by the class
+        ServerProtocol. The property DisplayName could potentially be localized
+        while the property Name must be exactly like it is returned by the
+        class ServerProtocol, with the correct casing.
+
+#>
+function Get-ProtocolNameProperties
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('TcpIp', 'NamedPipes', 'SharedMemory')]
+        [System.String]
+        $ProtocolName
+    )
+
+    $protocolNameProperties = @{ }
+
+    switch ($ProtocolName)
+    {
+        'TcpIp'
+        {
+            $protocolNameProperties.DisplayName = 'TCP/IP'
+            $protocolNameProperties.Name = 'Tcp'
+        }
+
+        'NamedPipes'
+        {
+            $protocolNameProperties.DisplayName = 'Named Pipes'
+            $protocolNameProperties.Name = 'Np'
+        }
+
+        'SharedMemory'
+        {
+            $protocolNameProperties.DisplayName = 'Shared Memory'
+            $protocolNameProperties.Name = 'Sm'
+        }
+    }
+
+    return $protocolNameProperties
+}
+
+<#
+    .SYNOPSIS
+        Returns the ServerProtocol object for the specified SQL Server instance
+        and protocol name.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL Server instance to connect to.
+
+    .PARAMETER ProtocolName
+        Specifies the name of network protocol to be configured. Possible values
+        are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to connect to.
+
+    .NOTES
+        The class Microsoft.SqlServer.Management.Smo.Wmi.ServerProtocol is
+        returned by this function.
+#>
+function Get-ServerProtocolObject
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('TcpIp', 'NamedPipes', 'SharedMemory')]
+        [System.String]
+        $ProtocolName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName
+    )
+
+    $serverProtocolProperties = $null
+
+    $newObjectParameters = @{
+        TypeName     = 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer'
+        ArgumentList = @($ServerName)
+    }
+
+    $managedComputerObject = New-Object @newObjectParameters
+
+    $serverInstance = $managedComputerObject.ServerInstances[$InstanceName]
+
+    if ($serverInstance)
+    {
+        $protocolNameProperties = Get-ProtocolNameProperties -ProtocolName $ProtocolName
+
+        $serverProtocolProperties = $serverInstance.ServerProtocols[$protocolNameProperties.Name]
+    }
+
+    return $serverProtocolProperties
+}

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -21,6 +21,21 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER ServerName
         Specifies the host name of the SQL Server to be configured. Default value is
         $env:COMPUTERNAME.
+
+    .PARAMETER SuppressRestart
+        If set to $true then the any attempt by the resource to restart the service
+        is suppressed. The default value is $false.
+
+    .PARAMETER RestartTimeout
+        Timeout value for restarting the SQL Server services. The default value
+        is 120 seconds.
+
+    .NOTES
+        The parameters SuppressRestart and RestartTimeout are part of the function
+        Get-TargetResource to be able to return the value that the configuration
+        have set, or the default values if not. If they weren't passed to the
+        function Get-TargetResource we would have to always return $null which
+        would indicate that they are not set at all.
 #>
 function Get-TargetResource
 {
@@ -149,7 +164,7 @@ function Get-TargetResource
         ignored for all other protocols.
 
     .PARAMETER SuppressRestart
-        If set to $true then the any attempt by the resource to restart the services
+        If set to $true then the any attempt by the resource to restart the service
         is suppressed. The default value is $false.
 
     .PARAMETER RestartTimeout
@@ -369,7 +384,7 @@ function Set-TargetResource
         ignored for all other protocols.
 
     .PARAMETER SuppressRestart
-        If set to $true then the any attempt by the resource to restart the services
+        If set to $true then the any attempt by the resource to restart the service
         is suppressed. The default value is $false.
 
     .PARAMETER RestartTimeout
@@ -482,7 +497,7 @@ function Test-TargetResource
         ignored for all other protocols.
 
     .PARAMETER SuppressRestart
-        If set to $true then the any attempt by the resource to restart the services
+        If set to $true then the any attempt by the resource to restart the service
         is suppressed. The default value is $false.
 
     .PARAMETER RestartTimeout

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -92,13 +92,13 @@ function Get-TargetResource
         {
             'TcpIp'
             {
-                $returnValue.ListenOnAllIpAddresses = $serverProtocolProperties.ProtocolProperties.ListenOnAllIPs
-                $returnValue.KeepAlive = $serverProtocolProperties.ProtocolProperties.KeepAlive
+                $returnValue.ListenOnAllIpAddresses = $serverProtocolProperties.ProtocolProperties['ListenOnAllIPs'].Value
+                $returnValue.KeepAlive = $serverProtocolProperties.ProtocolProperties['KeepAlive'].Value
             }
 
             'NamedPipes'
             {
-                $returnValue.PipeName = $serverProtocolProperties.ProtocolProperties.PipeName
+                $returnValue.PipeName = $serverProtocolProperties.ProtocolProperties['PipeName'].Value
             }
 
             'SharedMemory'

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -19,8 +19,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
         are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
 
     .PARAMETER ServerName
-        Specifies the host name of the SQL Server to be configured. Default value is
-        $env:COMPUTERNAME.
+        Specifies the host name of the SQL Server to be configured. If the SQL
+        Server belongs to a cluster or availability group specify the host name
+        for the listener or cluster group. Default value is `$env:COMPUTERNAME`.
 
     .PARAMETER SuppressRestart
         If set to $true then the any attempt by the resource to restart the service
@@ -145,8 +146,9 @@ function Get-TargetResource
         are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
 
     .PARAMETER ServerName
-        Specifies the host name of the SQL Server to be configured. Default value is
-        $env:COMPUTERNAME.
+        Specifies the host name of the SQL Server to be configured. If the SQL
+        Server belongs to a cluster or availability group specify the host name
+        for the listener or cluster group. Default value is `$env:COMPUTERNAME`.
 
     .PARAMETER Enabled
         Specifies if the protocol should be enabled or disabled.
@@ -365,8 +367,9 @@ function Set-TargetResource
         are 'TcpIp', 'NamedPipes', or 'ShareMemory'.
 
     .PARAMETER ServerName
-        Specifies the host name of the SQL Server to be configured. Default value is
-        $env:COMPUTERNAME.
+        Specifies the host name of the SQL Server to be configured. If the SQL
+        Server belongs to a cluster or availability group specify the host name
+        for the listener or cluster group. Default value is `$env:COMPUTERNAME`.
 
     .PARAMETER Enabled
         Specifies if the protocol should be enabled or disabled.

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -1,11 +1,10 @@
-$script:resourceModulePath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
-$script:modulesFolderPath = Join-Path -Path $script:resourceModulePath -ChildPath 'Modules'
+$script:sqlServerDscHelperModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\SqlServerDsc.Common'
+$script:resourceHelperModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\DscResource.Common'
 
-$script:resourceHelperModulePath = Join-Path -Path $script:modulesFolderPath -ChildPath 'SqlServerDsc.Common'
-Import-Module -Name (Join-Path -Path $script:resourceHelperModulePath -ChildPath 'SqlServerDsc.Common.psm1')
+Import-Module -Name $script:sqlServerDscHelperModulePath
+Import-Module -Name $script:resourceHelperModulePath
 
-# Load localized string data
-$script:localizedData = Get-LocalizedData -ResourceName 'DSC_SqlServerProtocol'
+$script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
 <#
     .SYNOPSIS

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.psm1
@@ -149,8 +149,8 @@ function Get-TargetResource
         ignored for all other protocols.
 
     .PARAMETER SuppressRestart
-        If set to $true then SQL Server and dependent services will be restarted
-        if a change to the configuration is made. The default value is $false.
+        If set to $true then the any attempt by the resource to restart the services
+        is suppressed. The default value is $false.
 
     .PARAMETER RestartTimeout
         Timeout value for restarting the SQL Server services. The default value
@@ -369,8 +369,8 @@ function Set-TargetResource
         ignored for all other protocols.
 
     .PARAMETER SuppressRestart
-        If set to $true then SQL Server and dependent services will be restarted
-        if a change to the configuration is made. The default value is $false.
+        If set to $true then the any attempt by the resource to restart the services
+        is suppressed. The default value is $false.
 
     .PARAMETER RestartTimeout
         Timeout value for restarting the SQL Server services. The default value
@@ -481,9 +481,9 @@ function Test-TargetResource
         Specifies the name of the named pipe. Only used for the Named Pipes protocol,
         ignored for all other protocols.
 
-    .PARAMETER RestartTimeout
-        If set to $true then SQL Server and dependent services will be restarted
-        if a change to the configuration is made. The default value is $false.
+    .PARAMETER SuppressRestart
+        If set to $true then the any attempt by the resource to restart the services
+        is suppressed. The default value is $false.
 
     .PARAMETER RestartTimeout
         Timeout value for restarting the SQL Server services. The default value

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
@@ -8,7 +8,7 @@ class DSC_SqlServerProtocol : OMI_BaseResource
     [Write, Description("Specifies to listen on all IP addresses. Only used for the TCP/IP protocol, ignored for all other protocols.")] Boolean ListenOnAllIpAddresses;
     [Write, Description("Specifies the keep alive duration in milliseconds. Only used for the TCP/IP protocol, ignored for all other protocols.")] UInt16 KeepAlive;
     [Write, Description("Specifies the name of the named pipe. Only used for the Named Pipes protocol, ignored for all other protocols.")] String PipeName;
-    [Write, Description("If set to $true then the any attempt by the resource to restart the services is suppressed. The default value is $false.")] Boolean SuppressRestart;
+    [Write, Description("If set to $true then the any attempt by the resource to restart the service is suppressed. The default value is $false.")] Boolean SuppressRestart;
     [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
     [Read, Description("Returns $true or $false whether the instance has multiple IP addresses or not.")] Boolean HasMultiIPAddresses;
 };

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
@@ -1,14 +1,14 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SqlServerProtocol")]
-class MSFT_SqlServerProtocol : OMI_BaseResource
+class DSC_SqlServerProtocol : OMI_BaseResource
 {
     [Key, Description("Specifies the name of the SQL Server instance to enable the protocol for.")] String InstanceName;
     [Key, Description("Specifies the name of network protocol to be configured. Possible values are 'TcpIp', 'NamedPipes', or 'ShareMemory'."), ValueMap{"SharedMemory", "NamedPipes", "TcpIp"}, Values{"SharedMemory", "NamedPipes", "TcpIp"}] String ProtocolName;
     [Write, Description("Specifies the host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Write, Description("Specifies if the protocol should be enabled or disabled.")] Boolean Enabled;
     [Write, Description("Specifies to listen on all IP addresses. Only used for the TCP/IP protocol, ignored for all other protocols.")] Boolean ListenOnAllIpAddresses;
-    [Write, Description("Specifies the keep alive duration. Only used for the TCP/IP protocol, ignored for all other protocols.")] UInt16 KeepAlive;
+    [Write, Description("Specifies the keep alive duration in milliseconds. Only used for the TCP/IP protocol, ignored for all other protocols.")] UInt16 KeepAlive;
     [Write, Description("Specifies the name of the named pipe. Only used for the Named Pipes protocol, ignored for all other protocols.")] String PipeName;
     [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.")] Boolean SuppressRestart;
     [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
     [Read, Description("Returns $true or $false whether the instance has multiple IP addresses or not.")] Boolean HasMultiIPAddresses;
-}
+};

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
@@ -1,0 +1,14 @@
+[ClassVersion("1.0.0.0"), FriendlyName("SqlServerProtocol")]
+class MSFT_SqlServerProtocol : OMI_BaseResource
+{
+    [Key, Description("Specifies the name of the SQL Server instance to enable the protocol for.")] String InstanceName;
+    [Key, Description("Specifies the name of network protocol to be configured. Possible values are 'TcpIp', 'NamedPipes', or 'ShareMemory'."), ValueMap{"SharedMemory", "NamedPipes", "TcpIp"}, Values{"SharedMemory", "NamedPipes", "TcpIp"}] String ProtocolName;
+    [Write, Description("Specifies the host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
+    [Write, Description("Specifies if the protocol should be enabled or disabled.")] Boolean Enabled;
+    [Write, Description("Specifies to listen on all IP addresses. Only used for the TCP/IP protocol, ignored for all other protocols.")] Boolean ListenOnAllIpAddresses;
+    [Write, Description("Specifies the keep alive duration. Only used for the TCP/IP protocol, ignored for all other protocols.")] UInt16 KeepAlive;
+    [Write, Description("Specifies the name of the named pipe. Only used for the Named Pipes protocol, ignored for all other protocols.")] String PipeName;
+    [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.")] Boolean SuppressRestart;
+    [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
+    [Read, Description("Returns $true or $false whether the instance has multiple IP addresses or not.")] Boolean HasMultiIPAddresses;
+}

--- a/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
+++ b/source/DSCResources/DSC_SqlServerProtocol/DSC_SqlServerProtocol.schema.mof
@@ -3,12 +3,12 @@ class DSC_SqlServerProtocol : OMI_BaseResource
 {
     [Key, Description("Specifies the name of the SQL Server instance to enable the protocol for.")] String InstanceName;
     [Key, Description("Specifies the name of network protocol to be configured. Possible values are 'TcpIp', 'NamedPipes', or 'ShareMemory'."), ValueMap{"SharedMemory", "NamedPipes", "TcpIp"}, Values{"SharedMemory", "NamedPipes", "TcpIp"}] String ProtocolName;
-    [Write, Description("Specifies the host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
+    [Write, Description("Specifies the host name of the SQL Server to be configured. If the SQL Server belongs to a cluster or availability group specify the host name for the listener or cluster group. Default value is $env:COMPUTERNAME.")] String ServerName;
     [Write, Description("Specifies if the protocol should be enabled or disabled.")] Boolean Enabled;
     [Write, Description("Specifies to listen on all IP addresses. Only used for the TCP/IP protocol, ignored for all other protocols.")] Boolean ListenOnAllIpAddresses;
     [Write, Description("Specifies the keep alive duration in milliseconds. Only used for the TCP/IP protocol, ignored for all other protocols.")] UInt16 KeepAlive;
     [Write, Description("Specifies the name of the named pipe. Only used for the Named Pipes protocol, ignored for all other protocols.")] String PipeName;
-    [Write, Description("If set to $true then SQL Server and dependent services will be restarted if a change to the configuration is made. The default value is $false.")] Boolean SuppressRestart;
+    [Write, Description("If set to $true then the any attempt by the resource to restart the services is suppressed. The default value is $false.")] Boolean SuppressRestart;
     [Write, Description("Timeout value for restarting the SQL Server services. The default value is 120 seconds.")] UInt16 RestartTimeout;
     [Read, Description("Returns $true or $false whether the instance has multiple IP addresses or not.")] Boolean HasMultiIPAddresses;
 };

--- a/source/DSCResources/DSC_SqlServerProtocol/README.md
+++ b/source/DSCResources/DSC_SqlServerProtocol/README.md
@@ -6,4 +6,16 @@ for a SQL Server instance.
 ## Requirements
 
 * Target machine must be running Windows Server 2012 or later.
-* Target machine must be running SQL Server 2012 or later.
+* Target machine must be running SQL Server Database Engine 2012 or later.
+* Target machine must have access to the SQLPS PowerShell module or the SqlServer
+  PowerShell module.
+* If a protocol is disabled that prevents the cmdlet `Restart-SqlService` to
+  contact the instance to evaluate if it is a cluster then the parameter
+  `SuppressRestart` must be used to override the restart. Same if a protocol
+  is enabled that was previously disabled and no other protocol allows
+  connecting to the instance then the parameter `SuppressRestart` must also
+  be used.
+* When connecting to a Failover Cluster where the account `SYSTEM` does
+  not have access then the correct credential must be provided in
+  the built-in parameter `PSDscRunAsCredential`. If not the following error
+  can appear; `An internal error occurred`.

--- a/source/DSCResources/DSC_SqlServerProtocol/README.md
+++ b/source/DSCResources/DSC_SqlServerProtocol/README.md
@@ -1,6 +1,6 @@
 # Description
 
-The `SqlServerProtocol` DSC resource will manage the SQL Server protocols
+The `SqlServerProtocol` DSC resource manage the SQL Server protocols
 for a SQL Server instance.
 
 ## Requirements

--- a/source/DSCResources/DSC_SqlServerProtocol/README.md
+++ b/source/DSCResources/DSC_SqlServerProtocol/README.md
@@ -1,0 +1,9 @@
+# Description
+
+The `SqlServerProtocol` DSC resource will manage the SQL Server protocols
+for a SQL Server instance.
+
+## Requirements
+
+* Target machine must be running Windows Server 2012 or later.
+* Target machine must be running SQL Server 2012 or later.

--- a/source/DSCResources/DSC_SqlServerProtocol/en-US/DSC_SqlServerProtocol.strings.psd1
+++ b/source/DSCResources/DSC_SqlServerProtocol/en-US/DSC_SqlServerProtocol.strings.psd1
@@ -1,0 +1,12 @@
+ConvertFrom-StringData @'
+    GetCurrentState = Getting the current state of the protocol '{0}' for the instance '{1}' on the server '{2}'. (SSP0001)
+    SetDesiredState = Setting the desired state for the protocol '{0}' on the instance '{1}'. (SSP0002)
+    ProtocolIsInDesiredState = The protocol '{0}' on the instance '{1}' is already in desired state. (SSP0002)
+    ProtocolHasBeenEnabled = The protocol '{0}' has been enabled on the SQL Server instance '{1}'. (SSP0003)
+    ProtocolHasBeenDisabled = The protocol '{0}' has been disabled on the SQL Server instance '{1}'. (SSP0004)
+    ParameterHasBeenSetToNewValue = The parameter '{0}' for the protocol '{1}' has been set to the value '{2}'. (SSP0005)
+    RestartSuppressed = The restart was suppressed. The configuration will not be active until the node is manually restart. (SSP0006)
+    TestDesiredState = Determining the current state of the protocol '{0}' for the instance '{1}' on the server '{2}'. (SSP0001)
+    NotInDesiredState = The protocol '{0}' for the instance '{1}' is not in desired state. (SSP0007)
+    InDesiredState = The protocol '{0}' for the instance '{1}' is in desired state. (SSP0008)
+'@

--- a/source/DSCResources/DSC_SqlServerProtocol/en-US/DSC_SqlServerProtocol.strings.psd1
+++ b/source/DSCResources/DSC_SqlServerProtocol/en-US/DSC_SqlServerProtocol.strings.psd1
@@ -9,4 +9,5 @@ ConvertFrom-StringData @'
     TestDesiredState = Determining the current state of the protocol '{0}' for the instance '{1}' on the server '{2}'. (SSP0001)
     NotInDesiredState = The protocol '{0}' for the instance '{1}' is not in desired state. (SSP0007)
     InDesiredState = The protocol '{0}' for the instance '{1}' is in desired state. (SSP0008)
+    FailedToGetSqlServerProtocol = Failed to get the settings for the SQL Server Database Engine server protocol TCP/IP. (SSP0009)
 '@

--- a/source/Examples/Resources/SqlServerProtocol/1-EnableTcpIp.ps1
+++ b/source/Examples/Resources/SqlServerProtocol/1-EnableTcpIp.ps1
@@ -1,0 +1,32 @@
+<#
+    .DESCRIPTION
+        This example will enable the TCP/IP protocol, set the protocol to listen
+        on all IP addresses, and set the keep alive duration.
+
+        The resource will be run as the account provided in $SystemAdministratorAccount.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SystemAdministratorAccount
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerProtocol 'ChangeTcpIpOnDefaultInstance'
+        {
+            InstanceName           = 'MSSQLSERVER'
+            ProtocolName           = 'TcpIp'
+            Enabled                = $true
+            ListenOnAllIpAddresses = $false
+            KeepAlive              = 20000
+
+            PsDscRunAsCredential   = $SystemAdministratorAccount
+        }
+    }
+}

--- a/source/Examples/Resources/SqlServerProtocol/2-EnableNamedPipes.ps1
+++ b/source/Examples/Resources/SqlServerProtocol/2-EnableNamedPipes.ps1
@@ -1,0 +1,30 @@
+<#
+    .DESCRIPTION
+        This example will enable the Named Pipes protocol and set the name of the pipe.
+
+        The resource will be run as the account provided in $SystemAdministratorAccount.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SystemAdministratorAccount
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerProtocol 'ChangeTcpIpOnDefaultInstance'
+        {
+            InstanceName         = 'MSSQLSERVER'
+            ProtocolName         = 'NamedPipes'
+            Enabled              = $true
+            PipeName             = '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query'
+
+            PsDscRunAsCredential = $SystemAdministratorAccount
+        }
+    }
+}

--- a/source/Examples/Resources/SqlServerProtocol/3-EnableSharedMemory.ps1
+++ b/source/Examples/Resources/SqlServerProtocol/3-EnableSharedMemory.ps1
@@ -1,0 +1,29 @@
+<#
+    .DESCRIPTION
+        This example will enable the Shared Memory protocol.
+
+        The resource will be run as the account provided in $SystemAdministratorAccount.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SystemAdministratorAccount
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerProtocol 'ChangeTcpIpOnDefaultInstance'
+        {
+            InstanceName         = 'MSSQLSERVER'
+            ProtocolName         = 'SharedMemory'
+            Enabled              = $true
+
+            PsDscRunAsCredential = $SystemAdministratorAccount
+        }
+    }
+}

--- a/source/Examples/Resources/SqlServerProtocol/4-DisableTcpIp.ps1
+++ b/source/Examples/Resources/SqlServerProtocol/4-DisableTcpIp.ps1
@@ -1,0 +1,29 @@
+<#
+    .DESCRIPTION
+        This example will disable the TCP/IP protocol.
+
+        The resource will be run as the account provided in $SystemAdministratorAccount.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SystemAdministratorAccount
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerProtocol 'ChangeTcpIpOnDefaultInstance'
+        {
+            InstanceName           = 'MSSQLSERVER'
+            ProtocolName           = 'TcpIp'
+            Enabled                = $false
+
+            PsDscRunAsCredential   = $SystemAdministratorAccount
+        }
+    }
+}

--- a/source/Examples/Resources/SqlServerProtocol/5-DisableNamedPipes.ps1
+++ b/source/Examples/Resources/SqlServerProtocol/5-DisableNamedPipes.ps1
@@ -1,0 +1,29 @@
+<#
+    .DESCRIPTION
+        This example will disable the Named Pipes protocol.
+
+        The resource will be run as the account provided in $SystemAdministratorAccount.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SystemAdministratorAccount
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerProtocol 'ChangeTcpIpOnDefaultInstance'
+        {
+            InstanceName           = 'MSSQLSERVER'
+            ProtocolName           = 'NamedPipes'
+            Enabled                = $false
+
+            PsDscRunAsCredential   = $SystemAdministratorAccount
+        }
+    }
+}

--- a/source/Examples/Resources/SqlServerProtocol/6-DisableSharedMemory.ps1
+++ b/source/Examples/Resources/SqlServerProtocol/6-DisableSharedMemory.ps1
@@ -1,0 +1,29 @@
+<#
+    .DESCRIPTION
+        This example will disable the Shared Memory protocol.
+
+        The resource will be run as the account provided in $SystemAdministratorAccount.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SystemAdministratorAccount
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlServerProtocol 'ChangeTcpIpOnDefaultInstance'
+        {
+            InstanceName           = 'MSSQLSERVER'
+            ProtocolName           = 'SharedMemory'
+            Enabled                = $false
+
+            PsDscRunAsCredential   = $SystemAdministratorAccount
+        }
+    }
+}

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
@@ -47,6 +47,8 @@
         'Invoke-SqlScript'
         'Get-ServiceAccount'
         'Find-ExceptionByNumber'
+        'Compare-ResourcePropertyState'
+        'Test-DscPropertyState'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -988,7 +988,7 @@ function Restart-SqlService
                 else
                 {
                     Write-Verbose -Message (
-                        $script:localizedData.NotOwnerOfClusterResource -f $ServerName, $sqlService.Name, $sqlService.OwnerNode
+                        $script:localizedData.NotOwnerOfClusterResource -f $env:COMPUTERNAME, $sqlService.Name, $sqlService.OwnerNode
                     ) -Verbose
                 }
             }

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -976,6 +976,7 @@ function Restart-SqlService
                                 Invoke-CimMethod -MethodName BringOnline -Arguments @{
                                     Timeout = $Timeout
                                 }
+                        }
                         else
                         {
                             Write-Verbose -Message (
@@ -1020,12 +1021,13 @@ function Restart-SqlService
         }
 
         Write-Verbose -Message ($script:localizedData.GetServiceInformation -f 'SQL Server') -Verbose
+
         $sqlService = Get-Service -Name $serviceName
 
         <#
-                    Get all dependent services that are running.
-                    There are scenarios where an automatic service is stopped and should not be restarted automatically.
-                #>
+            Get all dependent services that are running.
+            There are scenarios where an automatic service is stopped and should not be restarted automatically.
+        #>
         $agentService = $sqlService.DependentServices |
             Where-Object -FilterScript { $_.Status -eq 'Running' }
 

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -981,7 +981,7 @@ function Restart-SqlService
                         {
                             Write-Verbose -Message (
                                 $script:localizedData.NotOwnerOfClusterResource -f $ServerName, $agentService.Name, $agentService.OwnerNode
-                            )
+                            ) -Verbose
                         }
                     }
                 }
@@ -989,7 +989,7 @@ function Restart-SqlService
                 {
                     Write-Verbose -Message (
                         $script:localizedData.NotOwnerOfClusterResource -f $ServerName, $sqlService.Name, $sqlService.OwnerNode
-                    )
+                    ) -Verbose
                 }
             }
             else

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -147,12 +147,14 @@ function Copy-ItemWithRobocopy
         Write-Verbose -Message $script:localizedData.RobocopyNotUsingUnbufferedIo -Verbose
     }
 
-    $robocopyArgumentList = '{0} {1} {2} {3} {4} {5}' -f $quotedPath,
-    $quotedDestinationPath,
-    $robocopyArgumentCopySubDirectoriesIncludingEmpty,
-    $robocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-    $robocopyArgumentUseUnbufferedIO,
-    $robocopyArgumentSilent
+    $robocopyArgumentList = '{0} {1} {2} {3} {4} {5}' -f @(
+        $quotedPath,
+        $quotedDestinationPath,
+        $robocopyArgumentCopySubDirectoriesIncludingEmpty,
+        $robocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+        $robocopyArgumentUseUnbufferedIO,
+        $robocopyArgumentSilent
+    )
 
     $robocopyStartProcessParameters = @{
         FilePath     = $robocopyExecutable.Name

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -45,7 +45,7 @@ function Get-RegistryPropertyValue
     }
     catch
     {
-         $getItemPropertyResult = $null
+        $getItemPropertyResult = $null
     }
 
     return $getItemPropertyResult
@@ -148,14 +148,14 @@ function Copy-ItemWithRobocopy
     }
 
     $robocopyArgumentList = '{0} {1} {2} {3} {4} {5}' -f $quotedPath,
-                                                         $quotedDestinationPath,
-                                                         $robocopyArgumentCopySubDirectoriesIncludingEmpty,
-                                                         $robocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
-                                                         $robocopyArgumentUseUnbufferedIO,
-                                                         $robocopyArgumentSilent
+    $quotedDestinationPath,
+    $robocopyArgumentCopySubDirectoriesIncludingEmpty,
+    $robocopyArgumentDeletesDestinationFilesAndDirectoriesNotExistAtSource,
+    $robocopyArgumentUseUnbufferedIO,
+    $robocopyArgumentSilent
 
     $robocopyStartProcessParameters = @{
-        FilePath = $robocopyExecutable.Name
+        FilePath     = $robocopyExecutable.Name
         ArgumentList = $robocopyArgumentList
     }
 
@@ -164,13 +164,13 @@ function Copy-ItemWithRobocopy
 
     switch ($($robocopyProcess.ExitCode))
     {
-        {$_ -in 8, 16}
+        { $_ -in 8, 16 }
         {
             $errorMessage = $script:localizedData.RobocopyErrorCopying -f $_
             New-InvalidOperationException -Message $errorMessage
         }
 
-        {$_ -gt 7 }
+        { $_ -gt 7 }
         {
             $errorMessage = $script:localizedData.RobocopyFailuresCopying -f $_
             New-InvalidResultException -Message $errorMessage
@@ -193,7 +193,7 @@ function Copy-ItemWithRobocopy
             ) -Verbose
         }
 
-        {$_ -eq 0 -or $null -eq $_ }
+        { $_ -eq 0 -or $null -eq $_ }
         {
             Write-Verbose -Message $script:localizedData.RobocopyAllFilesPresent -Verbose
         }
@@ -398,7 +398,7 @@ function Start-SqlSetupProcess
     )
 
     $startProcessParameters = @{
-        FilePath = $FilePath
+        FilePath     = $FilePath
         ArgumentList = $ArgumentList
     }
 
@@ -457,28 +457,28 @@ function Start-SqlSetupProcess
 #>
 function Connect-SQL
 {
-    [CmdletBinding(DefaultParameterSetName='SqlServer')]
+    [CmdletBinding(DefaultParameterSetName = 'SqlServer')]
     param
     (
-        [Parameter(ParameterSetName='SqlServer')]
-        [Parameter(ParameterSetName='SqlServerWithCredential')]
+        [Parameter(ParameterSetName = 'SqlServer')]
+        [Parameter(ParameterSetName = 'SqlServerWithCredential')]
         [ValidateNotNull()]
         [System.String]
         $ServerName = $env:COMPUTERNAME,
 
-        [Parameter(ParameterSetName='SqlServer')]
-        [Parameter(ParameterSetName='SqlServerWithCredential')]
+        [Parameter(ParameterSetName = 'SqlServer')]
+        [Parameter(ParameterSetName = 'SqlServerWithCredential')]
         [ValidateNotNull()]
         [System.String]
         $InstanceName = 'MSSQLSERVER',
 
-        [Parameter(ParameterSetName='SqlServerWithCredential', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'SqlServerWithCredential', Mandatory = $true)]
         [ValidateNotNull()]
         [Alias('DatabaseCredential')]
         [System.Management.Automation.PSCredential]
         $SetupCredential,
 
-        [Parameter(ParameterSetName='SqlServerWithCredential')]
+        [Parameter(ParameterSetName = 'SqlServerWithCredential')]
         [ValidateSet('WindowsUser', 'SqlLogin')]
         [System.String]
         $LoginType = 'WindowsUser',
@@ -500,7 +500,7 @@ function Connect-SQL
         $databaseEngineInstance = '{0}\{1}' -f $ServerName, $InstanceName
     }
 
-    $sqlServerObject  = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+    $sqlServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
     $sqlConnectionContext = $sqlServerObject.ConnectionContext
     $sqlConnectionContext.ServerInstance = $databaseEngineInstance
     $sqlConnectionContext.StatementTimeout = $StatementTimeout
@@ -719,7 +719,7 @@ function Import-SQLPSModule
     if ($Force.IsPresent)
     {
         Write-Verbose -Message $script:localizedData.ModuleForceRemoval -Verbose
-        Remove-Module -Name @('SqlServer','SQLPS','SQLASCmdlets') -Force -ErrorAction SilentlyContinue
+        Remove-Module -Name @('SqlServer', 'SQLPS', 'SQLASCmdlets') -Force -ErrorAction SilentlyContinue
     }
 
     <#
@@ -740,7 +740,7 @@ function Import-SQLPSModule
     # Get the newest SqlServer module if more than one exist
     $availableModule = Get-Module -FullyQualifiedName 'SqlServer' -ListAvailable |
         Sort-Object -Property 'Version' -Descending |
-        Select-Object -First 1 -Property Name, Path, Version
+            Select-Object -First 1 -Property Name, Path, Version
 
     if ($availableModule)
     {
@@ -764,14 +764,14 @@ function Import-SQLPSModule
         #>
         $availableModule = Get-Module -FullyQualifiedName 'SQLPS' -ListAvailable |
             Select-Object -Property Name, Path, @{
-                Name = 'Version'
+                Name       = 'Version'
                 Expression = {
                     # Parse the build version number '120', '130' from the Path.
                     (Select-String -InputObject $_.Path -Pattern '\\([0-9]{3})\\' -List).Matches.Groups[1].Value
                 }
             } |
-            Sort-Object -Property 'Version' -Descending |
-            Select-Object -First 1
+                Sort-Object -Property 'Version' -Descending |
+                    Select-Object -First 1
 
         if ($availableModule)
         {
@@ -904,106 +904,106 @@ function Restart-SqlService
             $agentService = $sqlService | Get-CimAssociatedInstance -ResultClassName MSCluster_Resource |
                 Where-Object -FilterScript { ($_.Type -eq 'SQL Server Agent') -and ($_.State -eq 2) }
 
-            # Build a listing of resources being acted upon
-            $resourceNames = @($sqlService.Name, ($agentService | Select-Object -ExpandProperty Name)) -join ","
+        # Build a listing of resources being acted upon
+        $resourceNames = @($sqlService.Name, ($agentService | Select-Object -ExpandProperty Name)) -join ","
 
-            # Stop the SQL Server and dependent resources
-            Write-Verbose -Message ($script:localizedData.BringClusterResourcesOffline -f $resourceNames) -Verbose
-            $sqlService | Invoke-CimMethod -MethodName TakeOffline -Arguments @{
-                Timeout = $Timeout
-            }
-
-            # Start the SQL server resource
-            Write-Verbose -Message ($script:localizedData.BringSqlServerClusterResourcesOnline) -Verbose
-            $sqlService | Invoke-CimMethod -MethodName BringOnline -Arguments @{
-                Timeout = $Timeout
-            }
-
-            # Start the SQL Agent resource
-            if ($agentService)
-            {
-                Write-Verbose -Message ($script:localizedData.BringSqlServerAgentClusterResourcesOnline) -Verbose
-                $agentService | Invoke-CimMethod -MethodName BringOnline -Arguments @{
-                    Timeout = $Timeout
-                }
-            }
+        # Stop the SQL Server and dependent resources
+        Write-Verbose -Message ($script:localizedData.BringClusterResourcesOffline -f $resourceNames) -Verbose
+        $sqlService | Invoke-CimMethod -MethodName TakeOffline -Arguments @{
+            Timeout = $Timeout
         }
-        else
+
+        # Start the SQL server resource
+        Write-Verbose -Message ($script:localizedData.BringSqlServerClusterResourcesOnline) -Verbose
+        $sqlService | Invoke-CimMethod -MethodName BringOnline -Arguments @{
+            Timeout = $Timeout
+        }
+
+        # Start the SQL Agent resource
+        if ($agentService)
         {
-            # Not a cluster, restart the Windows service.
-            $restartWindowsService = $true
+            Write-Verbose -Message ($script:localizedData.BringSqlServerAgentClusterResourcesOnline) -Verbose
+            $agentService | Invoke-CimMethod -MethodName BringOnline -Arguments @{
+                Timeout = $Timeout
+            }
         }
     }
     else
     {
-        # Should not check if a cluster, assume that a Windows service should be restarted.
+        # Not a cluster, restart the Windows service.
         $restartWindowsService = $true
     }
+}
+else
+{
+    # Should not check if a cluster, assume that a Windows service should be restarted.
+    $restartWindowsService = $true
+}
 
-    if ($restartWindowsService)
+if ($restartWindowsService)
+{
+    if ($InstanceName -eq 'MSSQLSERVER')
     {
-        if ($InstanceName -eq 'MSSQLSERVER')
-        {
-            $serviceName = 'MSSQLSERVER'
-        }
-        else
-        {
-            $serviceName = 'MSSQL${0}' -f $InstanceName
-        }
+        $serviceName = 'MSSQLSERVER'
+    }
+    else
+    {
+        $serviceName = 'MSSQL${0}' -f $InstanceName
+    }
 
-        Write-Verbose -Message ($script:localizedData.GetServiceInformation -f 'SQL Server') -Verbose
-        $sqlService = Get-Service -Name $serviceName
+    Write-Verbose -Message ($script:localizedData.GetServiceInformation -f 'SQL Server') -Verbose
+    $sqlService = Get-Service -Name $serviceName
 
-        <#
+    <#
             Get all dependent services that are running.
             There are scenarios where an automatic service is stopped and should not be restarted automatically.
         #>
-        $agentService = $sqlService.DependentServices | Where-Object -FilterScript { $_.Status -eq 'Running' }
+    $agentService = $sqlService.DependentServices | Where-Object -FilterScript { $_.Status -eq 'Running' }
 
-        # Restart the SQL Server service
-        Write-Verbose -Message ($script:localizedData.RestartService -f 'SQL Server') -Verbose
-        $sqlService | Restart-Service -Force
+    # Restart the SQL Server service
+    Write-Verbose -Message ($script:localizedData.RestartService -f 'SQL Server') -Verbose
+    $sqlService | Restart-Service -Force
 
-        # Start dependent services
-        $agentService | ForEach-Object {
-            Write-Verbose -Message ($script:localizedData.StartingDependentService -f $_.DisplayName) -Verbose
-            $_ | Start-Service
-        }
+    # Start dependent services
+    $agentService | ForEach-Object {
+        Write-Verbose -Message ($script:localizedData.StartingDependentService -f $_.DisplayName) -Verbose
+        $_ | Start-Service
     }
+}
 
-    Write-Verbose -Message ($script:localizedData.WaitingInstanceTimeout -f $ServerName, $InstanceName, $Timeout) -Verbose
+Write-Verbose -Message ($script:localizedData.WaitingInstanceTimeout -f $ServerName, $InstanceName, $Timeout) -Verbose
 
-    if (-not $SkipWaitForOnline.IsPresent)
+if (-not $SkipWaitForOnline.IsPresent)
+{
+    $connectTimer = [System.Diagnostics.StopWatch]::StartNew()
+
+    do
     {
-        $connectTimer = [System.Diagnostics.StopWatch]::StartNew()
+        # This call, if it fails, will take between ~9-10 seconds to return.
+        $testConnectionServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction SilentlyContinue
 
-        do
+        # Make sure we have an SMO object to test Status
+        if ($testConnectionServerObject)
         {
-            # This call, if it fails, will take between ~9-10 seconds to return.
-            $testConnectionServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction SilentlyContinue
-
-            # Make sure we have an SMO object to test Status
-            if ($testConnectionServerObject)
+            if ($testConnectionServerObject.Status -eq 'Online')
             {
-                if ($testConnectionServerObject.Status -eq 'Online')
-                {
-                    break
-                }
+                break
             }
-
-            # Waiting 2 seconds to not hammer the SQL Server instance.
-            Start-Sleep -Seconds 2
-        } until ($connectTimer.Elapsed.Seconds -ge $Timeout)
-
-        $connectTimer.Stop()
-
-        # Was the timeout period reach before able to connect to the SQL Server instance?
-        if (-not $testConnectionServerObject -or $testConnectionServerObject.Status -ne 'Online')
-        {
-            $errorMessage = $script:localizedData.FailedToConnectToInstanceTimeout -f $ServerName, $InstanceName, $Timeout
-            New-InvalidOperationException -Message $errorMessage
         }
+
+        # Waiting 2 seconds to not hammer the SQL Server instance.
+        Start-Sleep -Seconds 2
+    } until ($connectTimer.Elapsed.Seconds -ge $Timeout)
+
+    $connectTimer.Stop()
+
+    # Was the timeout period reach before able to connect to the SQL Server instance?
+    if (-not $testConnectionServerObject -or $testConnectionServerObject.Status -ne 'Online')
+    {
+        $errorMessage = $script:localizedData.FailedToConnectToInstanceTimeout -f $ServerName, $InstanceName, $Timeout
+        New-InvalidOperationException -Message $errorMessage
     }
+}
 }
 
 <#
@@ -1150,15 +1150,15 @@ function Restart-ReportingServicesService
 #>
 function Invoke-Query
 {
-    [CmdletBinding(DefaultParameterSetName='SqlServer')]
+    [CmdletBinding(DefaultParameterSetName = 'SqlServer')]
     param
     (
-        [Parameter(ParameterSetName='SqlServer')]
+        [Parameter(ParameterSetName = 'SqlServer')]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $ServerName = $env:COMPUTERNAME,
 
-        [Parameter(ParameterSetName='SqlServer')]
+        [Parameter(ParameterSetName = 'SqlServer')]
         [System.String]
         $InstanceName = 'MSSQLSERVER',
 
@@ -1180,7 +1180,7 @@ function Invoke-Query
         [System.String]
         $LoginType = 'Integrated',
 
-        [Parameter(ValueFromPipeline, ParameterSetName='SqlObject', Mandatory = $true)]
+        [Parameter(ValueFromPipeline, ParameterSetName = 'SqlObject', Mandatory = $true)]
         [ValidateNotNull()]
         [Microsoft.SqlServer.Management.Smo.Server]
         $SqlServerObject,
@@ -1234,7 +1234,7 @@ function Invoke-Query
         #>
         $escapedRedactedString = [System.Text.RegularExpressions.Regex]::Escape($redactString)
 
-        $redactedQuery = $redactedQuery -ireplace $escapedRedactedString,'*******'
+        $redactedQuery = $redactedQuery -ireplace $escapedRedactedString, '*******'
     }
 
     if ($WithResults)
@@ -1413,7 +1413,7 @@ function Test-LoginEffectivePermissions
     {
         $loginMissingPermissions = Compare-Object -ReferenceObject $Permissions -DifferenceObject $loginEffectivePermissions |
             Where-Object -FilterScript { $_.SideIndicator -ne '=>' } |
-            Select-Object -ExpandProperty InputObject
+                Select-Object -ExpandProperty InputObject
 
         if ( $loginMissingPermissions.Count -eq 0 )
         {
@@ -1904,9 +1904,9 @@ function Get-ServiceAccount
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
         $ServiceAccount
-     )
+    )
 
-    $accountParameters = @{}
+    $accountParameters = @{ }
 
     switch -Regex ($ServiceAccount.UserName.ToUpper())
     {
@@ -1947,7 +1947,7 @@ function Get-ServiceAccount
 
 <#
     .SYNOPSIS
-    Recursevly searches Exception stack for specific error number.
+    Recursively searches Exception stack for specific error number.
 
     .PARAMETER ExceptionToSearch
     The Exception object to test
@@ -1991,4 +1991,230 @@ function Find-ExceptionByNumber
 
     # Return
     return $errorFound
+}
+
+<#
+    .SYNOPSIS
+        This function is used to compare current and desired values for any DSC
+        resource, and return a hashtable with the result from the comparison.
+
+    .PARAMETER CurrentValues
+        The current values that should be compared to to desired values. Normally
+        the values returned from Get-TargetResource.
+
+    .PARAMETER DesiredValues
+        The values set in the configuration and is provided in the call to the
+        functions *-TargetResource, and that will be compared against current
+        values. Normally set to $PSBoundParameters.
+
+    .PARAMETER Properties
+        An array of property names, from the keys provided in DesiredValues, that
+        will be compared. If this parameter is left out, all the keys in the
+        DesiredValues will be compared.
+#>
+function Compare-ResourcePropertyState
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable[]])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Hashtable]
+        $CurrentValues,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Hashtable]
+        $DesiredValues,
+
+        [Parameter()]
+        [System.String[]]
+        $Properties,
+
+        [Parameter()]
+        [System.String[]]
+        $IgnoreProperties
+    )
+
+    if ($PSBoundParameters.ContainsKey('Properties'))
+    {
+        # Filter out the parameters (keys) not specified in Properties
+        $desiredValuesToRemove = $DesiredValues.Keys |
+            Where-Object -FilterScript {
+                $_ -notin $Properties
+            }
+
+        $desiredValuesToRemove |
+            ForEach-Object -Process {
+                $DesiredValues.Remove($_)
+            }
+    }
+    else
+    {
+        <#
+            Remove any common parameters that might be part of DesiredValues,
+            if it $PSBoundParameters was used to pass the desired values.
+        #>
+        $commonParametersToRemove = $DesiredValues.Keys |
+            Where-Object -FilterScript {
+                $_ -in [System.Management.Automation.PSCmdlet]::CommonParameters `
+                    -or $_ -in [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+            }
+
+        $commonParametersToRemove |
+            ForEach-Object -Process {
+                $DesiredValues.Remove($_)
+            }
+    }
+
+    # Remove any properties that should be ignored.
+    if ($PSBoundParameters.ContainsKey('IgnoreProperties'))
+    {
+        $IgnoreProperties |
+            ForEach-Object -Process {
+                if ($DesiredValues.ContainsKey($_))
+                {
+                    $DesiredValues.Remove($_)
+                }
+            }
+    }
+
+    $compareTargetResourceStateReturnValue = @()
+
+    foreach ($parameterName in $DesiredValues.Keys)
+    {
+        Write-Verbose -Message ($script:localizedData.EvaluatePropertyState -f $parameterName) -Verbose
+
+        $parameterState = @{
+            ParameterName = $parameterName
+            Expected      = $DesiredValues.$parameterName
+            Actual        = $CurrentValues.$parameterName
+        }
+
+        # Check if the parameter is in compliance.
+        $isPropertyInDesiredState = Test-DscPropertyState -Values @{
+            CurrentValue = $CurrentValues.$parameterName
+            DesiredValue = $DesiredValues.$parameterName
+        }
+
+        if ($isPropertyInDesiredState)
+        {
+            Write-Verbose -Message ($script:localizedData.PropertyInDesiredState -f $parameterName) -Verbose
+
+            $parameterState['InDesiredState'] = $true
+        }
+        else
+        {
+            Write-Verbose -Message ($script:localizedData.PropertyNotInDesiredState -f $parameterName) -Verbose
+
+            $parameterState['InDesiredState'] = $false
+        }
+
+        $compareTargetResourceStateReturnValue += $parameterState
+    }
+
+    return $compareTargetResourceStateReturnValue
+}
+
+<#
+    .SYNOPSIS
+        This function is used to compare the current and the desired value of a
+        property.
+
+    .PARAMETER Values
+        This is set to a hash table with the current value (the CurrentValue key)
+        and desired value (the DesiredValue key).
+
+    .EXAMPLE
+        Test-DscPropertyState -Values @{
+            CurrentValue = 'John'
+            DesiredValue = 'Alice'
+        }
+
+    .EXAMPLE
+        Test-DscPropertyState -Values @{
+            CurrentValue = 1
+            DesiredValue = 2
+        }
+#>
+function Test-DscPropertyState
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Hashtable]
+        $Values
+    )
+
+    if ($null -eq $Values.CurrentValue -and $null -eq $Values.DesiredValue)
+    {
+        # Both values are $null so return $true
+        $returnValue = $true
+    }
+    elseif ($null -eq $Values.CurrentValue -or $null -eq $Values.DesiredValue)
+    {
+        # Either CurrentValue or DesiredValue are $null so return $false
+        $returnValue = $false
+    }
+    elseif ($Values.DesiredValue.GetType().IsArray -or $Values.CurrentValue.GetType().IsArray)
+    {
+        $compareObjectParameters = @{
+            ReferenceObject  = $Values.CurrentValue
+            DifferenceObject = $Values.DesiredValue
+        }
+
+        $arrayCompare = Compare-Object @compareObjectParameters
+
+        if ($null -ne $arrayCompare)
+        {
+            Write-Verbose -Message $script:localizedData.ArrayDoesNotMatch -Verbose
+
+            $arrayCompare |
+                ForEach-Object -Process {
+                    Write-Verbose -Message ($script:localizedData.ArrayValueThatDoesNotMatch -f `
+                            $_.InputObject, $_.SideIndicator) -Verbose
+                }
+
+            $returnValue = $false
+        }
+        else
+        {
+            $returnValue = $true
+        }
+    }
+    elseif ($Values.CurrentValue -ne $Values.DesiredValue)
+    {
+        $desiredType = $Values.DesiredValue.GetType()
+
+        $returnValue = $false
+
+        $supportedTypes = @(
+            'String'
+            'Int32'
+            'UInt32'
+            'Int16'
+            'UInt16'
+            'Single'
+            'Boolean'
+        )
+
+        if ($desiredType.Name -notin $supportedTypes)
+        {
+            Write-Warning -Message ($script:localizedData.UnableToCompareType -f $desiredType.Name)
+        }
+        else
+        {
+            Write-Verbose -Message (
+                $script:localizedData.PropertyValueOfTypeDoesNotMatch `
+                    -f $desiredType.Name, $Values.CurrentValue, $Values.DesiredValue
+            ) -Verbose
+        }
+    }
+    else
+    {
+        $returnValue = $true
+    }
+
+    return $returnValue
 }

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -905,6 +905,9 @@ function Restart-SqlService
         $OwnerNode
     )
 
+    $restartWindowsService = $true
+
+    # Check if a cluster, otherwise assume that a Windows service should be restarted.
     if (-not $SkipClusterCheck.IsPresent)
     {
         ## Connect to the instance
@@ -912,101 +915,25 @@ function Restart-SqlService
 
         if ($serverObject.IsClustered)
         {
-            # Get the cluster resources
-            Write-Verbose -Message ($script:localizedData.GetSqlServerClusterResources) -Verbose
+            # Make sure Windows service is not restarted outside of the cluster.
+            $restartWindowsService = $false
 
-            $sqlService = Get-CimInstance -Namespace 'root/MSCluster' -ClassName 'MSCluster_Resource' -Filter "Type = 'SQL Server'" |
-                Where-Object -FilterScript {
-                    $_.PrivateProperties.InstanceName -eq $serverObject.ServiceName -and $_.State -eq 2
-                }
-
-            # If the cluster resource is found and online then continue.
-            if ($sqlService)
-            {
-                $isOwnerOfClusterResource = $true
-
-                if ($PSBoundParameters.ContainsKey('OwnerNode') -and $sqlService.OwnerNode -notin $OwnerNode)
-                {
-                    $isOwnerOfClusterResource = $false
-                }
-
-                if ($isOwnerOfClusterResource)
-                {
-                    Write-Verbose -Message ($script:localizedData.GetSqlAgentClusterResource) -Verbose
-
-                    $agentService = $sqlService |
-                        Get-CimAssociatedInstance -ResultClassName MSCluster_Resource |
-                            Where-Object -FilterScript {
-                                $_.Type -eq 'SQL Server Agent' -and $_.State -eq 2
-                            }
-
-                    # Build a listing of resources being acted upon
-                    $resourceNames = @($sqlService.Name, ($agentService |
-                                Select-Object -ExpandProperty Name)) -join ","
-
-                    # Stop the SQL Server and dependent resources
-                    Write-Verbose -Message ($script:localizedData.BringClusterResourcesOffline -f $resourceNames) -Verbose
-
-                    $sqlService |
-                        Invoke-CimMethod -MethodName TakeOffline -Arguments @{
-                            Timeout = $Timeout
-                        }
-
-                    # Start the SQL server resource
-                    Write-Verbose -Message ($script:localizedData.BringSqlServerClusterResourcesOnline) -Verbose
-
-                    $sqlService |
-                        Invoke-CimMethod -MethodName BringOnline -Arguments @{
-                            Timeout = $Timeout
-                        }
-
-                    # Start the SQL Agent resource
-                    if ($agentService)
-                    {
-                        if ($PSBoundParameters.ContainsKey('OwnerNode') -and $agentService.OwnerNode -notin $OwnerNode)
-                        {
-                            $isOwnerOfClusterResource = $false
-                        }
-
-                        if ($isOwnerOfClusterResource)
-                        {
-                            Write-Verbose -Message ($script:localizedData.BringSqlServerAgentClusterResourcesOnline) -Verbose
-
-                            $agentService |
-                                Invoke-CimMethod -MethodName BringOnline -Arguments @{
-                                    Timeout = $Timeout
-                                }
-                        }
-                        else
-                        {
-                            Write-Verbose -Message (
-                                $script:localizedData.NotOwnerOfClusterResource -f $ServerName, $agentService.Name, $agentService.OwnerNode
-                            ) -Verbose
-                        }
-                    }
-                }
-                else
-                {
-                    Write-Verbose -Message (
-                        $script:localizedData.NotOwnerOfClusterResource -f $env:COMPUTERNAME, $sqlService.Name, $sqlService.OwnerNode
-                    ) -Verbose
-                }
+            $restartSqlClusterServiceParameters = @{
+                InstanceName = $serverObject.ServiceName
             }
-            else
+
+            if ($PSBoundParameters.ContainsKey('Timeout'))
             {
-                Write-Warning -Message ($script:localizedData.ClusterResourceNotFoundOrOffline -f $serverObject.ServiceName)
+                $restartSqlClusterServiceParameters['Timeout'] = $Timeout
             }
+
+            if ($PSBoundParameters.ContainsKey('OwnerNode'))
+            {
+                $restartSqlClusterServiceParameters['OwnerNode'] = $OwnerNode
+            }
+
+            Restart-SqlClusterService @restartSqlClusterServiceParameters
         }
-        else
-        {
-            # Not a cluster, restart the Windows service.
-            $restartWindowsService = $true
-        }
-    }
-    else
-    {
-        # Should not check if a cluster, assume that a Windows service should be restarted.
-        $restartWindowsService = $true
     }
 
     if ($restartWindowsService)
@@ -1053,7 +980,7 @@ function Restart-SqlService
         do
         {
             # This call, if it fails, will take between ~9-10 seconds to return.
-            $testConnectionServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction SilentlyContinue
+            $testConnectionServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'SilentlyContinue'
 
             # Make sure we have an SMO object to test Status
             if ($testConnectionServerObject)
@@ -1076,6 +1003,131 @@ function Restart-SqlService
             $errorMessage = $script:localizedData.FailedToConnectToInstanceTimeout -f $ServerName, $InstanceName, $Timeout
             New-InvalidOperationException -Message $errorMessage
         }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Restarts a SQL Server cluster instance and associated services
+
+    .PARAMETER InstanceName
+        Specifies the instance name that matches a SQL Server MSCluster_Resource
+        property <clustergroup>.PrivateProperties.InstanceName.
+
+    .PARAMETER Timeout
+        Timeout value for restarting the SQL services. The default value is 120 seconds.
+
+    .PARAMETER OwnerNode
+        Specifies a list of owner nodes names of a cluster groups. If the SQL Server
+        instance is a Failover Cluster instance then the cluster group will only
+        be taken offline and back online when the owner of the cluster group is
+        one of the nodes specified in this list. These node names specified in this
+        parameter must match the Owner property of the cluster resource, for example
+        @('sqltest10', 'SQLTEST11'). The names are case-insensitive.
+        If this parameter is not specified the cluster group will be taken offline
+        and back online regardless of owner.
+#>
+function Restart-SqlClusterService
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter()]
+        [System.UInt32]
+        $Timeout = 120,
+
+        [Parameter()]
+        [System.String[]]
+        $OwnerNode
+    )
+
+    # Get the cluster resources
+    Write-Verbose -Message ($script:localizedData.GetSqlServerClusterResources) -Verbose
+
+    $sqlService = Get-CimInstance -Namespace 'root/MSCluster' -ClassName 'MSCluster_Resource' -Filter "Type = 'SQL Server'" |
+        Where-Object -FilterScript {
+            $_.PrivateProperties.InstanceName -eq $InstanceName -and $_.State -eq 2
+        }
+
+    # If the cluster resource is found and online then continue.
+    if ($sqlService)
+    {
+        $isOwnerOfClusterResource = $true
+
+        if ($PSBoundParameters.ContainsKey('OwnerNode') -and $sqlService.OwnerNode -notin $OwnerNode)
+        {
+            $isOwnerOfClusterResource = $false
+        }
+
+        if ($isOwnerOfClusterResource)
+        {
+            Write-Verbose -Message ($script:localizedData.GetSqlAgentClusterResource) -Verbose
+
+            $agentService = $sqlService |
+                Get-CimAssociatedInstance -ResultClassName MSCluster_Resource |
+                    Where-Object -FilterScript {
+                        $_.Type -eq 'SQL Server Agent' -and $_.State -eq 2
+                    }
+
+            # Build a listing of resources being acted upon
+            $resourceNames = @($sqlService.Name, ($agentService |
+                        Select-Object -ExpandProperty Name)) -join "', '"
+
+            # Stop the SQL Server and dependent resources
+            Write-Verbose -Message ($script:localizedData.BringClusterResourcesOffline -f $resourceNames) -Verbose
+
+            $sqlService |
+                Invoke-CimMethod -MethodName TakeOffline -Arguments @{
+                    Timeout = $Timeout
+                }
+
+            # Start the SQL server resource
+            Write-Verbose -Message ($script:localizedData.BringSqlServerClusterResourcesOnline) -Verbose
+
+            $sqlService |
+                Invoke-CimMethod -MethodName BringOnline -Arguments @{
+                    Timeout = $Timeout
+                }
+
+            # Start the SQL Agent resource
+            if ($agentService)
+            {
+                if ($PSBoundParameters.ContainsKey('OwnerNode') -and $agentService.OwnerNode -notin $OwnerNode)
+                {
+                    $isOwnerOfClusterResource = $false
+                }
+
+                if ($isOwnerOfClusterResource)
+                {
+                    Write-Verbose -Message ($script:localizedData.BringSqlServerAgentClusterResourcesOnline) -Verbose
+
+                    $agentService |
+                        Invoke-CimMethod -MethodName BringOnline -Arguments @{
+                            Timeout = $Timeout
+                        }
+                }
+                else
+                {
+                    Write-Verbose -Message (
+                        $script:localizedData.NotOwnerOfClusterResource -f $env:COMPUTERNAME, $agentService.Name, $agentService.OwnerNode
+                    ) -Verbose
+                }
+            }
+        }
+        else
+        {
+            Write-Verbose -Message (
+                $script:localizedData.NotOwnerOfClusterResource -f $env:COMPUTERNAME, $sqlService.Name, $sqlService.OwnerNode
+            ) -Verbose
+        }
+    }
+    else
+    {
+        Write-Warning -Message ($script:localizedData.ClusterResourceNotFoundOrOffline -f $InstanceName)
     }
 }
 

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -58,7 +58,6 @@ ConvertFrom-StringData @'
     PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
-    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'. (SQLCOMMON0066)
-    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline. (SQLCOMMON0067)
-    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0068)
+    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline. (SQLCOMMON0066)
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0067)
 '@

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -60,5 +60,5 @@ ConvertFrom-StringData @'
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
     ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
     ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline.
-    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. Owner is node '{2}' so no restart is needed.
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed.
 '@

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -59,4 +59,6 @@ ConvertFrom-StringData @'
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
     ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
+    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline.
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. Owner is node '{2}' so no restart is needed.
 '@

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -27,7 +27,7 @@ ConvertFrom-StringData @'
     FailedToImportPowerShellSqlModule = Failed to import {0} module. (SQLCOMMON0031)
     GetSqlServerClusterResources = Getting cluster resource for SQL Server. (SQLCOMMON0032)
     GetSqlAgentClusterResource = Getting active cluster resource SQL Server Agent. (SQLCOMMON0033)
-    BringClusterResourcesOffline = Bringing the SQL Server resources {0} offline. (SQLCOMMON0034)
+    BringClusterResourcesOffline = Bringing the SQL Server resources '{0}' offline. (SQLCOMMON0034)
     BringSqlServerClusterResourcesOnline = Bringing the SQL Server resource back online. (SQLCOMMON0035)
     BringSqlServerAgentClusterResourcesOnline = Bringing the SQL Server Agent resource online. (SQLCOMMON0036)
     GetServiceInformation = Getting information about service '{0}'. (SQLCOMMON0037)
@@ -58,7 +58,7 @@ ConvertFrom-StringData @'
     PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
-    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
-    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline.
-    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed.
+    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'. (SQLCOMMON0066)
+    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline. (SQLCOMMON0067)
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0068)
 '@

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -51,4 +51,12 @@ ConvertFrom-StringData @'
     ConnectingUsingImpersonation = Impersonate credential '{0}' with login type '{1}'. (SQLCOMMON0056)
     ExecuteQueryWithResults = Returning the results of the query `{0}`. (SQLCOMMON0057)
     ExecuteNonQuery = Executing the query `{0}`. (SQLCOMMON0058)
+    EvaluatePropertyState = Evaluating the state of the property '{0}'. (SQLCOMMON0059)
+    PropertyInDesiredState = The parameter '{0}' is in desired state. (SQLCOMMON0060)
+    PropertyNotInDesiredState = The parameter '{0}' is not in desired state. (SQLCOMMON0061)
+    ArrayValueThatDoesNotMatch = {0} - {1} (SQLCOMMON0062)
+    PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
+    UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
+    ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
+    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -57,4 +57,12 @@ ConvertFrom-StringData @'
     ConnectingUsingImpersonation = Uppträder som behörigheten '{0}' med inloggningstyp '{1}'. (SQLCOMMON0056)
     ExecuteQueryWithResults = Returnerar resultatet av frågan `{0}`. (SQLCOMMON0057)
     ExecuteNonQuery = Exekverar frågan `{0}`. (SQLCOMMON0058)
+    EvaluatePropertyState = Evaluating the state of the property '{0}'. (SQLCOMMON0059)
+    PropertyInDesiredState = The parameter '{0}' is in desired state. (SQLCOMMON0060)
+    PropertyNotInDesiredState = The parameter '{0}' is not in desired state. (SQLCOMMON0061)
+    ArrayValueThatDoesNotMatch = {0} - {1} (SQLCOMMON0062)
+    PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
+    UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
+    ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
+    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -64,7 +64,6 @@ ConvertFrom-StringData @'
     PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
-    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'. (SQLCOMMON0066)
-    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline. (SQLCOMMON0067)
-    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0068)
+    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline. (SQLCOMMON0066)
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0067)
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -65,4 +65,6 @@ ConvertFrom-StringData @'
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
     ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
+    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline.
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. Owner is node '{2}' so no restart is needed.
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -66,5 +66,5 @@ ConvertFrom-StringData @'
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
     ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
     ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline.
-    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. Owner is node '{2}' so no restart is needed.
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed.
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -33,7 +33,7 @@ ConvertFrom-StringData @'
     FailedToImportPowerShellSqlModule = Misslyckades att importera {0} modulen. (SQLCOMMON0031)
     GetSqlServerClusterResources = Hämtar kluster resurser för SQL Server. (SQLCOMMON0032)
     GetSqlAgentClusterResource = Hämtar aktiva kluster resurser för SQL Server Agent. (SQLCOMMON0033)
-    BringClusterResourcesOffline = Tar SQL Server resurser {0} offline. (SQLCOMMON0034)
+    BringClusterResourcesOffline = Tar SQL Server resurser '{0}' offline. (SQLCOMMON0034)
     BringSqlServerClusterResourcesOnline = Tar SQL Server resurser online igen. (SQLCOMMON0035)
     BringSqlServerAgentClusterResourcesOnline = Tar SQL Server Agent resurser online. (SQLCOMMON0036)
     GetServiceInformation = Hämtar information om SQL Server-tjänst '{0}'. (SQLCOMMON0037)
@@ -64,7 +64,7 @@ ConvertFrom-StringData @'
     PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
-    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'.
-    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline.
-    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed.
+    ParameterUsageWrong = None of the parameter(s) '{0}' may be used at the same time as any of the parameter(s) '{1}'. (SQLCOMMON0066)
+    ClusterResourceNotFoundOrOffline = The SQL Server cluster resource '{0}' was not found or the resource has been taken offline. (SQLCOMMON0067)
+    NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0068)
 '@

--- a/source/SqlServerDsc.psd1
+++ b/source/SqlServerDsc.psd1
@@ -66,6 +66,7 @@
         'SqlServerMemory'
         'SqlServerNetwork'
         'SqlServerPermission'
+        'SqlServerProtocol'
         'SqlServerReplication'
         'SqlServerRole'
         'SqlServerSecureConnection'

--- a/tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1
@@ -122,7 +122,7 @@ try
 
                 $resourceCurrentState.ProtocolName | Should -Be 'NamedPipes'
                 $resourceCurrentState.Enabled | Should -BeTrue
-                $resourceCurrentState.PipeName | Should -Be 'XXX'
+                $resourceCurrentState.PipeName | Should -Be '\\.\pipe\MSSQL$DSCSQLTEST\sql\query'
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {

--- a/tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1
@@ -74,7 +74,7 @@ try
 
                 $resourceCurrentState.ProtocolName | Should -Be 'NamedPipes'
                 $resourceCurrentState.Enabled | Should -BeFalse
-                $resourceCurrentState.PipeName | Should -Be 'XXX'
+                $resourceCurrentState.PipeName | Should -Be '\\.\pipe\MSSQL$DSCSQLTEST\sql\query'
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {

--- a/tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlServerProtocol.Integration.Tests.ps1
@@ -7,7 +7,7 @@ if (-not (Test-BuildCategory -Type 'Integration' -Category @('Integration_SQL201
 
 $script:dscModuleName = 'SqlServerDsc'
 $script:dscResourceFriendlyName = 'SqlServerProtocol'
-$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+$script:dscResourceName = "DSC_$($script:dscResourceFriendlyName)"
 
 try
 {

--- a/tests/Integration/DSC_SqlServerProtocol.config.ps1
+++ b/tests/Integration/DSC_SqlServerProtocol.config.ps1
@@ -33,7 +33,7 @@ else
     .SYNOPSIS
         Disables Named Pipes.
 #>
-Configuration MSFT_SqlServerProtocol_DisableNamedPipes_Config
+Configuration DSC_SqlServerProtocol_DisableNamedPipes_Config
 {
     Import-DscResource -ModuleName 'SqlServerDsc'
 
@@ -56,7 +56,7 @@ Configuration MSFT_SqlServerProtocol_DisableNamedPipes_Config
     .SYNOPSIS
         Enabled Named Pipes.
 #>
-Configuration MSFT_SqlServerProtocol_EnableNamedPipes_Config
+Configuration DSC_SqlServerProtocol_EnableNamedPipes_Config
 {
     Import-DscResource -ModuleName 'SqlServerDsc'
 

--- a/tests/Integration/MSFT_SqlServerProtocol.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_SqlServerProtocol.Integration.Tests.ps1
@@ -1,0 +1,137 @@
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (-not (Test-BuildCategory -Type 'Integration' -Category @('Integration_SQL2016','Integration_SQL2017')))
+{
+    return
+}
+
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlServerProtocol'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+
+try
+{
+    Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+}
+catch [System.IO.FileNotFoundException]
+{
+    throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+}
+
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -ResourceType 'Mof' `
+    -TestType 'Integration'
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_DisableNamedPipes_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ProtocolName | Should -Be 'NamedPipes'
+                $resourceCurrentState.Enabled | Should -BeFalse
+                $resourceCurrentState.PipeName | Should -Be 'XXX'
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_EnableNamedPipes_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ProtocolName | Should -Be 'NamedPipes'
+                $resourceCurrentState.Enabled | Should -BeTrue
+                $resourceCurrentState.PipeName | Should -Be 'XXX'
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+    }
+}
+finally
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}

--- a/tests/Integration/MSFT_SqlServerProtocol.config.ps1
+++ b/tests/Integration/MSFT_SqlServerProtocol.config.ps1
@@ -1,0 +1,77 @@
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
+
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName        = 'localhost'
+
+                UserName        = "$env:COMPUTERNAME\SqlInstall"
+                Password        = 'P@ssw0rd1'
+
+                InstanceName    = 'DSCSQLTEST'
+
+                CertificateFile = $env:DscPublicCertificatePath
+            }
+        )
+    }
+}
+
+<#
+    .SYNOPSIS
+        Disables Named Pipes.
+#>
+Configuration MSFT_SqlServerProtocol_DisableNamedPipes_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlServerProtocol 'Integration_Test'
+        {
+            InstanceName         = $Node.InstanceName
+            ProtocolName         = 'NamedPipes'
+            Enabled              = $false
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Enabled Named Pipes.
+#>
+Configuration MSFT_SqlServerProtocol_EnableNamedPipes_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlServerProtocol 'Integration_Test'
+        {
+            InstanceName         = $Node.InstanceName
+            ProtocolName         = 'NamedPipes'
+            Enabled              = $true
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Username, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+

--- a/tests/Unit/DSC_SqlServerProtocol.Tests.ps1
+++ b/tests/Unit/DSC_SqlServerProtocol.Tests.ps1
@@ -574,6 +574,33 @@ try
                 $mockInstanceName = 'DSCTEST'
             }
 
+            Context 'When the SQL Server instance does not exist' {
+                Mock -CommandName Compare-TargetResourceState -MockWith {
+                    return @(
+                        @{
+                            InDesiredState = $false
+                        }
+                    )
+                }
+
+                BeforeAll {
+                    Mock -CommandName Get-ServerProtocolObject -MockWith {
+                        return $null
+                    }
+
+                    $setTargetResourceParameters = @{
+                        InstanceName = $mockInstanceName
+                        ProtocolName = 'SharedMemory'
+                    }
+                }
+
+                It 'Should throw the correct error' {
+                    $expectedErrorMessage = $script:localizedData.FailedToGetSqlServerProtocol
+
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                }
+            }
+
             Context 'When the system is in the desired state' {
                 BeforeAll {
                     Mock -CommandName Compare-TargetResourceState -MockWith {

--- a/tests/Unit/DSC_SqlServerProtocol.Tests.ps1
+++ b/tests/Unit/DSC_SqlServerProtocol.Tests.ps1
@@ -78,8 +78,12 @@ try
                                 IsEnabled           = $true
                                 HasMultiIPAddresses = $true
                                 ProtocolProperties  = @{
-                                    ListenOnAllIPs = $true
-                                    KeepAlive      = 30000
+                                    ListenOnAllIPs = @{
+                                        Value = $true
+                                    }
+                                    KeepAlive      = @{
+                                        Value = 30000
+                                    }
                                 }
                             }
                         }
@@ -115,7 +119,9 @@ try
                                 IsEnabled           = $true
                                 HasMultiIPAddresses = $false
                                 ProtocolProperties  = @{
-                                    PipeName = $mockPipeName
+                                    PipeName = @{
+                                        Value = $mockPipeName
+                                    }
                                 }
                             }
                         }

--- a/tests/Unit/DSC_SqlServerProtocol.Tests.ps1
+++ b/tests/Unit/DSC_SqlServerProtocol.Tests.ps1
@@ -1,0 +1,1121 @@
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'DSC_SqlServerProtocol'
+
+function Invoke-TestSetup
+{
+    try
+    {
+        Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+    }
+
+    $script:testEnvironment = Initialize-TestEnvironment `
+        -DSCModuleName $script:dscModuleName `
+        -DSCResourceName $script:dscResourceName `
+        -ResourceType 'Mof' `
+        -TestType 'Unit'
+}
+
+function Invoke-TestCleanup
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}
+
+# Begin Testing
+
+Invoke-TestSetup
+
+try
+{
+    InModuleScope $script:dscResourceName {
+        Set-StrictMode -Version 1.0
+
+        Describe 'SqlServerProtocol\Get-TargetResource' -Tag 'Get' {
+            BeforeAll {
+                $mockInstanceName = 'DSCTEST'
+
+                Mock -CommandName Import-SQLPSModule
+            }
+
+            Context 'When the system is not in the desired state' {
+                Context 'When the SQL Server instance does not exist' {
+                    BeforeAll {
+                        Mock -CommandName Get-ServerProtocolObject -MockWith {
+                            return $null
+                        }
+
+                        $getTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'TcpIp'
+                        }
+                    }
+
+                    It 'Should return the correct values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
+                        $getTargetResourceResult.ProtocolName | Should -Be 'TcpIp'
+                        $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                        $getTargetResourceResult.SuppressRestart | Should -BeFalse
+                        $getTargetResourceResult.RestartTimeout | Should -Be 120
+                        $getTargetResourceResult.Enabled | Should -BeFalse
+                        $getTargetResourceResult.ListenOnAllIpAddresses | Should -BeFalse
+                        $getTargetResourceResult.KeepAlive | Should -Be 0
+                        $getTargetResourceResult.PipeName | Should -BeNullOrEmpty
+                        $getTargetResourceResult.HasMultiIPAddresses | Should -BeFalse
+                    }
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                Context 'When the desired protocol is TCP/IP' {
+                    BeforeAll {
+                        Mock -CommandName Get-ServerProtocolObject -MockWith {
+                            return @{
+                                IsEnabled           = $true
+                                HasMultiIPAddresses = $true
+                                ProtocolProperties  = @{
+                                    ListenOnAllIPs = $true
+                                    KeepAlive      = 30000
+                                }
+                            }
+                        }
+
+                        $getTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'TcpIp'
+                        }
+                    }
+
+                    It 'Should return the correct values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
+                        $getTargetResourceResult.ProtocolName | Should -Be 'TcpIp'
+                        $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                        $getTargetResourceResult.SuppressRestart | Should -BeFalse
+                        $getTargetResourceResult.RestartTimeout | Should -Be 120
+                        $getTargetResourceResult.Enabled | Should -BeTrue
+                        $getTargetResourceResult.ListenOnAllIpAddresses | Should -BeTrue
+                        $getTargetResourceResult.KeepAlive | Should -Be 30000
+                        $getTargetResourceResult.PipeName | Should -BeNullOrEmpty
+                        $getTargetResourceResult.HasMultiIPAddresses | Should -BeTrue
+                    }
+                }
+
+                Context 'When the desired protocol is Named Pipes' {
+                    BeforeAll {
+                        $mockPipeName = '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query'
+
+                        Mock -CommandName Get-ServerProtocolObject -MockWith {
+                            return @{
+                                IsEnabled           = $true
+                                HasMultiIPAddresses = $false
+                                ProtocolProperties  = @{
+                                    PipeName = $mockPipeName
+                                }
+                            }
+                        }
+
+                        $getTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'NamedPipes'
+                        }
+                    }
+
+                    It 'Should return the correct values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
+                        $getTargetResourceResult.ProtocolName | Should -Be 'NamedPipes'
+                        $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                        $getTargetResourceResult.SuppressRestart | Should -BeFalse
+                        $getTargetResourceResult.RestartTimeout | Should -Be 120
+                        $getTargetResourceResult.Enabled | Should -BeTrue
+                        $getTargetResourceResult.ListenOnAllIpAddresses | Should -BeFalse
+                        $getTargetResourceResult.KeepAlive | Should -Be 0
+                        $getTargetResourceResult.PipeName | Should -Be $mockPipeName
+                        $getTargetResourceResult.HasMultiIPAddresses | Should -BeFalse
+                    }
+                }
+
+                Context 'When the desired protocol is Shared Memory' {
+                    BeforeAll {
+                        Mock -CommandName Get-ServerProtocolObject -MockWith {
+                            return @{
+                                IsEnabled           = $true
+                                HasMultiIPAddresses = $false
+                                ProtocolProperties  = @{ }
+                            }
+                        }
+
+                        $getTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'SharedMemory'
+                        }
+                    }
+
+                    It 'Should return the correct values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
+                        $getTargetResourceResult.ProtocolName | Should -Be 'SharedMemory'
+                        $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                        $getTargetResourceResult.SuppressRestart | Should -BeFalse
+                        $getTargetResourceResult.RestartTimeout | Should -Be 120
+                        $getTargetResourceResult.Enabled | Should -BeTrue
+                        $getTargetResourceResult.ListenOnAllIpAddresses | Should -BeFalse
+                        $getTargetResourceResult.KeepAlive | Should -Be 0
+                        $getTargetResourceResult.PipeName | Should -BeNullOrEmpty
+                        $getTargetResourceResult.HasMultiIPAddresses | Should -BeFalse
+                    }
+                }
+
+                Context 'When the restart service is requested' {
+                    BeforeAll {
+                        Mock -CommandName Get-ServerProtocolObject -MockWith {
+                            return @{
+                                IsEnabled           = $true
+                                HasMultiIPAddresses = $false
+                                ProtocolProperties  = @{ }
+                            }
+                        }
+
+                        $getTargetResourceParameters = @{
+                            InstanceName    = $mockInstanceName
+                            ProtocolName    = 'SharedMemory'
+                            SuppressRestart = $true
+                            RestartTimeout  = 300
+                        }
+                    }
+
+                    It 'Should return the correct values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.InstanceName | Should -Be $mockInstanceName
+                        $getTargetResourceResult.ProtocolName | Should -Be 'SharedMemory'
+                        $getTargetResourceResult.SuppressRestart | Should -BeTrue
+                        $getTargetResourceResult.RestartTimeout | Should -Be 300
+                    }
+                }
+            }
+        }
+
+        Describe 'SqlServerProtocol\Test-TargetResource' -Tag 'Test' {
+            BeforeAll {
+                $testTargetResourceParameters = @{
+                    InstanceName = 'DSCTEST'
+                    ProtocolName = 'SharedMemory'
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                BeforeAll {
+                    Mock -CommandName Compare-TargetResourceState -MockWith {
+                        return @(
+                            @{
+                                ParameterName  = 'Enabled'
+                                InDesiredState = $true
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return $true' {
+                    $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                    $testTargetResourceResult | Should -BeTrue
+
+                    Assert-MockCalled -CommandName Compare-TargetResourceState -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                BeforeAll {
+                    Mock -CommandName Compare-TargetResourceState -MockWith {
+                        return @(
+                            @{
+                                ParameterName  = 'Enabled'
+                                InDesiredState = $false
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return $false' {
+                    $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                    $testTargetResourceResult | Should -BeFalse
+
+                    Assert-MockCalled -CommandName Compare-TargetResourceState -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+
+        Describe 'SqlServerProtocol\Compare-TargetResourceState' -Tag 'Compare' {
+            BeforeAll {
+                $mockInstanceName = 'DSCTEST'
+            }
+
+            Context 'When passing wrong set of parameters for either TCP/IP or Named Pipes' {
+                It 'Should throw the an exception when passing both ListenOnAllIpAddresses and PipeName' {
+                    $testTargetResourceParameters = @{
+                        InstanceName           = $mockInstanceName
+                        ProtocolName           = 'TcpIp'
+                        Enabled                = $true
+                        ListenOnAllIpAddresses = $false
+                        PipeName               = 'any pipe name'
+                    }
+
+                    { Compare-ResourcePropertyState @testTargetResourceParameters } | Should -Throw
+                }
+
+                It 'Should throw the an exception when passing both KeepAlive and PipeName' {
+                    $testTargetResourceParameters = @{
+                        InstanceName = $mockInstanceName
+                        ProtocolName = 'TcpIp'
+                        Enabled      = $true
+                        KeepAlive    = 30000
+                        PipeName     = 'any pipe name'
+                    }
+
+                    { Compare-ResourcePropertyState @testTargetResourceParameters } | Should -Throw
+                }
+            }
+
+            Context 'When passing wrong set of parameters for Shared Memory' {
+                It 'Should throw the an exception when passing PipeName' {
+                    $testTargetResourceParameters = @{
+                        InstanceName = $mockInstanceName
+                        ProtocolName = 'SharedMemory'
+                        Enabled      = $true
+                        PipeName     = 'any pipe name'
+                    }
+
+                    { Compare-ResourcePropertyState @testTargetResourceParameters } | Should -Throw
+                }
+
+                It 'Should throw the an exception when passing KeepAlive' {
+                    $testTargetResourceParameters = @{
+                        InstanceName = $mockInstanceName
+                        ProtocolName = 'SharedMemory'
+                        Enabled      = $true
+                        KeepAlive    = 30000
+                    }
+
+                    { Compare-ResourcePropertyState @testTargetResourceParameters } | Should -Throw
+                }
+
+                It 'Should throw the an exception when passing ListenOnAllIpAddresses' {
+                    $testTargetResourceParameters = @{
+                        InstanceName           = $mockInstanceName
+                        ProtocolName           = 'SharedMemory'
+                        Enabled                = $true
+                        ListenOnAllIpAddresses = $true
+                    }
+
+                    { Compare-ResourcePropertyState @testTargetResourceParameters } | Should -Throw
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                Context 'When the desired protocol is TCP/IP' {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                InstanceName           = $mockInstanceName
+                                ProtocolName           = 'TcpIp'
+                                Enabled                = $true
+                                KeepAlive              = 30000
+                                ListenOnAllIpAddresses = $true
+                            }
+                        }
+
+                        $compareTargetResourceParameters = @{
+                            InstanceName           = $mockInstanceName
+                            ProtocolName           = 'TcpIp'
+                            Enabled                = $true
+                            KeepAlive              = 30000
+                            ListenOnAllIpAddresses = $true
+                        }
+                    }
+
+                    It 'Should return the correct metadata for each protocol property' {
+                        $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                        $compareTargetResourceStateResult | Should -HaveCount 3
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Enabled' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeTrue
+                        $comparedReturnValue.InDesiredState | Should -BeTrue
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'ListenOnAllIpAddresses' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeTrue
+                        $comparedReturnValue.InDesiredState | Should -BeTrue
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'KeepAlive' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -Be 30000
+                        $comparedReturnValue.Actual | Should -Be 30000
+                        $comparedReturnValue.InDesiredState | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When the desired protocol is Named Pipes' {
+                    BeforeAll {
+                        $mockPipeName = '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query'
+
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'NamedPipes'
+                                Enabled      = $true
+                                PipeName     = $mockPipeName
+                            }
+                        }
+
+                        $compareTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'NamedPipes'
+                            Enabled      = $true
+                            PipeName     = $mockPipeName
+                        }
+                    }
+
+                    It 'Should return the correct metadata for each protocol property' {
+                        $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                        $compareTargetResourceStateResult | Should -HaveCount 2
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Enabled' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeTrue
+                        $comparedReturnValue.InDesiredState | Should -BeTrue
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'PipeName' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -Be $mockPipeName
+                        $comparedReturnValue.Actual | Should -Be $mockPipeName
+                        $comparedReturnValue.InDesiredState | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When the desired protocol is Shared Memory' {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'SharedMemory'
+                                Enabled      = $true
+                            }
+                        }
+
+                        $compareTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'SharedMemory'
+                            Enabled      = $true
+                        }
+                    }
+
+                    It 'Should return the correct metadata for each protocol property' {
+                        $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                        $compareTargetResourceStateResult | Should -HaveCount 1
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Enabled' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeTrue
+                        $comparedReturnValue.InDesiredState | Should -BeTrue
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                Context 'When the desired protocol is TCP/IP' {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                InstanceName           = $mockInstanceName
+                                ProtocolName           = 'TcpIp'
+                                Enabled                = $false
+                                KeepAlive              = 30000
+                                ListenOnAllIpAddresses = $false
+                            }
+                        }
+
+                        $compareTargetResourceParameters = @{
+                            InstanceName           = $mockInstanceName
+                            ProtocolName           = 'TcpIp'
+                            Enabled                = $true
+                            KeepAlive              = 50000
+                            ListenOnAllIpAddresses = $true
+                        }
+                    }
+
+                    It 'Should return the correct metadata for each protocol property' {
+                        $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                        $compareTargetResourceStateResult | Should -HaveCount 3
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Enabled' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeFalse
+                        $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'ListenOnAllIpAddresses' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeFalse
+                        $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'KeepAlive' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -Be 50000
+                        $comparedReturnValue.Actual | Should -Be 30000
+                        $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When the desired protocol is Named Pipes' {
+                    BeforeAll {
+                        $mockPipeName = '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query'
+                        $mockExpectedPipeName = '\\.\pipe\$$\CLU01A\MSSQL$SQL2014\sql\query'
+
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'NamedPipes'
+                                Enabled      = $false
+                                PipeName     = $mockPipeName
+                            }
+                        }
+
+                        $compareTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'NamedPipes'
+                            Enabled      = $true
+                            PipeName     = $mockExpectedPipeName
+                        }
+                    }
+
+                    It 'Should return the correct metadata for each protocol property' {
+                        $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                        $compareTargetResourceStateResult | Should -HaveCount 2
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Enabled' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeFalse
+                        $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'PipeName' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -Be $mockExpectedPipeName
+                        $comparedReturnValue.Actual | Should -Be $mockPipeName
+                        $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When the desired protocol is Shared Memory' {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'SharedMemory'
+                                Enabled      = $false
+                            }
+                        }
+
+                        $compareTargetResourceParameters = @{
+                            InstanceName = $mockInstanceName
+                            ProtocolName = 'SharedMemory'
+                            Enabled      = $true
+                        }
+                    }
+
+                    It 'Should return the correct metadata for each protocol property' {
+                        $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                        $compareTargetResourceStateResult | Should -HaveCount 1
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Enabled' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+                        $comparedReturnValue.Expected | Should -BeTrue
+                        $comparedReturnValue.Actual | Should -BeFalse
+                        $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+        }
+
+        Describe 'SqlServerProtocol\Set-TargetResource' -Tag 'Set' {
+            BeforeAll {
+                $mockInstanceName = 'DSCTEST'
+            }
+
+            Context 'When the system is in the desired state' {
+                BeforeAll {
+                    Mock -CommandName Compare-TargetResourceState -MockWith {
+                        return @(
+                            @{
+                                InDesiredState = $true
+                            }
+                        )
+                    }
+
+                    $setTargetResourceParameters = @{
+                        InstanceName = $mockInstanceName
+                        ProtocolName = 'SharedMemory'
+                        Enabled      = $true
+                    }
+                }
+
+                It 'Should return $true' {
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                    Assert-MockCalled -CommandName Compare-TargetResourceState -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                Context 'When the desired protocol is TCP/IP' {
+                    Context 'When enabling and setting all the protocol properties' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'Enabled'
+                                        Actual = $false
+                                        Expected = $true
+                                        InDesiredState = $false
+                                    }
+                                    @{
+                                        ParameterName = 'ListenOnAllIpAddresses'
+                                        Actual = $false
+                                        Expected = $true
+                                        InDesiredState = $false
+                                    }
+                                    @{
+                                        ParameterName = 'KeepAlive'
+                                        Actual = 30000
+                                        Expected = 50000
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $false -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            ListenOnAllIPs = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
+                                            KeepAlive = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName           = $mockInstanceName
+                                ProtocolName           = 'TcpIp'
+                                ListenOnAllIpAddresses = $true
+                                KeepAlive              = 50000
+                                Enabled                = $true
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should set the desired values and restart the SQL Server service' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When enabling the protocol and leaving the rest of the properties to their default value' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'Enabled'
+                                        Actual = $false
+                                        Expected = $true
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $false -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            ListenOnAllIPs = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
+                                            KeepAlive = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'TcpIp'
+                                Enabled      = $true
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should set the desired values and restart the SQL Server service' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When disabling the protocol and leaving the rest of the properties to their default value' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'Enabled'
+                                        Actual = $true
+                                        Expected = $false
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $true -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            ListenOnAllIPs = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
+                                            KeepAlive = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'TcpIp'
+                                Enabled      = $false
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should set the desired values and restart the SQL Server service' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When setting the individual protocol properties regardless if the protocol is enabled or disabled' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'ListenOnAllIpAddresses'
+                                        Actual = $false
+                                        Expected = $true
+                                        InDesiredState = $false
+                                    }
+                                    @{
+                                        ParameterName = 'KeepAlive'
+                                        Actual = 30000
+                                        Expected = 50000
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $false -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            ListenOnAllIPs = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
+                                            KeepAlive = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName           = $mockInstanceName
+                                ProtocolName           = 'TcpIp'
+                                ListenOnAllIpAddresses = $true
+                                KeepAlive              = 50000
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should set the desired values and _not_ restart the SQL Server service' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 0 -Scope It
+                        }
+                    }
+
+                    Context 'When suppressing the restart' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Write-Warning
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'Enabled'
+                                        Actual = $false
+                                        Expected = $true
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $false -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            ListenOnAllIPs = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
+                                            KeepAlive = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName    = $mockInstanceName
+                                ProtocolName    = 'TcpIp'
+                                Enabled         = $true
+                                SuppressRestart = $true
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should not restart the SQL Server service but instead write a warning message' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Write-Warning -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+
+                Context 'When the desired protocol is Named Pipes' {
+                    Context 'When enabling and setting all the protocol properties' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'Enabled'
+                                        Actual = $false
+                                        Expected = $true
+                                        InDesiredState = $false
+                                    }
+                                    @{
+                                        ParameterName = 'PipeName'
+                                        Actual = '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query'
+                                        Expected = '\\.\pipe\$$\CLU01A\MSSQL$SQL2014\sql\query'
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $false -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            PipeName = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query' -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'NamedPipes'
+                                PipeName     = '\\.\pipe\$$\CLU01A\MSSQL$SQL2014\sql\query'
+                                Enabled      = $true
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should set the desired values and restart the SQL Server service' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When enabling the protocol and leaving the rest of the properties to their default value' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'Enabled'
+                                        Actual = $false
+                                        Expected = $true
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $false -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            PipeName = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query' -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'NamedPipes'
+                                Enabled      = $true
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should set the desired values and restart the SQL Server service' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When setting the individual protocol properties regardless if the protocol is enabled or disabled' {
+                        BeforeAll {
+                            Mock -CommandName Restart-SqlService
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName = 'PipeName'
+                                        Actual = '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query'
+                                        Expected = '\\.\pipe\$$\CLU01A\MSSQL$SQL2014\sql\query'
+                                        InDesiredState = $false
+                                    }
+                                )
+                            }
+
+                            Mock -CommandName Get-ServerProtocolObject -MockWith {
+                                return New-Object -TypeName PSObject |
+                                    Add-Member -MemberType NoteProperty -Name 'IsEnabled' -Value $false -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'ProtocolProperties' -Value {
+                                        return @{
+                                            PipeName = New-Object -TypeName PSObject |
+                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '\\.\pipe\$$\TESTCLU01A\MSSQL$SQL2014\sql\query' -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        $script:wasMethodAlterCalled = $true
+                                    } -PassThru -Force
+                            }
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = $mockInstanceName
+                                ProtocolName = 'NamedPipes'
+                                PipeName     = '\\.\pipe\$$\CLU01A\MSSQL$SQL2014\sql\query'
+                            }
+                        }
+
+                        BeforeEach {
+                            $script:wasMethodAlterCalled = $false
+                        }
+
+                        It 'Should set the desired values and _not_ restart the SQL Server service' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            $script:wasMethodAlterCalled | Should -BeTrue
+
+                            Assert-MockCalled -CommandName Restart-SqlService -Exactly -Times 0 -Scope It
+                        }
+                    }
+                }
+            }
+        }
+
+        Describe 'SqlServerProtocol\Get-ProtocolNameProperties' -Tag 'Helper' {
+            $testCases = @(
+                @{
+                    ParameterValue = 'TcpIp'
+                    DisplayName    = 'TCP/IP'
+                    Name           = 'Tcp'
+                }
+                @{
+                    ParameterValue = 'NamedPipes'
+                    DisplayName    = 'Named Pipes'
+                    Name           = 'Np'
+                }
+                @{
+                    ParameterValue = 'SharedMemory'
+                    DisplayName    = 'Shared Memory'
+                    Name           = 'Sm'
+                }
+            )
+
+            It 'Should return the correct values when the protocol is ''<DisplayName>''' -TestCases $testCases {
+                param
+                (
+                    [Parameter()]
+                    [System.String]
+                    $ParameterValue,
+
+                    [Parameter()]
+                    [System.String]
+                    $DisplayName,
+
+                    [Parameter()]
+                    [System.String]
+                    $Name
+                )
+
+                $result = Get-ProtocolNameProperties -ProtocolName $ParameterValue
+
+                $result.DisplayName = $DisplayName
+                $result.Name = $Name
+            }
+        }
+
+        Describe 'SqlServerProtocol\Get-ServerProtocolObject' -Tag 'Helper' {
+            BeforeAll {
+                $mockInstanceName = 'TestInstance'
+
+                Mock -CommandName New-Object -MockWith {
+                    return @{
+                        ServerInstances = @{
+                            $mockInstanceName = @{
+                                ServerProtocols = @{
+                                    Tcp = @{
+                                        IsEnabled           = $true
+                                        HasMultiIPAddresses = $true
+                                        ProtocolProperties  = @{
+                                            ListenOnAllIPs = $true
+                                            KeepAlive      = 30000
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            It 'Should return a ManagedComputer object with the correct values' {
+                $mockGetServerProtocolObjectParameters = @{
+                    ServerName   = 'AnyServer'
+                    Instance     = $mockInstanceName
+                    ProtocolName = 'TcpIp'
+                }
+
+                $result = Get-ServerProtocolObject @mockGetServerProtocolObjectParameters
+
+                $result.IsEnabled | Should -BeTrue
+                $result.HasMultiIPAddresses | Should -BeTrue
+                $result.ProtocolProperties.ListenOnAllIPs | Should -BeTrue
+                $result.ProtocolProperties.KeepAlive | Should -Be 30000
+            }
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -2749,5 +2749,500 @@ InModuleScope $script:subModuleName {
             }
         }
     }
-}
 
+    Describe 'DscResource.Common\Test-DscPropertyState' -Tag 'TestDscPropertyState' {
+        Context 'When comparing tables' {
+            It 'Should return true for two identical tables' {
+                $mockValues = @{
+                    CurrentValue = 'Test'
+                    DesiredValue = 'Test'
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeTrue
+            }
+        }
+
+        Context 'When comparing strings' {
+            It 'Should return false when a value is different for [System.String]' {
+                $mockValues = @{
+                    CurrentValue = [System.String] 'something'
+                    DesiredValue = [System.String] 'test'
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when a String value is missing' {
+                $mockValues = @{
+                    CurrentValue = $null
+                    DesiredValue = [System.String] 'Something'
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return true when two strings are equal' {
+                $mockValues = @{
+                    CurrentValue = [System.String] 'Something'
+                    DesiredValue = [System.String] 'Something'
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -Be $true
+            }
+        }
+
+        Context 'When comparing integers' {
+            It 'Should return false when a value is different for [System.Int32]' {
+                $mockValues = @{
+                    CurrentValue = [System.Int32] 1
+                    DesiredValue = [System.Int32] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return true when the values are the same for [System.Int32]' {
+                $mockValues = @{
+                    CurrentValue = [System.Int32] 2
+                    DesiredValue = [System.Int32] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -Be $true
+            }
+
+            It 'Should return false when a value is different for [System.UInt32]' {
+                $mockValues = @{
+                    CurrentValue = [System.UInt32] 1
+                    DesiredValue = [System.UInt32] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -Be $false
+            }
+
+            It 'Should return true when the values are the same for [System.UInt32]' {
+                $mockValues = @{
+                    CurrentValue = [System.UInt32] 2
+                    DesiredValue = [System.UInt32] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -Be $true
+            }
+
+            It 'Should return false when a value is different for [System.Int16]' {
+                $mockValues = @{
+                    CurrentValue = [System.Int16] 1
+                    DesiredValue = [System.Int16] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return true when the values are the same for [System.Int16]' {
+                $mockValues = @{
+                    CurrentValue = [System.Int16] 2
+                    DesiredValue = [System.Int16] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -Be $true
+            }
+
+            It 'Should return false when a value is different for [System.UInt16]' {
+                $mockValues = @{
+                    CurrentValue = [System.UInt16] 1
+                    DesiredValue = [System.UInt16] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return true when the values are the same for [System.UInt16]' {
+                $mockValues = @{
+                    CurrentValue = [System.UInt16] 2
+                    DesiredValue = [System.UInt16] 2
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -Be $true
+            }
+
+            It 'Should return false when a Integer value is missing' {
+                $mockValues = @{
+                    CurrentValue = $null
+                    DesiredValue = [System.Int32] 1
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+        }
+
+        Context 'When comparing booleans' {
+            It 'Should return false when a value is different for [System.Boolean]' {
+                $mockValues = @{
+                    CurrentValue = [System.Boolean] $true
+                    DesiredValue = [System.Boolean] $false
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when a Boolean value is missing' {
+                $mockValues = @{
+                    CurrentValue = $null
+                    DesiredValue = [System.Boolean] $true
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+        }
+
+        Context 'When comparing arrays' {
+            It 'Should return true when evaluating an array' {
+                $mockValues = @{
+                    CurrentValue = @('1', '2')
+                    DesiredValue = @('1', '2')
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeTrue
+            }
+
+            It 'Should return false when evaluating an array with wrong values' {
+                $mockValues = @{
+                    CurrentValue = @('CurrentValueA', 'CurrentValueB')
+                    DesiredValue = @('DesiredValue1', 'DesiredValue2')
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating an array, but the current value is $null' {
+                $mockValues = @{
+                    CurrentValue = $null
+                    DesiredValue = @('1', '2')
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating an array, but the desired value is $null' {
+                $mockValues = @{
+                    CurrentValue = @('1', '2')
+                    DesiredValue = $null
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating an array, but the current value is an empty array' {
+                $mockValues = @{
+                    CurrentValue = @()
+                    DesiredValue = @('1', '2')
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating an array, but the desired value is an empty array' {
+                $mockValues = @{
+                    CurrentValue = @('1', '2')
+                    DesiredValue = @()
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return true when evaluating an array, when both values are $null' {
+                $mockValues = @{
+                    CurrentValue = $null
+                    DesiredValue = $null
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeTrue
+            }
+
+            It 'Should return true when evaluating an array, when both values are an empty array' {
+                $mockValues = @{
+                    CurrentValue = @()
+                    DesiredValue = @()
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeTrue
+            }
+        }
+
+        Context -Name 'When passing invalid types for DesiredValue' {
+            It 'Should write a warning when DesiredValue contain an unsupported type' {
+                Mock -CommandName Write-Warning -Verifiable
+
+                # This is a dummy type to test with a type that could never be a correct one.
+                class MockUnknownType
+                {
+                    [ValidateNotNullOrEmpty()]
+                    [System.String]
+                    $Property1
+
+                    [ValidateNotNullOrEmpty()]
+                    [System.String]
+                    $Property2
+
+                    MockUnknownType()
+                    {
+                    }
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-Object -TypeName 'MockUnknownType'
+                    DesiredValue = New-Object -TypeName 'MockUnknownType'
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+
+                Assert-MockCalled -CommandName Write-Warning -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Assert-VerifiableMock
+    }
+
+    Describe 'ActiveDirectoryDsc.Common\Compare-ResourcePropertyState' {
+        Context 'When one property is in desired state' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'DC01'
+                }
+            }
+
+            It 'Should return the correct values' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues = $mockCurrentValues
+                    DesiredValues = $mockDesiredValues
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -HaveCount 1
+                $compareTargetResourceStateResult.ParameterName | Should -Be 'ComputerName'
+                $compareTargetResourceStateResult.Expected | Should -Be 'DC01'
+                $compareTargetResourceStateResult.Actual | Should -Be 'DC01'
+                $compareTargetResourceStateResult.InDesiredState | Should -BeTrue
+            }
+        }
+
+        Context 'When two properties are in desired state' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Sweden'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Sweden'
+                }
+            }
+
+            It 'Should return the correct values' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues = $mockCurrentValues
+                    DesiredValues = $mockDesiredValues
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -HaveCount 2
+                $compareTargetResourceStateResult[0].ParameterName | Should -Be 'ComputerName'
+                $compareTargetResourceStateResult[0].Expected | Should -Be 'DC01'
+                $compareTargetResourceStateResult[0].Actual | Should -Be 'DC01'
+                $compareTargetResourceStateResult[0].InDesiredState | Should -BeTrue
+                $compareTargetResourceStateResult[1].ParameterName | Should -Be 'Location'
+                $compareTargetResourceStateResult[1].Expected | Should -Be 'Sweden'
+                $compareTargetResourceStateResult[1].Actual | Should -Be 'Sweden'
+                $compareTargetResourceStateResult[1].InDesiredState | Should -BeTrue
+            }
+        }
+
+        Context 'When passing just one property and that property is not in desired state' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'APP01'
+                }
+            }
+
+            It 'Should return the correct values' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues = $mockCurrentValues
+                    DesiredValues = $mockDesiredValues
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -HaveCount 1
+                $compareTargetResourceStateResult.ParameterName | Should -Be 'ComputerName'
+                $compareTargetResourceStateResult.Expected | Should -Be 'APP01'
+                $compareTargetResourceStateResult.Actual | Should -Be 'DC01'
+                $compareTargetResourceStateResult.InDesiredState | Should -BeFalse
+            }
+        }
+
+        Context 'When passing two properties and one property is not in desired state' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Sweden'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Europe'
+                }
+            }
+
+            It 'Should return the correct values' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues = $mockCurrentValues
+                    DesiredValues = $mockDesiredValues
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -HaveCount 2
+                $compareTargetResourceStateResult[0].ParameterName | Should -Be 'ComputerName'
+                $compareTargetResourceStateResult[0].Expected | Should -Be 'DC01'
+                $compareTargetResourceStateResult[0].Actual | Should -Be 'DC01'
+                $compareTargetResourceStateResult[0].InDesiredState | Should -BeTrue
+                $compareTargetResourceStateResult[1].ParameterName | Should -Be 'Location'
+                $compareTargetResourceStateResult[1].Expected | Should -Be 'Europe'
+                $compareTargetResourceStateResult[1].Actual | Should -Be 'Sweden'
+                $compareTargetResourceStateResult[1].InDesiredState | Should -BeFalse
+            }
+        }
+
+        Context 'When passing a common parameter set to desired value' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'DC01'
+                }
+            }
+
+            It 'Should return the correct values' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues = $mockCurrentValues
+                    DesiredValues = $mockDesiredValues
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -HaveCount 1
+                $compareTargetResourceStateResult.ParameterName | Should -Be 'ComputerName'
+                $compareTargetResourceStateResult.Expected | Should -Be 'DC01'
+                $compareTargetResourceStateResult.Actual | Should -Be 'DC01'
+                $compareTargetResourceStateResult.InDesiredState | Should -BeTrue
+            }
+        }
+
+        Context 'When using parameter Properties to compare desired values' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Sweden'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Europe'
+                }
+            }
+
+            It 'Should return the correct values' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues = $mockCurrentValues
+                    DesiredValues = $mockDesiredValues
+                    Properties    = @(
+                        'ComputerName'
+                    )
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -HaveCount 1
+                $compareTargetResourceStateResult.ParameterName | Should -Be 'ComputerName'
+                $compareTargetResourceStateResult.Expected | Should -Be 'DC01'
+                $compareTargetResourceStateResult.Actual | Should -Be 'DC01'
+                $compareTargetResourceStateResult.InDesiredState | Should -BeTrue
+            }
+        }
+
+        Context 'When using parameter Properties and IgnoreProperties to compare desired values' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Sweden'
+                    Ensure       = 'Present'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Europe'
+                    Ensure       = 'Absent'
+                }
+            }
+
+            It 'Should return the correct values' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues    = $mockCurrentValues
+                    DesiredValues    = $mockDesiredValues
+                    IgnoreProperties = @(
+                        'Ensure'
+                    )
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -HaveCount 2
+                $compareTargetResourceStateResult[0].ParameterName | Should -Be 'ComputerName'
+                $compareTargetResourceStateResult[0].Expected | Should -Be 'DC01'
+                $compareTargetResourceStateResult[0].Actual | Should -Be 'DC01'
+                $compareTargetResourceStateResult[0].InDesiredState | Should -BeTrue
+                $compareTargetResourceStateResult[1].ParameterName | Should -Be 'Location'
+                $compareTargetResourceStateResult[1].Expected | Should -Be 'Europe'
+                $compareTargetResourceStateResult[1].Actual | Should -Be 'Sweden'
+                $compareTargetResourceStateResult[1].InDesiredState | Should -BeFalse
+            }
+        }
+
+        Context 'When using parameter Properties and IgnoreProperties to compare desired values' {
+            BeforeAll {
+                $mockCurrentValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Sweden'
+                    Ensure       = 'Present'
+                }
+
+                $mockDesiredValues = @{
+                    ComputerName = 'DC01'
+                    Location     = 'Europe'
+                    Ensure       = 'Absent'
+                }
+            }
+
+            It 'Should return and empty array' {
+                $compareTargetResourceStateParameters = @{
+                    CurrentValues    = $mockCurrentValues
+                    DesiredValues    = $mockDesiredValues
+                    Properties       = @(
+                        'ComputerName'
+                    )
+                    IgnoreProperties = @(
+                        'ComputerName'
+                    )
+                }
+
+                $compareTargetResourceStateResult = Compare-ResourcePropertyState @compareTargetResourceStateParameters
+                $compareTargetResourceStateResult | Should -BeNullOrEmpty
+            }
+        }
+    }
+}


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc
  - Added new resource SqlServerProtocol (issue #1377).
  - When a PR is labelled with 'ready for merge' it is no longer being
    marked as stale if the PR is not merged for 30 days (for example it is
    dependent on something else) (issue #1504).
  - Updated the CI pipeline to use latest version of the module ModuleBuilder.
- SqlServerDsc.Common
  - The helper function `Restart-SqlService` was improved to handle Failover
    Clusters better. Now the SQL Server service will only be taken offline
    and back online again if the service is online to begin with.
  - The helper function `Restart-SqlServer` learned the new parameter
    `OwnerNode`. The parameter `OwnerNode` takes an array of Cluster node
    names. Using this parameter the cluster group will only be taken
    offline and back online if the cluster group owner is one specified
    in this parameter.

*This PR partly replaces `SqlServerNetwork`. Together with the resource proposal in issue #1378 the resource `SqlServerNetwork` will be be replaced all together.*

#### This Pull Request (PR) fixes the following issues

- Fixes #1377 
- Fixes #1504

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1511)
<!-- Reviewable:end -->
