### PR TITLE
BREAKING CHANGE: SqlSetup: Remove default skip cluster validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,10 @@ in a future release.
     `AGTSVCSTARTUPTYPE`. If the parameter `AgtSvcStartupType` is not specified
     in the configuration there will be no setup argument added at all
     ([issue #464](https://github.com/dsccommunity/SqlServerDsc/issues/464)).
+  - BREAKING CHANGE: When installing a failover cluster the cluster
+    validation is no longer skipped by default. To skip cluster validation
+    the configuration must opt-in by specifying the following
+    `SkipRule = 'Cluster_VerifyForErrors'` ([issue #335](https://github.com/dsccommunity/SqlServerDsc/issues/335)).
   - BREAKING CHANGE: Now, unless the parameter `SuppressReboot` is set to
     `$true`, the node will be restarted if the setup ends with the
     [error code 3010](https://docs.microsoft.com/en-us/previous-versions/tn-archive/bb418811(v=technet.10)#server-setup-fails-with-code-3010).

--- a/README.md
+++ b/README.md
@@ -1921,6 +1921,14 @@ Flag | Description
 - | -
 <!-- markdownlint-enable MD013 -->
 
+#### Skip rules
+
+The parameter `SkipRule` accept one or more skip rules with will be passed
+to `setup.exe`. Using the parameter `SkipRule` is _not recommended_ in a
+production environment unless there is a valid reason for it.
+
+For more information about skip rules see the article [SQL 2012 Setup Rules – The 'Missing Reference'](https://deep.data.blog/2014/04/02/sql-2012-setup-rules-the-missing-reference/).
+
 #### Credentials for running the resource
 
 ##### PsDscRunAsCredential
@@ -2083,6 +2091,8 @@ with different sizes and growths.
   of SQL Server on a localized operating system when the installation media
   includes language packs for both English and the language corresponding to the
   operating system.
+* **`[String[]]` SkipRule** _(Write)_: Specifies optional skip rules during
+  setup.
 * **`[String[]]` FeatureFlag** _(Write)_: Feature flags are used to toggle
   functionality on or off. See the documentation for what additional
   functionality exist through a feature flag.

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -638,6 +638,9 @@ function Get-TargetResource
         Specifies to install the English version of SQL Server on a localized operating
         system when the installation media includes language packs for both English and
         the language corresponding to the operating system.
+
+    .PARAMETER SkipRule
+        Specifies optional skip rules during setup.
 #>
 function Set-TargetResource
 {
@@ -902,7 +905,12 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $UseEnglish
+        $UseEnglish,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String[]]
+        $SkipRule
     )
 
     <#
@@ -1025,10 +1033,9 @@ function Set-TargetResource
 
     $setupArguments = @{}
 
-    if ($Action -in @('PrepareFailoverCluster', 'CompleteFailoverCluster', 'InstallFailoverCluster', 'Addnode'))
+    if ($PSBoundParameters.ContainsKey('SkipRule') )
     {
-        # This was brought over from the old module. Should be removed (breaking change).
-        $setupArguments['SkipRules'] = 'Cluster_VerifyForErrors'
+        $setupArguments['SkipRules'] = @($SkipRule)
     }
 
     <#
@@ -1469,7 +1476,13 @@ function Set-TargetResource
             if ($currentSetupArgument.Value -is [System.Array])
             {
                 # Sort and format the array
-                $setupArgumentValue = ($currentSetupArgument.Value | Sort-Object | ForEach-Object { '"{0}"' -f $_ }) -join ' '
+                $setupArgumentValue = (
+                    $currentSetupArgument.Value |
+                        Sort-Object |
+                        ForEach-Object {
+                            '"{0}"' -f $_
+                        }
+                ) -join ' '
             }
             elseif ($currentSetupArgument.Value -is [System.Boolean])
             {
@@ -1843,6 +1856,11 @@ function Set-TargetResource
         the language corresponding to the operating system.
 
         Not used in Test-TargetResource.
+
+    .PARAMETER SkipRule
+        Specifies optional skip rules during setup.
+
+        Not used in Test-TargetResource.
 #>
 function Test-TargetResource
 {
@@ -2098,7 +2116,12 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $UseEnglish
+        $UseEnglish,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String[]]
+        $SkipRule
     )
 
     <#

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
@@ -67,5 +67,6 @@ class DSC_SqlSetup : OMI_BaseResource
     [Write, Description("The timeout, in seconds, to wait for the setup process to finish. Default value is 7200 seconds (2 hours). If the setup process does not finish before this time, and error will be thrown.")] UInt32 SetupProcessTimeout;
     [Write, Description("Feature flags are used to toggle functionality on or off. See the documentation for what additional functionality exist through a feature flag.")] String FeatureFlag[];
     [Write, Description("Specifies to install the English version of SQL Server on a localized operating system when the installation media includes language packs for both English and the language corresponding to the operating system.")] Boolean UseEnglish;
+    [Write, Description("Specifies optional skip rules during setup.")] String[] SkipRule;
     [Read, Description("Returns a boolean value of $true if the instance is clustered, otherwise it returns $false.")] Boolean IsClustered;
 };

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
@@ -67,6 +67,6 @@ class DSC_SqlSetup : OMI_BaseResource
     [Write, Description("The timeout, in seconds, to wait for the setup process to finish. Default value is 7200 seconds (2 hours). If the setup process does not finish before this time, and error will be thrown.")] UInt32 SetupProcessTimeout;
     [Write, Description("Feature flags are used to toggle functionality on or off. See the documentation for what additional functionality exist through a feature flag.")] String FeatureFlag[];
     [Write, Description("Specifies to install the English version of SQL Server on a localized operating system when the installation media includes language packs for both English and the language corresponding to the operating system.")] Boolean UseEnglish;
-    [Write, Description("Specifies optional skip rules during setup.")] String[] SkipRule;
+    [Write, Description("Specifies optional skip rules during setup.")] String SkipRule[];
     [Read, Description("Returns a boolean value of $true if the instance is clustered, otherwise it returns $false.")] Boolean IsClustered;
 };

--- a/source/Examples/Resources/SqlSetup/8-UsingSkipRuleDuringInstall.ps1
+++ b/source/Examples/Resources/SqlSetup/8-UsingSkipRuleDuringInstall.ps1
@@ -1,0 +1,95 @@
+<#
+    .DESCRIPTION
+        This example shows how to ad skip rules to setup.exe.
+
+    .NOTES
+        Using skip rules is not recommended in a production environment.
+#>
+Configuration Example
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlInstallCredential,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlAdministratorCredential = $SqlInstallCredential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlServiceCredential,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $SqlAgentServiceCredential = $SqlServiceCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        #region Install prerequisites for SQL Server
+        WindowsFeature 'NetFramework35'
+        {
+            Name   = 'NET-Framework-Core'
+            Source = '\\fileserver.company.local\images$\Win2k12R2\Sources\Sxs' # Assumes built-in Everyone has read permission to the share and path.
+            Ensure = 'Present'
+        }
+
+        WindowsFeature 'NetFramework45'
+        {
+            Name   = 'NET-Framework-45-Core'
+            Ensure = 'Present'
+        }
+        #endregion Install prerequisites for SQL Server
+
+        #region Install SQL Server Failover Cluster
+        SqlSetup 'InstallNamedInstanceNode1-INST2016'
+        {
+            Action                     = 'InstallFailoverCluster'
+            ForceReboot                = $false
+            UpdateEnabled              = 'False'
+            SourcePath                 = '\\fileserver.company.local\images$\SQL2016RTM'
+            SourceCredential           = $SqlInstallCredential
+
+            InstanceName               = 'INST2016'
+            Features                   = 'SQLENGINE'
+
+            InstallSharedDir           = 'C:\Program Files\Microsoft SQL Server'
+            InstallSharedWOWDir        = 'C:\Program Files (x86)\Microsoft SQL Server'
+            InstanceDir                = 'C:\Program Files\Microsoft SQL Server'
+
+            SQLCollation               = 'Finnish_Swedish_CI_AS'
+            SQLSvcAccount              = $SqlServiceCredential
+            AgtSvcAccount              = $SqlAgentServiceCredential
+            SQLSysAdminAccounts        = 'COMPANY\SQL Administrators', $SqlAdministratorCredential.UserName
+
+            # Drive D: must be a shared disk.
+            InstallSQLDataDir          = 'D:\MSSQL\Data'
+            SQLUserDBDir               = 'D:\MSSQL\Data'
+            SQLUserDBLogDir            = 'D:\MSSQL\Log'
+            SQLTempDBDir               = 'D:\MSSQL\Temp'
+            SQLTempDBLogDir            = 'D:\MSSQL\Temp'
+            SQLBackupDir               = 'D:\MSSQL\Backup'
+
+            FailoverClusterNetworkName = 'TESTCLU01A'
+            FailoverClusterIPAddress   = '192.168.0.46'
+            FailoverClusterGroupName   = 'TESTCLU01A'
+
+            # Not recommended to use in production.
+            SkipRule                   = 'Cluster_VerifyForErrors'
+
+            PsDscRunAsCredential       = $SqlInstallCredential
+
+            DependsOn                  = '[WindowsFeature]NetFramework35', '[WindowsFeature]NetFramework45'
+        }
+        #region Install SQL Server Failover Cluster
+    }
+}

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -286,6 +286,7 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
             NpEnabled              = $true
             TcpEnabled             = $true
             UseEnglish             = $true
+            SkipRule               = 'ServerCoreBlockUnsupportedSxSCheck'
 
             # This must be set if using SYSTEM account to install.
             SQLSysAdminAccounts   = @(


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlSetup
  - BREAKING CHANGE: When installing a failover cluster the cluster
    validation is no longer skipped by default. To skip cluster validation
    the configuration must opt-in by specifying the following
    `SkipRule = 'Cluster_VerifyForErrors'` (issue #335).

#### This Pull Request (PR) fixes the following issues

- Fixes #335

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1554)
<!-- Reviewable:end -->
