### PR TITLE
SqlServerDsc: Remove function Set-PSModulePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ in a future release.
 - SqlServerDsc.Common
   - The helper function `Invoke-InstallationMediaCopy` was changed to
     handle a breaking change in PowerShell 7 ([issue #1530](https://github.com/dsccommunity/SqlServerDsc/issues/1530)).
+  - Removed the local helper function `Set-PSModulePath` as it was
+    implemented in the module DscResource.Common.
 - CommonTestHelper
   - The test helper function `New-SQLSelfSignedCertificate` was changed
     to install the dependent module `PSPKI` through `RequiredModules.psd1`.

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -2542,28 +2542,3 @@ function Get-ServerProtocolObject
 
     return $serverProtocolProperties
 }
-
-function Set-PSModulePath
-{
-    [CmdletBinding()]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $Path,
-
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $Machine
-    )
-
-    if ($Machine.IsPresent)
-    {
-        [System.Environment]::SetEnvironmentVariable('PSModulePath', $Path, [System.EnvironmentVariableTarget]::Machine)
-    }
-    else
-    {
-        $env:PSModulePath = $Path
-    }
-}


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc.Common
  - Removed the local helper function `Set-PSModulePath` as it was
    implemented in the module DscResource.Common.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1551)
<!-- Reviewable:end -->
