### PR TITLE
BREAKING CHANGE: SqlDatabasePermission: Remove create user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ in a future release.
     using this resource ([issue #848](https://github.com/dsccommunity/SqlServerDsc/issues/848)).
   - Updated examples.
   - Added integration tests ([issue #741](https://github.com/dsccommunity/SqlServerDsc/issues/741)).
+  - Get-TargetResource will no longer throw an exception if the database
+    does not exist.
 - SqlDatabaseRecoveryModel
   - BREAKING CHANGE: The parameter `ServerName` is now non-mandatory and
     defaults to `$env:COMPUTERNAME` ([issue #319](https://github.com/dsccommunity/SqlServerDsc/issues/319)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@ in a future release.
     it does not exist. Use the resource _SqlDatabaseUser_ to enforce that
     the database user exist in the database prior to setting permissions
     using this resource ([issue #848](https://github.com/dsccommunity/SqlServerDsc/issues/848)).
+  - BREAKING CHANGE: The resource no longer checks if a login exist so that
+    it is possible to set permissions for database users that does not
+    have a login, e.g. the database user 'guest' ([issue #1134](https://github.com/dsccommunity/SqlServerDsc/issues/1134)).
   - Updated examples.
   - Added integration tests ([issue #741](https://github.com/dsccommunity/SqlServerDsc/issues/741)).
   - Get-TargetResource will no longer throw an exception if the database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,12 @@ in a future release.
   - Normalize parameter descriptive text for default values.
   - BREAKING CHANGE: Database changed to DatabaseName for consistency with
     other modules ([issue #1484](https://github.com/dsccommunity/SqlServerDsc/issues/1484)).
+  - BREAKING CHANGE: The resource no longer create the database user if
+    it does not exist. Use the resource _SqlDatabaseUser_ to enforce that
+    the database user exist in the database prior to setting permissions
+    using this resource ([issue #848](https://github.com/dsccommunity/SqlServerDsc/issues/848)).
+  - Updated examples.
+  - Added integration tests ([issue #741](https://github.com/dsccommunity/SqlServerDsc/issues/741)).
 - SqlDatabaseRecoveryModel
   - BREAKING CHANGE: The parameter `ServerName` is now non-mandatory and
     defaults to `$env:COMPUTERNAME` ([issue #319](https://github.com/dsccommunity/SqlServerDsc/issues/319)).

--- a/README.md
+++ b/README.md
@@ -671,11 +671,11 @@ All issues are not listed here, see [here for all open issues](https://github.co
 
 This resource is used to grant, deny or revoke permissions for a user in a database.
 For more information about permissions, please read the article
-[Permissions (Database Engine)](https://msdn.microsoft.com/en-us/library/ms191291.aspx).
+[Permissions (Database Engine)](https://docs.microsoft.com/en-us/sql/relational-databases/security/permissions-database-engine).
 
->Note! When revoking permission with PermissionState 'GrantWithGrant', both the
-grantee and _all the other users the grantee has granted the same permission to_,
-will also get their permission revoked.
+>**Note:** When revoking permission with PermissionState 'GrantWithGrant', both the
+>grantee and _all the other users the grantee has granted the same permission to_,
+>will also get their permission revoked.
 
 #### Requirements
 
@@ -692,8 +692,8 @@ will also get their permission revoked.
 * **`[String]` PermissionState** _(Key)_: The state of the permission.
   { Grant | Deny | GrantWithGrant }.
 * **`[String[]]` Permissions** _(Required)_: The permissions to be granted or denied
-  for the user in the database. Valid permissions can be found in the article
-  [SQL Server Permissions](https://msdn.microsoft.com/en-us/library/ms191291.aspx#Anchor_3).
+  for the user in the database. Valid permission names can be found in the article
+  [DatabasePermissionSet Class properties](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.databasepermissionset#properties).
 * **`[String]` ServerName** _(Write)_: The host name of the SQL Server to be configured.
   Default values is `$env:COMPUTERNAME`.
 * **`[String]` Ensure** _(Write)_: If the permission should be granted (Present)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,6 +161,7 @@ stages:
                   'tests/Integration/DSC_SqlServerReplication.Integration.Tests.ps1'
                   # Group 4
                   'tests/Integration/DSC_SqlScript.Integration.Tests.ps1'
+                  'tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1'
                   # Group 5
                   'tests/Integration/DSC_SqlServerSecureConnection.Integration.Tests.ps1'
                   'tests/Integration/DSC_SqlScriptQuery.Integration.Tests.ps1'
@@ -227,6 +228,7 @@ stages:
                   'tests/Integration/DSC_SqlServerReplication.Integration.Tests.ps1'
                   # Group 4
                   'tests/Integration/DSC_SqlScript.Integration.Tests.ps1'
+                  'tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1'
                   # Group 5
                   'tests/Integration/DSC_SqlServerSecureConnection.Integration.Tests.ps1'
                   'tests/Integration/DSC_SqlScriptQuery.Integration.Tests.ps1'

--- a/source/DSCResources/DSC_SqlDatabasePermission/DSC_SqlDatabasePermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabasePermission/DSC_SqlDatabasePermission.psm1
@@ -35,12 +35,10 @@ function Get-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $DatabaseName,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -50,7 +48,6 @@ function Get-TargetResource
         $PermissionState,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $Permissions,
 
@@ -61,7 +58,6 @@ function Get-TargetResource
 
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $InstanceName
     )
@@ -179,12 +175,10 @@ function Set-TargetResource
         $Ensure,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $DatabaseName,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -194,7 +188,6 @@ function Set-TargetResource
         $PermissionState,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $Permissions,
 
@@ -204,7 +197,6 @@ function Set-TargetResource
         $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $InstanceName = 'MSSQLSERVER'
     )
@@ -331,12 +323,10 @@ function Test-TargetResource
         $Ensure,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $DatabaseName,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
 
@@ -346,7 +336,6 @@ function Test-TargetResource
         $PermissionState,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String[]]
         $Permissions,
 
@@ -356,7 +345,6 @@ function Test-TargetResource
         $ServerName = $env:COMPUTERNAME,
 
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
         [System.String]
         $InstanceName = 'MSSQLSERVER'
     )

--- a/source/DSCResources/DSC_SqlDatabasePermission/en-US/DSC_SqlDatabasePermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabasePermission/en-US/DSC_SqlDatabasePermission.strings.psd1
@@ -1,7 +1,6 @@
 ConvertFrom-StringData @'
     GetDatabasePermission = Get permissions for the user '{0}' in the database '{1}' on the instance '{2}'.
     DatabaseNotFound = The database '{0}' does not exist.
-    FailedToEnumDatabasePermissions = Failed to get the permission for the user '{0}' in the database '{1}'.
     ChangePermissionForUser = Changing the permission for the user '{0}' in the database '{1}' on the instance '{2}'.
     LoginIsNotUser = The login '{0}' is not a user in the database '{1}'.
     AddPermission = {0} the permissions '{1}' to the database '{2}'.

--- a/source/DSCResources/DSC_SqlDatabasePermission/en-US/DSC_SqlDatabasePermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabasePermission/en-US/DSC_SqlDatabasePermission.strings.psd1
@@ -1,12 +1,9 @@
 ConvertFrom-StringData @'
     GetDatabasePermission = Get permissions for the user '{0}' in the database '{1}' on the instance '{2}'.
     DatabaseNotFound = The database '{0}' does not exist.
-    LoginNotFound = The login '{0}' does not exist on the instance.
     FailedToEnumDatabasePermissions = Failed to get the permission for the user '{0}' in the database '{1}'.
     ChangePermissionForUser = Changing the permission for the user '{0}' in the database '{1}' on the instance '{2}'.
     LoginIsNotUser = The login '{0}' is not a user in the database '{1}'.
-    AddingLoginAsUser = Adding the login as a user of the database.
-    FailedToAddUser = Failed to add the login '{0}' as a user of the database '{1}'.
     AddPermission = {0} the permissions '{1}' to the database '{2}'.
     DropPermission = Revoking the {0} permissions '{1}' from the database '{2}'.
     FailedToSetPermissionDatabase = Failed to set the permissions for the login '{0}' in the database '{1}'.

--- a/source/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
+++ b/source/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
@@ -17,28 +17,6 @@ Configuration Example
 
     node localhost
     {
-        SqlServerLogin 'Add_SqlServerLogin_SQLAdmin'
-        {
-            Ensure               = 'Present'
-            Name                 = 'CONTOSO\SQLAdmin'
-            LoginType            = 'WindowsUser'
-            ServerName           = 'sqltest.company.local'
-            InstanceName         = 'DSC'
-
-            PsDscRunAsCredential = $SqlAdministratorCredential
-        }
-
-        SqlServerLogin 'Add_SqlServerLogin_SQLUser'
-        {
-            Ensure               = 'Present'
-            Name                 = 'CONTOSO\SQLUser'
-            LoginType            = 'WindowsUser'
-            ServerName           = 'sqltest.company.local'
-            InstanceName         = 'DSC'
-
-            PsDscRunAsCredential = $SqlAdministratorCredential
-        }
-
         SqlDatabasePermission 'Grant_SqlDatabasePermissions_SQLAdmin_Db01'
         {
             Ensure               = 'Present'

--- a/source/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
+++ b/source/Examples/Resources/SqlDatabasePermission/1-GrantDatabasePermissions.ps1
@@ -23,7 +23,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Grant'
-            Permissions          = 'Connect', 'Update'
+            Permissions          = @('Connect', 'Update')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 
@@ -36,7 +36,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLUser'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Grant'
-            Permissions          = 'Connect', 'Update'
+            Permissions          = @('Connect', 'Update')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 
@@ -49,7 +49,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorksLT'
             PermissionState      = 'Grant'
-            Permissions          = 'Connect', 'Update'
+            Permissions          = @('Connect', 'Update')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 

--- a/source/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
+++ b/source/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
@@ -23,7 +23,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Grant'
-            Permissions          = 'Connect', 'Update'
+            Permissions          = @('Connect', 'Update')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 
@@ -36,7 +36,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'CreateTable'
+            Permissions          = @('Select', 'CreateTable')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 

--- a/source/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
+++ b/source/Examples/Resources/SqlDatabasePermission/2-RevokeDatabasePermissions.ps1
@@ -36,7 +36,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'Create Table'
+            Permissions          = 'Select', 'CreateTable'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 

--- a/source/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/source/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -23,7 +23,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'CreateTable'
+            Permissions          = @('Select', 'CreateTable')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 
@@ -36,7 +36,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLUser'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'CreateTable'
+            Permissions          = @('Select', 'CreateTable')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 
@@ -49,7 +49,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorksLT'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'CreateTable'
+            Permissions          = @('Select', 'CreateTable')
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 

--- a/source/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/source/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -23,7 +23,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'Create Table'
+            Permissions          = 'Select', 'CreateTable'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 
@@ -36,7 +36,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLUser'
             DatabaseName         = 'AdventureWorks'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'Create Table'
+            Permissions          = 'Select', 'CreateTable'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 
@@ -49,7 +49,7 @@ Configuration Example
             Name                 = 'CONTOSO\SQLAdmin'
             DatabaseName         = 'AdventureWorksLT'
             PermissionState      = 'Deny'
-            Permissions          = 'Select', 'Create Table'
+            Permissions          = 'Select', 'CreateTable'
             ServerName           = 'sqltest.company.local'
             InstanceName         = 'DSC'
 

--- a/source/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
+++ b/source/Examples/Resources/SqlDatabasePermission/3-DenyDatabasePermissions.ps1
@@ -17,28 +17,6 @@ Configuration Example
 
     node localhost
     {
-        SqlServerLogin 'Add_SqlServerLogin_SQLAdmin'
-        {
-            Ensure               = 'Present'
-            Name                 = 'CONTOSO\SQLAdmin'
-            LoginType            = 'WindowsUser'
-            ServerName           = 'sqltest.company.local'
-            InstanceName         = 'DSC'
-
-            PsDscRunAsCredential = $SqlAdministratorCredential
-        }
-
-        SqlServerLogin 'Add_SqlServerLogin_SQLUser'
-        {
-            Ensure               = 'Present'
-            Name                 = 'CONTOSO\SQLUser'
-            LoginType            = 'WindowsUser'
-            ServerName           = 'sqltest.company.local'
-            InstanceName         = 'DSC'
-
-            PsDscRunAsCredential = $SqlAdministratorCredential
-        }
-
         SqlDatabasePermission 'Deny_SqlDatabasePermissions_SQLAdmin_Db01'
         {
             Ensure               = 'Present'

--- a/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
@@ -79,7 +79,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
                 $resourceCurrentState.PermissionState | Should -Be 'Grant'
                 'Select' | Should -BeIn $resourceCurrentState.Permissions
-                'Create Table' | Should -BeIn $resourceCurrentState.Permissions
+                'CreateTable' | Should -BeIn $resourceCurrentState.Permissions
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -132,7 +132,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
                 $resourceCurrentState.PermissionState | Should -Be 'Grant'
                 'Select' | Should -Not -BeIn $resourceCurrentState.Permissions
-                'Create Table' | Should -Not -BeIn $resourceCurrentState.Permissions
+                'CreateTable' | Should -Not -BeIn $resourceCurrentState.Permissions
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -185,7 +185,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
                 $resourceCurrentState.PermissionState | Should -Be 'Deny'
                 'Select' | Should -BeIn $resourceCurrentState.Permissions
-                'Create Table' | Should -BeIn $resourceCurrentState.Permissions
+                'CreateTable' | Should -BeIn $resourceCurrentState.Permissions
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -238,7 +238,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
                 $resourceCurrentState.PermissionState | Should -Be 'Deny'
                 'Select' | Should -Not -BeIn $resourceCurrentState.Permissions
-                'Create Table' | Should -Not -BeIn $resourceCurrentState.Permissions
+                'CreateTable' | Should -Not -BeIn $resourceCurrentState.Permissions
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {

--- a/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
@@ -245,6 +245,110 @@ try
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
+
+        $configurationName = "$($script:dscResourceName)_GrantGuest_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be 'guest'
+                $resourceCurrentState.PermissionState | Should -Be 'Grant'
+                'Select' | Should -BeIn $resourceCurrentState.Permissions
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_RemoveGrantGuest_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Absent'
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be 'guest'
+                $resourceCurrentState.PermissionState | Should -Be 'Grant'
+                'Select' | Should -Not -BeIn $resourceCurrentState.Permissions
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
     }
 }
 finally

--- a/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
@@ -1,0 +1,253 @@
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (-not (Test-BuildCategory -Type 'Integration' -Category @('Integration_SQL2016','Integration_SQL2017')))
+{
+    return
+}
+
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlDatabasePermission'
+$script:dscResourceName = "DSC_$($script:dscResourceFriendlyName)"
+
+try
+{
+    Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+}
+catch [System.IO.FileNotFoundException]
+{
+    throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+}
+
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -ResourceType 'Mof' `
+    -TestType 'Integration'
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_Grant_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+                $resourceCurrentState.PermissionState | Should -Be 'Grant'
+                'Select' | Should -BeIn $resourceCurrentState.Permissions
+                'Create Table' | Should -BeIn $resourceCurrentState.Permissions
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_RemoveGrant_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Absent'
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+                $resourceCurrentState.PermissionState | Should -Be 'Grant'
+                'Select' | Should -Not -BeIn $resourceCurrentState.Permissions
+                'Create Table' | Should -Not -BeIn $resourceCurrentState.Permissions
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_Deny_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+                $resourceCurrentState.PermissionState | Should -Be 'Deny'
+                'Select' | Should -BeIn $resourceCurrentState.Permissions
+                'Create Table' | Should -BeIn $resourceCurrentState.Permissions
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_RemoveDeny_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Absent'
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+                $resourceCurrentState.PermissionState | Should -Be 'Deny'
+                'Select' | Should -Not -BeIn $resourceCurrentState.Permissions
+                'Create Table' | Should -Not -BeIn $resourceCurrentState.Permissions
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+    }
+}
+finally
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}

--- a/tests/Integration/DSC_SqlDatabasePermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabasePermission.config.ps1
@@ -53,7 +53,7 @@ Configuration DSC_SqlDatabasePermission_Grant_Config
             PermissionState      = 'Grant'
             Permissions          = @(
                 'Select'
-                'Create Table'
+                'CreateTable'
             )
 
             ServerName           = $Node.ServerName
@@ -84,7 +84,7 @@ Configuration DSC_SqlDatabasePermission_RemoveGrant_Config
             PermissionState      = 'Grant'
             Permissions          = @(
                 'Select'
-                'Create Table'
+                'CreateTable'
             )
 
             ServerName           = $Node.ServerName
@@ -115,7 +115,7 @@ Configuration DSC_SqlDatabasePermission_Deny_Config
             PermissionState      = 'Deny'
             Permissions          = @(
                 'Select'
-                'Create Table'
+                'CreateTable'
             )
 
             ServerName           = $Node.ServerName
@@ -146,7 +146,7 @@ Configuration DSC_SqlDatabasePermission_RemoveDeny_Config
             PermissionState      = 'Deny'
             Permissions          = @(
                 'Select'
-                'Create Table'
+                'CreateTable'
             )
 
             ServerName           = $Node.ServerName

--- a/tests/Integration/DSC_SqlDatabasePermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabasePermission.config.ps1
@@ -158,3 +158,69 @@ Configuration DSC_SqlDatabasePermission_RemoveDeny_Config
         }
     }
 }
+
+<#
+    .SYNOPSIS
+        Grant rights in a database for the guest user.
+
+    .NOTES
+        Regression test for issue #1134.
+#>
+Configuration DSC_SqlDatabasePermission_GrantGuest_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabasePermission 'Integration_Test'
+        {
+            Ensure               = 'Present'
+            Name                 = 'guest'
+            DatabaseName         = $Node.DatabaseName
+            PermissionState      = 'Grant'
+            Permissions          = @(
+                'Select'
+            )
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.UserName, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Remove the granted rights in a database for the guest user.
+
+    .NOTES
+        Regression test for issue #1134.
+#>
+Configuration DSC_SqlDatabasePermission_RemoveGrantGuest_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabasePermission 'Integration_Test'
+        {
+            Ensure               = 'Absent'
+            Name                 = 'guest'
+            DatabaseName         = $Node.DatabaseName
+            PermissionState      = 'Grant'
+            Permissions          = @(
+                'Select'
+            )
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.UserName, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}

--- a/tests/Integration/DSC_SqlDatabasePermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabasePermission.config.ps1
@@ -1,0 +1,160 @@
+#region HEADER
+# Integration Test Config Template Version: 1.2.0
+#endregion
+
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName          = 'localhost'
+                CertificateFile   = $env:DscPublicCertificatePath
+
+                UserName          = "$env:COMPUTERNAME\SqlAdmin"
+                Password          = 'P@ssw0rd1'
+
+                ServerName        = $env:COMPUTERNAME
+                InstanceName      = 'DSCSQLTEST'
+
+                # This is created by the SqlDatabase integration tests.
+                DatabaseName      = 'Database1'
+
+                # This is created by the SqlDatabaseUser integration tests.
+                User1_Name        = 'User1'
+            }
+        )
+    }
+}
+
+<#
+    .SYNOPSIS
+        Grant rights in a database for a user.
+#>
+Configuration DSC_SqlDatabasePermission_Grant_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabasePermission 'Integration_Test'
+        {
+            Ensure               = 'Present'
+            Name                 = $Node.User1_Name
+            DatabaseName         = $Node.DatabaseName
+            PermissionState      = 'Grant'
+            Permissions          = @(
+                'Select'
+                'Create Table'
+            )
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.UserName, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Remove granted rights in the database for a user.
+#>
+Configuration DSC_SqlDatabasePermission_RemoveGrant_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabasePermission 'Integration_Test'
+        {
+            Ensure               = 'Absent'
+            Name                 = $Node.User1_Name
+            DatabaseName         = $Node.DatabaseName
+            PermissionState      = 'Grant'
+            Permissions          = @(
+                'Select'
+                'Create Table'
+            )
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.UserName, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Deny rights in a database for a user.
+#>
+Configuration DSC_SqlDatabasePermission_Deny_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabasePermission 'Integration_Test'
+        {
+            Ensure               = 'Present'
+            Name                 = $Node.User1_Name
+            DatabaseName         = $Node.DatabaseName
+            PermissionState      = 'Deny'
+            Permissions          = @(
+                'Select'
+                'Create Table'
+            )
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.UserName, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Remove deny rights in a database for a user.
+#>
+Configuration DSC_SqlDatabasePermission_RemoveDeny_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabasePermission 'Integration_Test'
+        {
+            Ensure               = 'Absent'
+            Name                 = $Node.User1_Name
+            DatabaseName         = $Node.DatabaseName
+            PermissionState      = 'Deny'
+            Permissions          = @(
+                'Select'
+                'Create Table'
+            )
+
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.UserName, (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force))
+        }
+    }
+}

--- a/tests/Integration/DSC_SqlServerProtocolTcpIp.config.ps1
+++ b/tests/Integration/DSC_SqlServerProtocolTcpIp.config.ps1
@@ -14,7 +14,7 @@ if (Test-Path -Path $configFile)
 else
 {
     $currentIp4Address = Get-NetIPAddress -AddressFamily 'IPv4' |
-        Where-Object -Property 'PrefixOrigin' -EQ 'Dhcp' |
+        Where-Object -Property 'InterfaceAlias' -EQ 'Ethernet' |
             Select-Object -FIrst 1 -ExpandProperty 'IPAddress'
 
     $ConfigurationData = @{

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -323,6 +323,14 @@ Name | Algorithm | Password
 --- | --- | ---
 AsymmetricKey1 | RSA_2048 | P@ssw0rd1
 
+## SqlDatabasePermission
+
+**Run order:** 4
+
+**Depends on:** SqlDatabaseUser
+
+The integration test will not leave anything on any instance.
+
 ## SqlServerReplication
 
 **Run order:** 3

--- a/tests/Unit/DSC_SqlDatabasePermission.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabasePermission.Tests.ps1
@@ -232,24 +232,6 @@ try
                 }
             }
 
-            Context 'When passing values to parameters and login name does not exist' {
-                It 'Should throw the correct error' {
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        DatabaseName    = $mockSqlDatabaseName
-                        Name            = 'unknownLoginName'
-                        PermissionState = 'Grant'
-                        Permissions     = @( 'Connect', 'Update' )
-                    }
-
-                    $errorMessage = $script:localizedData.LoginNotFound -f $testParameters.Name
-
-                    { Get-TargetResource @testParameters } | Should -Throw $errorMessage
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                }
-            }
-
             Context 'When passing values to parameters and database name and login name do exist' {
                 It 'Should throw the correct error with EnumDatabasePermissions method' {
                     $mockInvalidOperationEnumDatabasePermissions = $true
@@ -393,25 +375,6 @@ try
                     }
 
                     $errorMessage = $script:localizedData.DatabaseNotFound -f $testParameters.DatabaseName
-
-                    { Test-TargetResource @testParameters } | Should -Throw $errorMessage
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                }
-            }
-
-            Context 'When passing values to parameters and login name does not exist' {
-                It 'Should throw the correct error' {
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        DatabaseName    = $mockSqlDatabaseName
-                        Name            = 'unknownLoginName'
-                        PermissionState = 'Grant'
-                        Permissions     = @( 'Connect', 'Update' )
-                        Ensure          = 'Present'
-                    }
-
-                    $errorMessage = $script:localizedData.LoginNotFound -f $testParameters.Name
 
                     { Test-TargetResource @testParameters } | Should -Throw $errorMessage
 

--- a/tests/Unit/DSC_SqlDatabasePermission.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabasePermission.Tests.ps1
@@ -224,28 +224,8 @@ try
                         Permissions     = @( 'Connect', 'Update' )
                     }
 
-                    $errorMessage = $script:localizedData.DatabaseNotFound -f $testParameters.DatabaseName
-
-                    { Get-TargetResource @testParameters } | Should -Throw $errorMessage
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                }
-            }
-
-            Context 'When passing values to parameters and database name and login name do exist' {
-                It 'Should throw the correct error with EnumDatabasePermissions method' {
-                    $mockInvalidOperationEnumDatabasePermissions = $true
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        DatabaseName    = $mockSqlDatabaseName
-                        Name            = $mockSqlServerLogin
-                        PermissionState = 'Grant'
-                        Permissions     = @( 'Connect', 'Update' )
-                    }
-
-                    $errorMessage = $script:localizedData.FailedToEnumDatabasePermissions -f $testParameters.Name, $testParameters.DatabaseName
-
-                    { Get-TargetResource @testParameters } | Should -Throw $errorMessage
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should -Be 'Absent'
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                 }
@@ -260,7 +240,7 @@ try
                     Permissions     = @( 'Connect', 'Update', 'Select' )
                 }
 
-                It 'Should return the state as absent when the desired permission does not exist' {
+                It 'Should return the state as present when the key properties exist' {
                     $result = Get-TargetResource @testParameters
                     $result.Ensure | Should -Be 'Absent'
 
@@ -361,25 +341,6 @@ try
         Describe "DSC_SqlDatabasePermission\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
-            }
-
-            Context 'When passing values to parameters and database name does not exist' {
-                It 'Should throw the correct error' {
-                    $testParameters = $mockDefaultParameters
-                    $testParameters += @{
-                        DatabaseName    = 'unknownDatabaseName'
-                        Name            = $mockSqlServerLogin
-                        PermissionState = 'Grant'
-                        Permissions     = @( 'Connect', 'Update' )
-                        Ensure          = 'Present'
-                    }
-
-                    $errorMessage = $script:localizedData.DatabaseNotFound -f $testParameters.DatabaseName
-
-                    { Test-TargetResource @testParameters } | Should -Throw $errorMessage
-
-                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
-                }
             }
 
             Context 'When passing values to parameters and database name and login name do exist' {


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlDatabasePermission
  - BREAKING CHANGE: The resource no longer create the database user if
    it does not exist. Use the resource _SqlDatabaseUser_ to enforce that
    the database user exist in the database prior to setting permissions
    using this resource (issue #848).
  - BREAKING CHANGE: The resource no longer checks if a login exist so that
    it is possible to set permissions for database users that does not
    have a login, e.g. the database user 'guest' (issue #1134).
  - Updated examples.
  - Added integration tests (issue #741).
  - Get-TargetResource will no longer throw an exception if the database
    does not exist.

#### This Pull Request (PR) fixes the following issues

- Fixes #741
- Fixes #848
- Fixes #1134

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1556)
<!-- Reviewable:end -->
