### PR TITLE
SqlDatabaseObjectPermission: New resource

### DIFF
--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -1,7 +1,7 @@
 @{
     CustomRulePath      = '.\output\RequiredModules\DscResource.AnalyzerRules'
     IncludeDefaultRules = $true
-    IncludeRules   = @(
+    IncludeRules        = @(
         # DSC Resource Kit style guideline rules.
         'PSAvoidDefaultValueForMandatoryParameter',
         'PSAvoidDefaultValueSwitchParameter',
@@ -38,7 +38,46 @@
         'PSUseDeclaredVarsMoreThanAssignments',
         'PSUsePSCredentialType',
 
+        # Additional rules
+        'PSUseConsistentWhitespace',
+        'UseCorrectCasing',
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'AlignAssignmentStatement',
+
         'Measure-*'
     )
 
+    Rules               = @{
+        PSUseConsistentWhitespace  = @{
+            Enable                          = $true
+            CheckOpenBrace                  = $false
+            CheckInnerBrace                 = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $false
+            CheckSeparator                  = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhitespace = $true
+            CheckParameter                  = $false
+        }
+
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $false
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $false
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NoEmptyLineBefore  = $true
+            IgnoreOneLineBlock = $false
+            NewLineAfter       = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ in a future release.
 - SqlServerDsc
   - Added new resource SqlProtocol ([issue #1377](https://github.com/dsccommunity/SqlServerDsc/issues/1377)).
   - Added new resource SqlProtocolTcpIp ([issue #1378](https://github.com/dsccommunity/SqlServerDsc/issues/1378)).
+  - Added new resource SqlDatabaseObjectPermission ([issue #1119](https://github.com/dsccommunity/SqlServerDsc/issues/1119)).
   - Fixing a problem with the latest ModuleBuild 1.7.0 that breaks the CI
     pipeline.
   - Prepare repository for auto-documentation by adding README.md to each
@@ -1996,7 +1997,7 @@ in a future release.
 
 ### Changed
 
- Improvements how tests are initiated in AppVeyor
+- Improvements how tests are initiated in AppVeyor
   - Removed previous workaround (issue #201) from unit tests.
   - Changes in appveyor.yml so that SQL modules are removed before common test is
     run.
@@ -2083,8 +2084,8 @@ in a future release.
 - Added common test (xSQLServerCommon.Tests) for xSQLServer module
   - Now all markdown files will be style checked when tests are running in AppVeyor
     after sending in a pull request.
-  - Now all [Examples](/source/Examples/Resources) will be tested by compiling to a .mof
-    file after sending in a pull request.
+  - Now all [Examples](/source/Examples/Resources) will be tested by compiling
+    to a .mof file after sending in a pull request.
 - Changes to xSQLServerDatabaseOwner
   - The example 'SetDatabaseOwner' can now compile, it wrongly had a `DependsOn`
     in the example.
@@ -2164,7 +2165,7 @@ in a future release.
   - Get-TargetResource now works with Get-DscConfiguration.
 - Fixes in xSQLServerRole
   - Updated Ensure parameter to 'Present' default value.
-  - Renamed helper functions *-SqlServerRole to *-SqlServerRoleMember.
+  - Renamed helper functions *-SqlServerRole* to *-SqlServerRoleMember*.
 - Changes to xSQLAlias
   - Add UseDynamicTcpPort parameter for option "Dynamically determine port".
   - Change Get-WmiObject to Get-CimInstance in Resource and associated pester file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,17 @@ in a future release.
     names. Using this parameter the cluster group will only be taken
     offline and back online if the cluster group owner is one specified
     in this parameter.
+  - The helper function `Compare-ResourcePropertyState` was improved to
+    handle embedded instances by adding a parameter `CimInstanceKeyProperties`
+    that can be used to identify the unique parameter for each embedded
+    instance in a collection.
+  - The helper function `Test-DscPropertyState` was improved to evaluate
+    the properties in a single CIM instance or a collection of CIM instances
+    by recursively call itself.
+  - When the helper function `Test-DscPropertyState` evaluated an array
+    the verbose messages was not very descriptive. Instead of outputting
+    the side indicator from the compare it now outputs a descriptive
+    message.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ in a future release.
   is present or absent.
 * [**SqlDatabaseDefaultLocation**](#sqldatabasedefaultlocation) resource
   to manage default locations for Data, Logs, and Backups for SQL Server
+* [**SqlDatabaseObjectPermission**](#sqldatabaseobjectpermission) resource
+  to manage the permissions of database objects in a database for a SQL
+  Server instance.
 * [**SqlDatabasePermission**](#sqldatabasepermission) resource to
   manage SQL database permissions.
 * [**SqlDatabaseRole**](#sqldatabaserole) resource to manage SQL database roles.
@@ -666,6 +669,68 @@ more information about database default locations, please read the article
 #### Known issues
 
 All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlDatabaseDefaultLocation).
+
+### SqlDatabaseObjectPermission
+
+This DSC resource is used to manage the permissions of database objects
+in a database for a SQL Server instance.
+
+For more information about permission names that can be managed, see the
+property names of the [ObjectPermissionSet](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.objectpermissionset#properties) class.
+
+>**Note:** When revoking permission with PermissionState 'GrantWithGrant', both the
+>grantee and _all the other users the grantee has granted the same permission to_,
+>will also get their permission revoked.
+
+#### Requirements
+
+* Target machine must be running Windows Server 2012 or later.
+* Target machine must be running SQL Server 2012 or later.
+* Target machine must have access to the SQLPS PowerShell module or the
+  SqlServer PowerShell module.
+
+#### Parameters
+
+* **`[String]` InstanceName** _(Key)_: Specifies the name of the SQL instance
+  to be configured.
+* **`[String]` DatabaseName** _(Key)_: Specifies the name of the database
+  where the object resides.
+* **`[String]` SchemaName** _(Key)_: Specifies the name of the schema for
+  the database object.
+* **`[String]` ObjectName** _(Key)_: Specifies the name of the database
+  object to set permission for. Can be an empty value when setting permission
+  for a schema.
+* **`[String]` ObjectType** _(Key)_: Specifies the type of the database
+  object specified in parameter `ObjectName`. { Schema | Table | View |
+  StoredProcedure }.
+* **`[String]` Name** _(Key)_: Specifies the name of the database user,
+  user-defined database role, or database application role that will have
+  the permission.
+* **`[DSC_DatabaseObjectPermission[]]` Permission** _(Required)_: Specifies
+  the permissions as an array of embedded instances of the DSC_DatabaseObjectPermission
+  CIM class.
+* **`[String]` ServerName** _(Write)_: Specifies the host name of the SQL
+  Server to be configured. Default value is `$env:COMPUTERNAME`.
+
+##### Embedded instance DSC_DatabaseObjectPermission
+
+* **`[String]` State** _(Key)_: Specifies the state of the permission.
+  Valid values are 'Grant', 'Deny' and 'GrantWithGrant'.
+* **`[String[]]` Permission** _(Required)_: Specifies the set of permissions
+  for the database object for the principal assigned to 'Name'. Valid
+  permission names can be found in the article [ObjectPermissionSet Class properties](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.objectpermissionset#properties).
+* **`[String]` Ensure** _(Key)_: Specifies the desired state of the permission.
+  When set to 'Present', the permissions will be added. When set to 'Absent',
+  the permissions will be removed. Default value is 'Present'.
+
+#### Examples
+
+* [Add Database Permission](/source/Examples/Resources/SqlDatabaseObjectPermission/1-AddDatabaseObjectPermissions.ps1)
+* [Remove Database Permission](/source/Examples/Resources/SqlDatabaseObjectPermission/2-RemoveDatabaseObjectPermissions.ps1)
+
+#### Known issues
+
+All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlDatabaseObjectPermission).
 
 ### SqlDatabasePermission
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,6 +168,7 @@ stages:
                   'tests/Integration/DSC_SqlProtocol.Integration.Tests.ps1'
                   # Group 6 (tests makes changes that could make SQL Server to loose connectivity)
                   'tests/Integration/DSC_SqlProtocolTcpIp.Integration.Tests.ps1'
+                  'tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1'
               )
             name: test
             displayName: 'Run Integration Test'
@@ -235,6 +236,7 @@ stages:
                   'tests/Integration/DSC_SqlProtocol.Integration.Tests.ps1'
                   # Group 6 (tests makes changes that could make SQL Server to loose connectivity)
                   'tests/Integration/DSC_SqlProtocolTcpIp.Integration.Tests.ps1'
+                  'tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1'
               )
             name: test
             displayName: 'Run Integration Test'

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -1,0 +1,807 @@
+$script:sqlServerDscHelperModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\SqlServerDsc.Common'
+$script:resourceHelperModulePath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\DscResource.Common'
+
+Import-Module -Name $script:sqlServerDscHelperModulePath
+Import-Module -Name $script:resourceHelperModulePath
+
+$script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
+
+<#
+    .SYNOPSIS
+        Returns the current permissions for the object in the database.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL instance to be configured.
+
+    .PARAMETER DatabaseName
+        Specifies the name of the database where the object resides.
+
+    .PARAMETER SchemaName
+        Specifies the name of the schema for the database object.
+
+    .PARAMETER ObjectName
+        Specifies the name of the database object to set permission for.
+        Can be an empty value when setting permission for a schema.
+
+    .PARAMETER ObjectType
+        Specifies the type of the database object to set permission for.
+
+    .PARAMETER Name
+        Specifies the name of the database user, user-defined database role, or
+        database application role that will have the permission.
+
+    .PARAMETER Permission
+        Specifies the permissions as an array of embedded instances of the
+        DSC_DatabaseObjectPermission CIM class.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value
+        is $env:COMPUTERNAME.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DatabaseName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SchemaName,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [System.String]
+        $ObjectName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Schema', 'Table', 'View', 'StoredProcedure')]
+        [System.String]
+        $ObjectType,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Permission,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME
+    )
+
+    Write-Verbose -Message (
+        $script:localizedData.GetObjectPermission -f ('{0}.{1}' -f $SchemaName, $ObjectName), $ObjectType, $DatabaseName, $InstanceName, $ServerName
+    )
+
+    $Permission = Assert-PermissionEnsureProperty -Permission $Permission
+
+    # Create an empty collection of CimInstance that we can return.
+    $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+    $returnValue = @{
+        ServerName   = $ServerName
+        InstanceName = $InstanceName
+        DatabaseName = $DatabaseName
+        SchemaName   = $SchemaName
+        ObjectName   = $ObjectName
+        ObjectType   = $ObjectType
+        Name         = $Name
+        Permission   = $cimInstancePermissionCollection
+    }
+
+    $getDatabaseObjectParameters = @{
+        ServerName   = $ServerName
+        InstanceName = $InstanceName
+        DatabaseName = $DatabaseName
+        SchemaName   = $SchemaName
+        ObjectName   = $ObjectName
+        ObjectType   = $ObjectType
+    }
+
+    $sqlObject = Get-DatabaseObject @getDatabaseObjectParameters
+
+    if ($sqlObject)
+    {
+        # Get the names of the possible permissions by creating an empty object.
+        $permissionProperties = (
+            New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.ObjectPermissionSet' |
+                Get-Member -MemberType 'Property'
+        ).Name
+
+        # Loop through each desired permission state.
+        foreach ($desiredPermission in $Permission)
+        {
+            [System.String[]] $currentObjectPermissionNames = @()
+
+            # Get all current permissions for the permission state.
+            $currentObjectPermissions = $sqlObject.EnumObjectPermissions($Name) |
+                Where-Object -FilterScript {
+                    $_.PermissionState -eq $desiredPermission.State
+                }
+
+            if ($currentObjectPermissions)
+            {
+                # Loop through each property to see if it is set to $true
+                foreach ($currentPermissionProperty in $permissionProperties)
+                {
+                    if ($true -in $currentObjectPermissions.PermissionType.$currentPermissionProperty)
+                    {
+                        $currentObjectPermissionNames += $currentPermissionProperty
+                    }
+                }
+
+                # Remove any duplicate permission names.
+                $currentObjectPermissionNames = @(
+                    $currentObjectPermissionNames |
+                        Sort-Object -Unique
+                )
+            }
+
+            $compareObjectParameters = @{
+                ReferenceObject  = $desiredPermission.Permission
+                DifferenceObject = $currentObjectPermissionNames
+            }
+
+            $resultOfPermissionCompare = Compare-Object @compareObjectParameters |
+                Where-Object -FilterScript {
+                    $_.SideIndicator -eq '<='
+                }
+
+            # If there are no missing permission then return 'Ensure' state as 'Present'.
+            if ($null -eq $resultOfPermissionCompare)
+            {
+                $currentState = 'Present'
+            }
+            else
+            {
+                $currentState = 'Absent'
+            }
+
+            $cimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                -Permission $desiredPermission.Permission `
+                -PermissionState $desiredPermission.State `
+                -Ensure $currentState
+        }
+
+        $returnValue['Permission'] = $cimInstancePermissionCollection
+    }
+
+    return $returnValue
+}
+
+<#
+    .SYNOPSIS
+        Sets the permissions for the object in the database.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL instance to be configured.
+
+    .PARAMETER DatabaseName
+        Specifies the name of the database where the object resides.
+
+    .PARAMETER SchemaName
+        Specifies the name of the schema for the database object.
+
+    .PARAMETER ObjectName
+        Specifies the name of the database object to set permission for.
+        Can be an empty value when setting permission for a schema.
+
+    .PARAMETER ObjectType
+        Specifies the type of the database object to set permission for.
+
+    .PARAMETER Name
+        Specifies the name of the database user, user-defined database role, or
+        database application role that will have the permission.
+
+    .PARAMETER Permission
+        Specifies the permissions as an array of embedded instances of the
+        DSC_DatabaseObjectPermission CIM class.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value
+        is $env:COMPUTERNAME.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DatabaseName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SchemaName,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [System.String]
+        $ObjectName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Schema', 'Table', 'View', 'StoredProcedure')]
+        [System.String]
+        $ObjectType,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Permission,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME
+    )
+
+    $Permission = Assert-PermissionEnsureProperty -Permission $Permission
+
+    <#
+        Compare the current state against the desired state. Calling this will
+        also import the necessary module to later call Get-ServerProtocolObject
+        which uses the SMO class ManagedComputer.
+    #>
+    $propertyState = Compare-TargetResourceState @PSBoundParameters
+
+    # Get all properties that are not in desired state.
+    $propertiesNotInDesiredState = $propertyState.Where( { -not $_.InDesiredState })
+
+    if ($propertiesNotInDesiredState.Count -gt 0)
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SetDesiredState -f ('{0}.{1}' -f $SchemaName, $ObjectName)
+        )
+
+        $getDatabaseObjectParameters = @{
+            ServerName   = $ServerName
+            InstanceName = $InstanceName
+            DatabaseName = $DatabaseName
+            SchemaName   = $SchemaName
+            ObjectName   = $ObjectName
+            ObjectType   = $ObjectType
+        }
+
+        $sqlObject = Get-DatabaseObject @getDatabaseObjectParameters
+
+        if ($sqlObject)
+        {
+            $permissionProperty = $propertiesNotInDesiredState.Where( { $_.ParameterName -eq 'Permission' })
+
+            # Check if Permission property need updating.
+            if ($permissionProperty)
+            {
+                # Loop through each desired permission state.
+                foreach ($desiredPermissionState in $Permission)
+                {
+                    # Get the equivalent permission state form the current state.
+                    $currentPermissionState = $permissionProperty.Actual.Where({ $_.State -eq $desiredPermissionState.State })
+
+                    if ($desiredPermissionState.Ensure -ne $currentPermissionState.Ensure)
+                    {
+                        try
+                        {
+                            $permissionSet = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.ObjectPermissionSet'
+
+                            # Prepare the desired permission set to assign to the object.
+                            foreach ($permissionName in $desiredPermissionState.Permission)
+                            {
+                                $permissionSet."$permissionName" = $true
+                            }
+
+                            switch ($desiredPermissionState.Ensure)
+                            {
+                                'Present'
+                                {
+                                    Write-Verbose -Message (
+                                        $script:localizedData.SetPermission -f @(
+                                            ($desiredPermissionState.Permission -join ','),
+                                            $Name
+                                            $desiredPermissionState.State,
+                                            ('{0}.{1}' -f $SchemaName, $ObjectName),
+                                            $ObjectType,
+                                            $DatabaseName
+                                        )
+                                    )
+
+                                    switch ($desiredPermissionState.State)
+                                    {
+                                        'GrantWithGrant'
+                                        {
+                                            $sqlObject.Grant($permissionSet, $Name, $true)
+                                        }
+
+                                        'Grant'
+                                        {
+                                            $sqlObject.Grant($permissionSet, $Name)
+                                        }
+
+                                        'Deny'
+                                        {
+                                            $sqlObject.Deny($permissionSet, $Name)
+                                        }
+                                    }
+                                }
+
+                                'Absent'
+                                {
+                                    Write-Verbose -Message (
+                                        $script:localizedData.RevokePermission -f @(
+                                            ($desiredPermissionState.Permission -join ','),
+                                            $Name
+                                            $desiredPermissionState.State,
+                                            ('{0}.{1}' -f $SchemaName, $ObjectName),
+                                            $ObjectType,
+                                            $DatabaseName
+                                        )
+                                    )
+
+                                    if ($desiredPermissionState.State -eq 'GrantWithGrant')
+                                    {
+                                        $sqlObject.Revoke($permissionSet, $Name, $false, $true)
+                                    }
+                                    else
+                                    {
+                                        $sqlObject.Revoke($permissionSet, $Name)
+                                    }
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            $errorMessage = $script:localizedData.FailedToSetDatabaseObjectPermission -f @(
+                                $Name,
+                                ('{0}.{1}' -f $SchemaName, $ObjectName),
+                                $DatabaseName
+                            )
+
+                            New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+                        }
+                    }
+                    else
+                    {
+                        Write-Verbose -Message (
+                            $script:localizedData.PermissionStateInDesiredState -f @(
+                                $desiredPermissionState.State,
+                                ('{0}.{1}' -f $SchemaName, $ObjectName)
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        else
+        {
+            $errorMessage = $script:localizedData.FailedToGetDatabaseObject -f @(
+                ('{0}.{1}' -f $SchemaName, $ObjectName),
+                $ObjectType,
+                $DatabaseName
+            )
+
+            New-InvalidOperationException -Message $errorMessage
+        }
+    }
+    else
+    {
+        Write-Verbose -Message (
+            $script:localizedData.DatabaseObjectIsInDesiredState -f $ObjectName, $ObjectType
+        )
+    }
+}
+
+<#
+    .SYNOPSIS
+        Determines if the permissions is set for the object in the database.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL instance to be configured.
+
+    .PARAMETER DatabaseName
+        Specifies the name of the database where the object resides.
+
+    .PARAMETER SchemaName
+        Specifies the name of the schema for the database object.
+
+    .PARAMETER ObjectName
+        Specifies the name of the database object to set permission for.
+        Can be an empty value when setting permission for a schema.
+
+    .PARAMETER ObjectType
+        Specifies the type of the database object to set permission for.
+
+    .PARAMETER Name
+        Specifies the name of the database user, user-defined database role, or
+        database application role that will have the permission.
+
+    .PARAMETER Permission
+        Specifies the permissions as an array of embedded instances of the
+        DSC_DatabaseObjectPermission CIM class.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value
+        is $env:COMPUTERNAME.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DatabaseName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SchemaName,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [System.String]
+        $ObjectName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Schema', 'Table', 'View', 'StoredProcedure')]
+        [System.String]
+        $ObjectType,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Permission,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME
+    )
+
+    $fullObjectName = '{0}.{1}' -f $SchemaName, $ObjectName
+
+    Write-Verbose -Message (
+        $script:localizedData.TestDesiredState -f @(
+            $fullObjectName,
+            $ObjectType,
+            $DatabaseName,
+            $InstanceName,
+            $ServerName
+        )
+    )
+
+    $propertyState = Compare-TargetResourceState @PSBoundParameters
+
+    if ($false -in $propertyState.InDesiredState)
+    {
+        $testTargetResourceReturnValue = $false
+
+        Write-Verbose -Message (
+            $script:localizedData.NotInDesiredState -f $fullObjectName
+        )
+    }
+    else
+    {
+        $testTargetResourceReturnValue = $true
+
+        Write-Verbose -Message (
+            $script:localizedData.InDesiredState -f $fullObjectName
+        )
+    }
+
+    return $testTargetResourceReturnValue
+}
+
+<#
+    .SYNOPSIS
+        Determines if the permissions is set for the object in the database.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL instance to be configured.
+
+    .PARAMETER DatabaseName
+        Specifies the name of the database where the object resides.
+
+    .PARAMETER SchemaName
+        Specifies the name of the schema for the database object.
+
+    .PARAMETER ObjectName
+        Specifies the name of the database object to set permission for.
+        Can be an empty value when setting permission for a schema.
+
+    .PARAMETER ObjectType
+        Specifies the type of the database object to set permission for.
+
+    .PARAMETER Name
+        Specifies the name of the database user, user-defined database role, or
+        database application role that will have the permission.
+
+    .PARAMETER Permission
+        Specifies the permissions as an array of embedded instances of the
+        DSC_DatabaseObjectPermission CIM class.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value
+        is $env:COMPUTERNAME.
+#>
+function Compare-TargetResourceState
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DatabaseName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SchemaName,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [System.String]
+        $ObjectName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Schema', 'Table', 'View', 'StoredProcedure')]
+        [System.String]
+        $ObjectType,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Permission,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ServerName = $env:COMPUTERNAME
+    )
+
+    $Permission = Assert-PermissionEnsureProperty -Permission $Permission
+
+    $getTargetResourceParameters = @{
+        InstanceName = $InstanceName
+        DatabaseName = $DatabaseName
+        SchemaName   = $SchemaName
+        ObjectName   = $ObjectName
+        ObjectType   = $ObjectType
+        Name         = $Name
+        Permission   = $Permission
+        ServerName   = $ServerName
+    }
+
+    <#
+        We remove any parameters not passed by $PSBoundParameters so that
+        Get-TargetResource can also evaluate $PSBoundParameters correctly.
+
+        Need the @() around the Keys property to get a new array to enumerate.
+    #>
+    @($getTargetResourceParameters.Keys) | ForEach-Object {
+        if (-not $PSBoundParameters.ContainsKey($_))
+        {
+            $getTargetResourceParameters.Remove($_)
+        }
+    }
+
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+    $compareTargetResourceStateParameters = @{
+        CurrentValues            = $getTargetResourceResult
+        DesiredValues            = $PSBoundParameters
+        Properties               = @(
+            'Permission'
+        )
+        <#
+            This is the property that makes each DSC_DatabaseObjectPermission
+            CIM instance unique in the collection. It will be used to filter out
+            the values to compare against in the current state.
+        #>
+        CimInstanceKeyProperties = @{
+            Permission = 'State'
+        }
+    }
+
+    return Compare-ResourcePropertyState @compareTargetResourceStateParameters
+}
+
+<#
+    .SYNOPSIS
+        Returns the object class for the specified name och object type.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. Default value
+        is $env:COMPUTERNAME.
+
+    .PARAMETER InstanceName
+        Specifies the name of the SQL instance to be configured.
+
+    .PARAMETER DatabaseName
+        Specifies the name of the database where the object resides.
+
+    .PARAMETER SchemaName
+        Specifies the name of the schema for the database object.
+
+    .PARAMETER ObjectName
+        Specifies the name of the database object to set per mission for.
+        Can be an empty value when setting permission for a schema.
+
+    .PARAMETER ObjectType
+        Specifies the type of the database object to set permission for.
+#>
+function Get-DatabaseObject
+{
+    [CmdletBinding()]
+    [OutputType([PSObject])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ServerName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $InstanceName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DatabaseName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SchemaName,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [System.String]
+        $ObjectName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Schema', 'Table', 'View', 'StoredProcedure')]
+        [System.String]
+        $ObjectType
+    )
+
+    $sqlObject = $null
+
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+
+    if ($sqlServerObject)
+    {
+        $sqlDatabaseObject = $sqlServerObject.Databases[$DatabaseName]
+
+        if ($sqlDatabaseObject)
+        {
+            $sqlObject = switch ($ObjectType)
+            {
+                'Schema'
+                {
+                    $sqlDatabaseObject.Schemas.Item($SchemaName)
+                }
+
+                'Table'
+                {
+                    $sqlDatabaseObject.Tables.Item($ObjectName, $SchemaName)
+                }
+
+                'StoredProcedure'
+                {
+                    $sqlDatabaseObject.StoredProcedures.Item($ObjectName, $SchemaName)
+                }
+
+                'View'
+                {
+                    $sqlDatabaseObject.Views.Item($ObjectName, $SchemaName)
+                }
+            }
+        }
+    }
+
+    return $sqlObject
+}
+
+<#
+    .SYNOPSIS
+        Converts permission names to DSC_DatabaseObjectPermission CIM class.
+
+    .PARAMETER PermissionName
+        Specifies array of permission names.
+#>
+function ConvertTo-CimDatabaseObjectPermission
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Management.Infrastructure.CimInstance])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [AllowNull()]
+        [System.String[]]
+        $Permission,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PermissionState,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey('Ensure'))
+    {
+        $Ensure = 'Present'
+    }
+
+    $cimClassName = 'DSC_DatabaseObjectPermission'
+    $cimNamespace = 'root/microsoft/Windows/DesiredStateConfiguration'
+
+    $cimProperties = @{
+        State      = $PermissionState
+        Permission = $Permission
+        Ensure     = $Ensure
+    }
+
+    return New-CimInstance -ClassName $cimClassName `
+        -Namespace $cimNamespace `
+        -Property $cimProperties `
+        -ClientOnly
+}
+
+function Assert-PermissionEnsureProperty
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Management.Infrastructure.CimInstance[]])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Permission
+    )
+
+    <#
+        If Ensure property is not set in the desired permission, then
+        default to 'Present'.
+    #>
+    foreach ($desiredPermission in $Permission)
+    {
+        if (-not $desiredPermission.Ensure)
+        {
+            $desiredPermission.Ensure = 'Present'
+        }
+    }
+
+    return $Permission
+}

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.schema.mof
@@ -1,0 +1,20 @@
+[ClassVersion("1.0.0.0"), FriendlyName("SqlDatabaseObjectPermission")]
+class DSC_SqlDatabaseObjectPermission : OMI_BaseResource
+{
+    [Key, Description("Specifies the name of the SQL instance to be configured.")] String InstanceName;
+    [Key, Description("Specifies the name of the database where the object resides.")] String DatabaseName;
+    [Key, Description("Specifies the name of the schema for the database object.")] String SchemaName;
+    [Key, Description("Specifies the name of the database object to set permission for. Can be an empty value when setting permission for a schema.")] String ObjectName;
+    [Key, Description("Specifies the type of the database object specified in parameter ObjectName."), ValueMap{"Schema", "Table","View","StoredProcedure"}, Values{"Schema", "Table","View","StoredProcedure"}] String ObjectType;
+    [Key, Description("Specifies the name of the database user, user-defined database role, or database application role that will have the permission.")] String Name;
+    [Required, EmbeddedInstance("DSC_DatabaseObjectPermission"), Description("Specifies the permissions as an array of embedded instances of the DSC_DatabaseObjectPermission CIM class.")] String Permission[];
+    [Write, Description("Specifies the host name of the SQL Server to be configured. Default value is $env:COMPUTERNAME.")] String ServerName;
+};
+
+[ClassVersion("1.0.0")]
+class DSC_DatabaseObjectPermission
+{
+    [Key, Description("Specifies the state of the permission. Valid values are 'Grant', 'Deny' and 'GrantWithGrant'."), ValueMap{"Grant","Deny","GrantWithGrant"}, Values{"Grant","Deny","GrantWithGrant"}] String State;
+    [Required, Description("Specifies the set of permissions for the database object for the principal assigned to 'Name'.")] String Permission[];
+    [Write, Description("Specifies the desired state of the permission. When set to 'Present', the permissions will be added. When set to 'Absent', the permissions will be removed. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+};

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/README.md
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/README.md
@@ -6,9 +6,28 @@ of database objects in a database for a SQL Server instance.
 For more information about permission names that can be managed, see the
 property names of the [ObjectPermissionSet](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.objectpermissionset#properties) class.
 
+>**Note:** When revoking permission with PermissionState 'GrantWithGrant', both the
+>grantee and _all the other users the grantee has granted the same permission to_,
+>will also get their permission revoked.
+
 ## Requirements
 
 * Target machine must be running Windows Server 2012 or later.
 * Target machine must be running SQL Server 2012 or later.
 * Target machine must have access to the SQLPS PowerShell module or the
   SqlServer PowerShell module.
+
+## Embedded instance DSC_DatabaseObjectPermission
+
+* **`[String]` State** _(Key)_: Specifies the state of the permission.
+  Valid values are 'Grant', 'Deny' and 'GrantWithGrant'.
+* **`[String[]]` Permission** _(Required)_: Specifies the set of permissions
+  for the database object for the principal assigned to 'Name'. Valid
+  permission names can be found in the article [ObjectPermissionSet Class properties](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.objectpermissionset#properties).
+* **`[String]` Ensure** _(Key)_: Specifies the desired state of the permission.
+  When set to 'Present', the permissions will be added. When set to 'Absent',
+  the permissions will be removed. Default value is 'Present'.
+
+## Known issues
+
+All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlDatabaseObjectPermission).

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/README.md
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/README.md
@@ -1,0 +1,14 @@
+# Description
+
+The `SqlDatabaseObjectPermission` DSC resource manage the permissions
+of database objects in a database for a SQL Server instance.
+
+For more information about permission names that can be managed, see the
+property names of the [ObjectPermissionSet](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.objectpermissionset#properties) class.
+
+## Requirements
+
+* Target machine must be running Windows Server 2012 or later.
+* Target machine must be running SQL Server 2012 or later.
+* Target machine must have access to the SQLPS PowerShell module or the
+  SqlServer PowerShell module.

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
@@ -1,0 +1,13 @@
+ConvertFrom-StringData @'
+    GetObjectPermission = Getting the current state of the permissions for the database object '{0}' of type '{1}' in the database '{2}' for the instance '{3}' on the server '{4}'. (SDOP0001)
+    TestDesiredState = Determining the current state of the permissions for the database object '{0}' of type '{1}' in the database '{2}' for the instance '{3}' on the server '{4}'. (SDOP0002)
+    NotInDesiredState = The permissions for the database object '{0}' is not in desired state. (SDOP0003)
+    InDesiredState = The permissions for the database object '{0}' is in desired state. (SDOP0004)
+    FailedToGetDatabaseObject = Failed to get the database object '{0}' of type '{1}' in the database '{2}'. (SDOP0005)
+    DatabaseObjectIsInDesiredState = The database object '{0}' of type '{1}' is already in desired state. (SDOP0006)
+    SetPermission = Setting permissions '{0}' for the user '{1}' with the state '{2}' for the database object '{3}' of type '{4}' in the database '{5}' (SDOP0007)
+    RevokePermission = Revoking permissions '{0}' for the user '{1}' and the state '{2}' for the database object '{3}' of type '{4}' in the database '{5}' (SDOP0008)
+    SetDesiredState = Setting the desired permissions for the database object '{0}'. (SDOP0009)
+    FailedToSetDatabaseObjectPermission = Failed to set the permissions for the user '{0}' on the database object '{1}' in the database '{2}'. (SDOP0009)
+    PermissionStateInDesiredState = The permission state '{0}' is already in desired state for database object '{1}'.
+'@

--- a/source/Examples/Resources/SqlDatabaseObjectPermission/1-AddDatabaseObjectPermissions.ps1
+++ b/source/Examples/Resources/SqlDatabaseObjectPermission/1-AddDatabaseObjectPermissions.ps1
@@ -1,0 +1,51 @@
+<#
+    .DESCRIPTION
+        This example shows how to ensure that the user 'TestAppRole' is given
+        the desired permission for a table in the database "AdventureWorks".
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SqlAdministratorCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlDatabaseObjectPermission 'Table1_TestAppRole_Permission'
+        {
+            ServerName           = 'testclu01a'
+            InstanceName         = 'sql2014'
+            DatabaseName         = 'AdventureWorks'
+            SchemaName           = 'dbo'
+            ObjectName           = 'Table1'
+            ObjectType           = 'Table'
+            Name                 = 'TestAppRole'
+            Permission           = @(
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'GrantWithGrant'
+                    Permission = @('Select')
+                }
+
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Grant'
+                    Permission = @('Update')
+                }
+
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Deny'
+                    Permission = @('Delete', 'Alter')
+                }
+            )
+
+            PSDscRunAsCredential = $SqlAdministratorCredential
+        }
+    }
+}

--- a/source/Examples/Resources/SqlDatabaseObjectPermission/2-RemoveDatabaseObjectPermissions.ps1
+++ b/source/Examples/Resources/SqlDatabaseObjectPermission/2-RemoveDatabaseObjectPermissions.ps1
@@ -1,0 +1,54 @@
+<#
+    .DESCRIPTION
+        This example shows how to revoke permissions for the user 'TestAppRole'
+        for a table in the database "AdventureWorks".
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SqlAdministratorCredential
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlDatabaseObjectPermission 'Table1_TestAppRole_Permission'
+        {
+            ServerName           = 'testclu01a'
+            InstanceName         = 'sql2014'
+            DatabaseName         = 'AdventureWorks'
+            SchemaName           = 'dbo'
+            ObjectName           = 'Table1'
+            ObjectType           = 'Table'
+            Name                 = 'TestAppRole'
+            Permission           = @(
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'GrantWithGrant'
+                    Permission = @('Select')
+                    Ensure     = 'Absent'
+                }
+
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Grant'
+                    Permission = @('Update')
+                    Ensure     = 'Absent'
+                }
+
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Deny'
+                    Permission = @('Delete', 'Alter')
+                    Ensure     = 'Absent'
+                }
+            )
+
+            PSDscRunAsCredential = $SqlAdministratorCredential
+        }
+    }
+}

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -54,7 +54,6 @@ ConvertFrom-StringData @'
     EvaluatePropertyState = Evaluating the state of the property '{0}'. (SQLCOMMON0059)
     PropertyInDesiredState = The parameter '{0}' is in desired state. (SQLCOMMON0060)
     PropertyNotInDesiredState = The parameter '{0}' is not in desired state. (SQLCOMMON0061)
-    ArrayValueThatDoesNotMatch = {0} - {1} (SQLCOMMON0062)
     PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
@@ -62,4 +61,10 @@ ConvertFrom-StringData @'
     NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0067)
     LoadedAssembly = Loaded the assembly '{0}'. (SQLCOMMON0068)
     FailedToLoadAssembly = Failed to load the assembly '{0}'. (SQLCOMMON0069)
+    TooManyCimInstances = More than one CIM instance was returned from the current state. (SQLCOMMON0070)
+    TestingCimInstance = Testing CIM instance '{0}' with the key properties '{1}'. (SQLCOMMON0071)
+    MissingCimInstance = The CIM instance '{0}' with the key properties '{1}' is missing. (SQLCOMMON0072)
+    ArrayValueIsAbsent = The array value '{0}' is absent. (SQLCOMMON0073)
+    ArrayValueIsPresent = The array value '{0}' is present. (SQLCOMMON0073)
+    KeyPropertiesMissing = The hashtable passed to function Test-DscPropertyState is missing the key 'KeyProperties'. This must be set to the property names that makes each instance in the CIM instance collection unique. (SQLCOMMON0074)
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -60,7 +60,6 @@ ConvertFrom-StringData @'
     EvaluatePropertyState = Evaluating the state of the property '{0}'. (SQLCOMMON0059)
     PropertyInDesiredState = The parameter '{0}' is in desired state. (SQLCOMMON0060)
     PropertyNotInDesiredState = The parameter '{0}' is not in desired state. (SQLCOMMON0061)
-    ArrayValueThatDoesNotMatch = {0} - {1} (SQLCOMMON0062)
     PropertyValueOfTypeDoesNotMatch = {0} value does not match. Current value is '{1}', but expected the value '{2}'. (SQLCOMMON0063)
     UnableToCompareType = Unable to compare the type {0} as it is not handled by the Test-DscPropertyState cmdlet. (SQLCOMMON0064)
     ArrayDoesNotMatch = One or more values in an array does not match the desired state. Details of the changes are below. (SQLCOMMON0065)
@@ -68,4 +67,10 @@ ConvertFrom-StringData @'
     NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0067)
     LoadedAssembly = Loaded the assembly '{0}'. (SQLCOMMON0068)
     FailedToLoadAssembly = Failed to load the assembly '{0}'. (SQLCOMMON0069)
+    TooManyCimInstances = More than one CIM instance was returned from the current state. (SQLCOMMON0070)
+    TestingCimInstance = Testing CIM instance '{0}' with the key properties '{1}'. (SQLCOMMON0071)
+    MissingCimInstance = The CIM instance '{0}' with the key properties '{1}' is missing. (SQLCOMMON0072)
+    ArrayValueIsAbsent = The array value '{0}' is absent. (SQLCOMMON0073)
+    ArrayValueIsPresent = The array value '{0}' is present. (SQLCOMMON0073)
+    KeyPropertiesMissing = The hashtable passed to function Test-DscPropertyState is missing the key 'KeyProperties'. This must be set to the property names that makes each instance in the CIM instance collection unique. (SQLCOMMON0074)
 '@

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -1,0 +1,170 @@
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
+if (-not (Test-BuildCategory -Type 'Integration' -Category @('Integration_SQL2016','Integration_SQL2017')))
+{
+    return
+}
+
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceFriendlyName = 'SqlDatabaseObjectPermission'
+$script:dscResourceName = "DSC_$($script:dscResourceFriendlyName)"
+
+try
+{
+    Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+}
+catch [System.IO.FileNotFoundException]
+{
+    throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+}
+
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -ResourceType 'Mof' `
+    -TestType 'Integration'
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_Prerequisites_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_Grant_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+
+                # TODO: Make sure to test all properties.
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        $configurationName = "$($script:dscResourceName)_Revoke_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+
+                # TODO: Make sure to test all properties.
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+    }
+}
+finally
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -107,17 +107,17 @@ try
                 $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
 
-                $getTargetResourceResult.Permission | Should -HaveCount 2
-                $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
-                $getTargetResourceResult.Permission[1] | Should -BeOfType 'CimInstance'
+                $resourceCurrentState.Permission | Should -HaveCount 2
+                $resourceCurrentState.Permission[0] | Should -BeOfType 'CimInstance'
+                $resourceCurrentState.Permission[1] | Should -BeOfType 'CimInstance'
 
-                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Grant' })
+                $grantPermission = $resourceCurrentState.Permission.Where( { $_.State -eq 'Grant' })
                 $grantPermission | Should -Not -BeNullOrEmpty
                 $grantPermission.Ensure | Should -Be 'Present'
                 $grantPermission.Permission | Should -HaveCount 1
                 $grantPermission.Permission | Should -Contain @('Select')
 
-                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Deny' })
+                $grantPermission = $resourceCurrentState.Permission.Where( { $_.State -eq 'Deny' })
                 $grantPermission | Should -Not -BeNullOrEmpty
                 $grantPermission.Ensure | Should -Be 'Present'
                 $grantPermission.Permission | Should -HaveCount 2
@@ -176,17 +176,17 @@ try
                 $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
 
-                $getTargetResourceResult.Permission | Should -HaveCount 2
-                $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
-                $getTargetResourceResult.Permission[1] | Should -BeOfType 'CimInstance'
+                $resourceCurrentState.Permission | Should -HaveCount 2
+                $resourceCurrentState.Permission[0] | Should -BeOfType 'CimInstance'
+                $resourceCurrentState.Permission[1] | Should -BeOfType 'CimInstance'
 
-                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Grant' })
+                $grantPermission = $resourceCurrentState.Permission.Where( { $_.State -eq 'Grant' })
                 $grantPermission | Should -Not -BeNullOrEmpty
                 $grantPermission.Ensure | Should -Be 'Absent'
                 $grantPermission.Permission | Should -HaveCount 1
                 $grantPermission.Permission | Should -Contain @('Select')
 
-                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Deny' })
+                $grantPermission = $resourceCurrentState.Permission.Where( { $_.State -eq 'Deny' })
                 $grantPermission | Should -Not -BeNullOrEmpty
                 $grantPermission.Ensure | Should -Be 'Absent'
                 $grantPermission.Permission | Should -HaveCount 2

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -103,7 +103,7 @@ try
                 $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
                 $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
                 $resourceCurrentState.SchemaName | Should -Be $ConfigurationData.AllNodes.SchemaName
-                $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.ObjectName
+                $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.TableName
                 $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
 
@@ -172,7 +172,7 @@ try
                 $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
                 $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
                 $resourceCurrentState.SchemaName | Should -Be $ConfigurationData.AllNodes.SchemaName
-                $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.ObjectName
+                $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.TableName
                 $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
 

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -182,7 +182,7 @@ try
 
                 $grantPermission = $resourceCurrentState.Permission.Where( { $_.State -eq 'Grant' })
                 $grantPermission | Should -Not -BeNullOrEmpty
-                $grantPermission.Ensure | Should -Be 'Absent'
+                $grantPermission.Ensure | Should -Be 'Present'
                 $grantPermission.Permission | Should -HaveCount 1
                 $grantPermission.Permission | Should -Contain @('Select')
 

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -102,9 +102,27 @@ try
                 $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
                 $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
                 $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.SchemaName | Should -Be $ConfigurationData.AllNodes.SchemaName
+                $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.ObjectName
+                $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
 
-                # TODO: Make sure to test all properties.
+                $getTargetResourceResult.Permission | Should -HaveCount 2
+                $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
+                $getTargetResourceResult.Permission[1] | Should -BeOfType 'CimInstance'
+
+                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Grant' })
+                $grantPermission | Should -Not -BeNullOrEmpty
+                $grantPermission.Ensure | Should -Be 'Present'
+                $grantPermission.Permission | Should -HaveCount 1
+                $grantPermission.Permission | Should -Contain @('Select')
+
+                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Deny' })
+                $grantPermission | Should -Not -BeNullOrEmpty
+                $grantPermission.Ensure | Should -Be 'Present'
+                $grantPermission.Permission | Should -HaveCount 2
+                $grantPermission.Permission | Should -Contain @('Delete')
+                $grantPermission.Permission | Should -Contain @('Alter')
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -153,9 +171,27 @@ try
                 $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
                 $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
                 $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.SchemaName | Should -Be $ConfigurationData.AllNodes.SchemaName
+                $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.ObjectName
+                $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
 
-                # TODO: Make sure to test all properties.
+                $getTargetResourceResult.Permission | Should -HaveCount 2
+                $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
+                $getTargetResourceResult.Permission[1] | Should -BeOfType 'CimInstance'
+
+                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Grant' })
+                $grantPermission | Should -Not -BeNullOrEmpty
+                $grantPermission.Ensure | Should -Be 'Absent'
+                $grantPermission.Permission | Should -HaveCount 1
+                $grantPermission.Permission | Should -Contain @('Select')
+
+                $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Deny' })
+                $grantPermission | Should -Not -BeNullOrEmpty
+                $grantPermission.Ensure | Should -Be 'Absent'
+                $grantPermission.Permission | Should -HaveCount 2
+                $grantPermission.Permission | Should -Contain @('Delete')
+                $grantPermission.Permission | Should -Contain @('Alter')
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
@@ -36,26 +36,26 @@ else
 
                 GetQuery        = @'
 select b.name + '.' + a.name As ObjectName
-from sys.objects a
-inner join sys.schemas b
+from [$(DatabaseName)].sys.objects a
+inner join [$(DatabaseName)].sys.schemas b
     on a.schema_id = b.schema_id
 where a.name = '$(TableName)'
 FOR JSON AUTO
 '@
 
                 TestQuery       = @'
-if (select count(name) from sys.objects where name = '$(TableName)') = 0
+if (select count(name) from [$(DatabaseName)].sys.objects where name = '$(TableName)') = 0
 BEGIN
-    RAISERROR ('Did not find table [$(TableName)]', 16, 1)
+    RAISERROR ('Did not find table [$(TableName)] in database [$(DatabaseName)].', 16, 1)
 END
 ELSE
 BEGIN
-    PRINT 'Found table [$(TableName)]'
+    PRINT 'Found table [$(TableName)] in database [$(DatabaseName)].'
 END
 '@
 
                 SetQuery        = @'
-CREATE TABLE [dbo].[Table1](
+CREATE TABLE [$(DatabaseName)].[dbo].[$(TableName)](
     [Name] [nchar](10) NULL
 ) ON [PRIMARY]
 '@
@@ -86,6 +86,7 @@ Configuration DSC_SqlDatabaseObjectPermission_Prerequisites_Config
             QueryTimeout         = 30
             Variable             = @(
                 ('TableName={0}' -f $Node.TableName)
+                ('DatabaseName={0}' -f $Node.DatabaseName)
             )
 
             PsDscRunAsCredential = New-Object `

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
@@ -87,8 +87,8 @@ Configuration DSC_SqlDatabaseObjectPermission_Prerequisites_Config
             PsDscRunAsCredential = New-Object `
                 -TypeName System.Management.Automation.PSCredential `
                 -ArgumentList @(
-                    $Node.Admin_Username,
-                    (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force)
+                    $Node.Username,
+                    (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force)
                 )
         }
     }

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
@@ -1,3 +1,7 @@
+# Suppressing this rule because ConvertTo-SecureString is used to simplify the tests.
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param ()
+
 $configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
 if (Test-Path -Path $configFile)
 {

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
@@ -1,0 +1,185 @@
+$configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')
+if (Test-Path -Path $configFile)
+{
+    <#
+        Allows reading the configuration data from a JSON file,
+        for real testing scenarios outside of the CI.
+    #>
+    $ConfigurationData = Get-Content -Path $configFile | ConvertFrom-Json
+}
+else
+{
+    $ConfigurationData = @{
+        AllNodes = @(
+            @{
+                NodeName        = 'localhost'
+                CertificateFile = $env:DscPublicCertificatePath
+
+                UserName        = "$env:COMPUTERNAME\SqlAdmin"
+                Password        = 'P@ssw0rd1'
+
+                ServerName      = $env:COMPUTERNAME
+                InstanceName    = 'DSCSQLTEST'
+
+                # This is created by the SqlDatabase integration tests.
+                DatabaseName    = 'Database1'
+
+                # This is created by the SqlDatabaseUser integration tests.
+                User1_Name      = 'User1'
+
+                SchemaName      = 'dbo'
+                TableName       = 'Table1'
+
+                GetQuery        = @'
+select b.name + '.' + a.name As ObjectName
+from sys.objects a
+inner join sys.schemas b
+    on a.schema_id = b.schema_id
+where a.name = '$(TableName)'
+FOR JSON AUTO
+'@
+
+                TestQuery       = @'
+if (select count(name) from sys.objects where name = '$(TableName)') = 0
+BEGIN
+    RAISERROR ('Did not find table [$(TableName)]', 16, 1)
+END
+ELSE
+BEGIN
+    PRINT 'Found table [$(TableName)]'
+END
+'@
+
+                SetQuery        = @'
+CREATE TABLE [dbo].[Table1](
+    [Name] [nchar](10) NULL
+) ON [PRIMARY]
+'@
+
+            }
+        )
+    }
+}
+
+<#
+    .SYNOPSIS
+        Grant a user permission for an object in a database.
+#>
+Configuration DSC_SqlDatabaseObjectPermission_Prerequisites_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlScriptQuery 'CreateTable'
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+
+            GetQuery             = $Node.GetQuery
+            TestQuery            = $Node.TestQuery
+            SetQuery             = $Node.SetQuery
+            QueryTimeout         = 30
+            Variable             = @(
+                ('TableName={0}' -f $Node.TableName)
+            )
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.Admin_Username,
+                    (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force)
+                )
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Grant a user permission for a table in a database.
+#>
+Configuration DSC_SqlDatabaseObjectPermission_Grant_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabaseObjectPermission 'Integration_Test'
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            DatabaseName         = $Node.DatabaseName
+            SchemaName           = $Node.SchemaName
+            ObjectName           = $Node.TableName
+            ObjectType           = 'Table'
+            Name                 = $Node.User1_Name
+            Permission           = @(
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Grant'
+                    Permission = @('Select')
+                }
+
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Deny'
+                    Permission = @('Delete', 'Alter')
+                }
+            )
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.UserName,
+                    (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force)
+                )
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Revoke the permission for a user for a table in a database.
+#>
+Configuration DSC_SqlDatabaseObjectPermission_Revoke_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabaseObjectPermission 'Integration_Test'
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            DatabaseName         = $Node.DatabaseName
+            SchemaName           = $Node.SchemaName
+            ObjectName           = $Node.TableName
+            ObjectType           = 'Table'
+            Name                 = $Node.User1_Name
+            Permission           = @(
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Grant'
+                    Permission = @('Select')
+                    # Intentionally leaving this permission on the node.
+                    Ensure     = 'Present'
+                }
+
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'Deny'
+                    Permission = @('Delete', 'Alter')
+                    Ensure     = 'Absent'
+                }
+            )
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.UserName,
+                    (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force)
+                )
+        }
+    }
+}
+

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -413,3 +413,23 @@ worker.*
 
 *The integration tests will clean up and not leave anything on the build
 worker.*
+
+## SqlDatabaseObjectPermission
+
+**Run order:** 6
+
+**Depends on:** SqlSetup, SqlDatabase (and uses SqlScriptQuery)
+
+The integration test will leave these database objects for other integration tests
+to use.
+
+Database | Object Name | Object Type | Schema
+--- | --- | --- | ---
+Database1 | Table1 | Table | dbo
+
+The integration test will leave these user permissions for database objects
+for other integration tests to use.
+
+User name | Database | Object Name | Permission
+--- | --- | --- | ---
+User1 | Database1 | Table1 | Select

--- a/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
@@ -1,0 +1,2393 @@
+<#
+    .SYNOPSIS
+        Automated unit test for DSC_DSC_SqlDatabaseObjectPermission DSC resource.
+#>
+
+$script:dscModuleName = 'SqlServerDsc'
+$script:dscResourceName = 'DSC_SqlDatabaseObjectPermission'
+
+function Invoke-TestSetup
+{
+    try
+    {
+        Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+    }
+
+    $script:testEnvironment = Initialize-TestEnvironment `
+        -DSCModuleName $script:dscModuleName `
+        -DSCResourceName $script:dscResourceName `
+        -ResourceType 'Mof' `
+        -TestType 'Unit'
+}
+
+function Invoke-TestCleanup
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}
+
+# Begin Testing
+
+Invoke-TestSetup
+
+try
+{
+    InModuleScope $script:dscResourceName {
+        Set-StrictMode -Version 1.0
+
+        Describe 'DSC_SqlDatabaseObjectPermission\Get-TargetResource' -Tag 'Get' {
+            BeforeAll {
+                Mock -CommandName New-Object -ParameterFilter {
+                    $TypeName -eq 'Microsoft.SqlServer.Management.Smo.ObjectPermissionSet'
+                } -MockWith {
+                    # Return anything so we get an object to pass in the pipeline.
+                    return ''
+                }
+
+                Mock -CommandName Get-Member -MockWith {
+                    <#
+                        Returns the names of the properties of the type
+                        Microsoft.SqlServer.Management.Smo.ObjectPermissionSet.
+                    #>
+                    return @(
+                        @{
+                            Name = 'Alter'
+                        }
+                        @{
+                            Name = 'Connect'
+                        }
+                        @{
+                            Name = 'Control'
+                        }
+                        @{
+                            Name = 'CreateSequence'
+                        }
+                        @{
+                            Name = 'Delete'
+                        }
+                        @{
+                            Name = 'Execute'
+                        }
+                        @{
+                            Name = 'Impersonate'
+                        }
+                        @{
+                            Name = 'Insert'
+                        }
+                        @{
+                            Name = 'Receive'
+                        }
+                        @{
+                            Name = 'References'
+                        }
+                        @{
+                            Name = 'Select'
+                        }
+                        @{
+                            Name = 'Send'
+                        }
+                        @{
+                            Name = 'TakeOwnership'
+                        }
+                        @{
+                            Name = 'Update'
+                        }
+                        @{
+                            Name = 'ViewChangeTracking'
+                        }
+                        @{
+                            Name = 'ViewDefinition'
+                        }
+                    )
+                }
+
+                Mock -CommandName Get-DatabaseObject -MockWith {
+                    # Should mock a database object, e.g. Schema, Table, View.
+                    return New-Object -TypeName PSCustomObject |
+                        Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' -Value {
+                            # Returns properties of the type Microsoft.SqlServer.Management.Smo.ObjectPermissionInfo.
+                            return New-Object -TypeName PSCustomObject |
+                                Add-Member -MemberType NoteProperty -Name 'Grantee' -Value 'TestAppRole' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'GranteeType' -Value 'ApplicationRole' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'Grantor' -Value 'dbo' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'GrantorType' -Value 'User' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'ColumnName' -Value $null -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'ObjectClass' -Value 'ObjectColumn' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'ObjectName' -Value 'Table1' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'ObjectSchema' -Value 'dbo' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'ObjectID' -Value '245575913' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'PermissionState' -Value 'Grant' -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'PermissionType' -Value @(
+                                    # Returns properties of the type Microsoft.SqlServer.Management.Smo.ObjectPermissionSet.
+                                    New-Object -TypeName PSCustomObject |
+                                        Add-Member -MemberType NoteProperty -Name 'Alter' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Connect' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Control' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'CreateSequence' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Delete' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Execute' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Impersonate' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Insert' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Receive' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'References' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Select' -Value $true -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Send' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'TakeOwnership' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Update' -Value $true -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'ViewChangeTracking' -Value $false -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'ViewDefinition' -Value $false -PassThru -Force
+                                    ) -PassThru -Force
+                                } -PassThru -Force
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                BeforeAll {
+                    # Create an empty collection of CimInstance that we can return.
+                    $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                    <#
+                        Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                        to increase code coverage.
+                    #>
+                    $cimInstancePermissionCollection += New-CimInstance `
+                        -ClassName 'DSC_DatabaseObjectPermission' `
+                        -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                        -Property @{
+                            State      = 'Grant'
+                            Permission = @('Select', 'Update')
+                            Ensure     = '' # Must be empty string to hit a line in the code.
+                        } `
+                        -ClientOnly
+
+                    $getTargetResourceParameters = @{
+                        InstanceName = 'DSCTEST'
+                        DatabaseName = 'AdventureWorks'
+                        SchemaName   = 'dbo'
+                        ObjectName   = 'Table1'
+                        ObjectType   = 'Table'
+                        Name         = 'TestAppRole'
+                        Permission   = $cimInstancePermissionCollection
+                    }
+                }
+
+                It 'Should return the same values as the passed parameter values' {
+                    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                    $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                    $getTargetResourceResult.InstanceName | Should -Be $getTargetResourceParameters.InstanceName
+                    $getTargetResourceResult.DatabaseName | Should -Be $getTargetResourceParameters.DatabaseName
+                    $getTargetResourceResult.SchemaName | Should -Be $getTargetResourceParameters.SchemaName
+                    $getTargetResourceResult.ObjectName | Should -Be $getTargetResourceParameters.ObjectName
+                    $getTargetResourceResult.ObjectType | Should -Be $getTargetResourceParameters.ObjectType
+                    $getTargetResourceResult.Name | Should -Be $getTargetResourceParameters.Name
+                }
+
+                It 'Should return the correct metadata for the permission state' {
+                    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                    $getTargetResourceResult.Permission | Should -HaveCount 1
+                    $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
+
+                    $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Grant' })
+                    $grantPermission | Should -Not -BeNullOrEmpty
+                    $grantPermission.Ensure | Should -Be 'Present'
+                    $grantPermission.Permission | Should -HaveCount 2
+                    $grantPermission.Permission | Should -Contain @('Select')
+                    $grantPermission.Permission | Should -Contain @('Update')
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                Context 'When an existing permission state is missing a permission' {
+                    BeforeAll {
+                        # Create an empty collection of CimInstance that we can return.
+                        $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                        <#
+                            Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                            to increase code coverage.
+                        #>
+                        $cimInstancePermissionCollection += New-CimInstance `
+                            -ClassName 'DSC_DatabaseObjectPermission' `
+                            -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                            -Property @{
+                                State      = 'Grant'
+                                Permission = @('Delete')
+                                Ensure     = 'Present'
+                            } `
+                            -ClientOnly
+
+                        $getTargetResourceParameters = @{
+                            InstanceName = 'DSCTEST'
+                            DatabaseName = 'AdventureWorks'
+                            SchemaName   = 'dbo'
+                            ObjectName   = 'Table1'
+                            ObjectType   = 'Table'
+                            Name         = 'TestAppRole'
+                            Permission   = $cimInstancePermissionCollection
+                        }
+                    }
+
+                    It 'Should return the same values as the passed parameter values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                        $getTargetResourceResult.InstanceName | Should -Be $getTargetResourceParameters.InstanceName
+                        $getTargetResourceResult.DatabaseName | Should -Be $getTargetResourceParameters.DatabaseName
+                        $getTargetResourceResult.SchemaName | Should -Be $getTargetResourceParameters.SchemaName
+                        $getTargetResourceResult.ObjectName | Should -Be $getTargetResourceParameters.ObjectName
+                        $getTargetResourceResult.ObjectType | Should -Be $getTargetResourceParameters.ObjectType
+                        $getTargetResourceResult.Name | Should -Be $getTargetResourceParameters.Name
+                    }
+
+                    It 'Should return the correct metadata for the permission state' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.Permission | Should -HaveCount 1
+                        $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
+
+                        $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Grant' })
+                        $grantPermission | Should -Not -BeNullOrEmpty
+                        $grantPermission.Ensure | Should -Be 'Absent'
+                        $grantPermission.Permission | Should -HaveCount 1
+                        $grantPermission.Permission | Should -Contain @('Delete')
+                    }
+                }
+
+                Context 'When a permission state is missing that should be present' {
+                    BeforeAll {
+                        # Create an empty collection of CimInstance that we can return.
+                        $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                        <#
+                            Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                            to increase code coverage.
+                        #>
+                        $cimInstancePermissionCollection += New-CimInstance `
+                            -ClassName 'DSC_DatabaseObjectPermission' `
+                            -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                            -Property @{
+                                State      = 'Deny'
+                                Permission = @('Delete')
+                                Ensure     = 'Present'
+                            } `
+                            -ClientOnly
+
+                        $getTargetResourceParameters = @{
+                            InstanceName = 'DSCTEST'
+                            DatabaseName = 'AdventureWorks'
+                            SchemaName   = 'dbo'
+                            ObjectName   = 'Table1'
+                            ObjectType   = 'Table'
+                            Name         = 'TestAppRole'
+                            Permission   = $cimInstancePermissionCollection
+                        }
+                    }
+
+                    It 'Should return the same values as the passed parameter values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                        $getTargetResourceResult.InstanceName | Should -Be $getTargetResourceParameters.InstanceName
+                        $getTargetResourceResult.DatabaseName | Should -Be $getTargetResourceParameters.DatabaseName
+                        $getTargetResourceResult.SchemaName | Should -Be $getTargetResourceParameters.SchemaName
+                        $getTargetResourceResult.ObjectName | Should -Be $getTargetResourceParameters.ObjectName
+                        $getTargetResourceResult.ObjectType | Should -Be $getTargetResourceParameters.ObjectType
+                        $getTargetResourceResult.Name | Should -Be $getTargetResourceParameters.Name
+                    }
+
+                    It 'Should return the correct metadata for the permission state' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.Permission | Should -HaveCount 1
+                        $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
+
+                        $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Deny' })
+                        $grantPermission | Should -Not -BeNullOrEmpty
+                        $grantPermission.Ensure | Should -Be 'Absent'
+                        $grantPermission.Permission | Should -HaveCount 1
+                        $grantPermission.Permission | Should -Contain @('Delete')
+                    }
+                }
+
+                Context 'When a permission state is present but should be absent' {
+                    BeforeAll {
+                        # Create an empty collection of CimInstance that we can return.
+                        $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                        <#
+                            Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                            to increase code coverage.
+                        #>
+                        $cimInstancePermissionCollection += New-CimInstance `
+                            -ClassName 'DSC_DatabaseObjectPermission' `
+                            -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                            -Property @{
+                                State      = 'Grant'
+                                Permission = @('Select')
+                                Ensure     = 'Absent'
+                            } `
+                            -ClientOnly
+
+                        $getTargetResourceParameters = @{
+                            InstanceName = 'DSCTEST'
+                            DatabaseName = 'AdventureWorks'
+                            SchemaName   = 'dbo'
+                            ObjectName   = 'Table1'
+                            ObjectType   = 'Table'
+                            Name         = 'TestAppRole'
+                            Permission   = $cimInstancePermissionCollection
+                        }
+                    }
+
+                    It 'Should return the same values as the passed parameter values' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.ServerName | Should -Be $env:COMPUTERNAME
+                        $getTargetResourceResult.InstanceName | Should -Be $getTargetResourceParameters.InstanceName
+                        $getTargetResourceResult.DatabaseName | Should -Be $getTargetResourceParameters.DatabaseName
+                        $getTargetResourceResult.SchemaName | Should -Be $getTargetResourceParameters.SchemaName
+                        $getTargetResourceResult.ObjectName | Should -Be $getTargetResourceParameters.ObjectName
+                        $getTargetResourceResult.ObjectType | Should -Be $getTargetResourceParameters.ObjectType
+                        $getTargetResourceResult.Name | Should -Be $getTargetResourceParameters.Name
+                    }
+
+                    It 'Should return the correct metadata for the permission state' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
+                        $getTargetResourceResult.Permission | Should -HaveCount 1
+                        $getTargetResourceResult.Permission[0] | Should -BeOfType 'CimInstance'
+
+                        $grantPermission = $getTargetResourceResult.Permission.Where( { $_.State -eq 'Grant' })
+                        $grantPermission | Should -Not -BeNullOrEmpty
+                        $grantPermission.Ensure | Should -Be 'Present'
+                        $grantPermission.Permission | Should -HaveCount 1
+                        $grantPermission.Permission | Should -Contain @('Select')
+                        $grantPermission.Permission | Should -Not -Contain @('Delete')
+                    }
+                }
+            }
+        }
+
+        Describe 'SqlDatabaseObjectPermission\Test-TargetResource' -Tag 'Test' {
+            BeforeAll {
+                $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                # Using all lower-case on 'update' intentionally.
+                $cimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                    -Permission @('Select', 'update') `
+                    -PermissionState 'Grant' `
+                    -Ensure 'Present'
+
+                $testTargetResourceParameters = @{
+                    InstanceName = 'sql2014'
+                    DatabaseName = 'AdventureWorks'
+                    SchemaName   = 'dbo'
+                    ObjectName   = 'Table1'
+                    ObjectType   = 'Table'
+                    Name         = 'TestAppRole'
+                    Permission   = $cimInstancePermissionCollection
+                }
+            }
+
+            Context 'When the system is in the desired state' {
+                BeforeAll {
+                    Mock -CommandName Compare-TargetResourceState -MockWith {
+                        return @(
+                            @{
+                                ParameterName  = 'Permission'
+                                InDesiredState = $true
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return $true' {
+                    $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                    $testTargetResourceResult | Should -BeTrue
+
+                    Assert-MockCalled -CommandName Compare-TargetResourceState -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                BeforeAll {
+                    Mock -CommandName Compare-TargetResourceState -MockWith {
+                        return @(
+                            @{
+                                ParameterName  = 'Permission'
+                                InDesiredState = $false
+                            }
+                        )
+                    }
+                }
+
+                It 'Should return $false' {
+                    $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                    $testTargetResourceResult | Should -BeFalse
+
+                    Assert-MockCalled -CommandName Compare-TargetResourceState -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+
+        Describe 'SqlDatabaseObjectPermission\Compare-TargetResourceState' -Tag 'Compare' {
+            BeforeAll {
+                $mockInstanceName = 'DSCTEST'
+            }
+
+            Context 'When the system is in the desired state' {
+                BeforeAll {
+                    # Create an empty collection of CimInstance that we can return.
+                    $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                    <#
+                        Using all lower-case on 'update' intentionally.
+                        Intentionally not providing the CIM instance property
+                        'Ensure' on this CIM instance.
+                    #>
+                    $cimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                        -Permission @('Select', 'update') `
+                        -PermissionState 'Grant'
+
+                    <#
+                        Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                        to increase code coverage.
+                    #>
+                    $cimInstancePermissionCollection += New-CimInstance `
+                        -ClassName 'DSC_DatabaseObjectPermission' `
+                        -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                        -Property @{
+                            State      = 'Deny'
+                            Permission = @('Delete')
+                            Ensure     = '' # Must be empty string to hit a line in the code.
+                        } `
+                        -ClientOnly
+
+                    $cimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                        -Permission @('Drop') `
+                        -PermissionState 'GrantWithGrant' `
+                        -Ensure 'Absent'
+
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        return @{
+                            InstanceName = 'sql2014'
+                            DatabaseName = 'AdventureWorks'
+                            SchemaName   = 'dbo'
+                            ObjectName   = 'Table1'
+                            ObjectType   = 'Table'
+                            Name         = 'TestAppRole'
+                            Permission   = $cimInstancePermissionCollection
+                            ServerName   = 'testclu01a'
+                        }
+                    }
+
+                    # Intentionally left the parameter ServerName out.
+                    $compareTargetResourceParameters = @{
+                        InstanceName = 'sql2014'
+                        DatabaseName = 'AdventureWorks'
+                        SchemaName   = 'dbo'
+                        ObjectName   = 'Table1'
+                        ObjectType   = 'Table'
+                        Name         = 'TestAppRole'
+                        Permission   = $cimInstancePermissionCollection
+                    }
+                }
+
+                It 'Should return the correct metadata for the permission property' {
+                    $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                    $compareTargetResourceStateResult | Should -HaveCount 1
+
+                    $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                    $comparedReturnValue | Should -Not -BeNullOrEmpty
+                    $comparedReturnValue.InDesiredState | Should -BeTrue
+
+                    # Actual permissions
+                    $comparedReturnValue.Actual | Should -HaveCount 3
+                    $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+                    $comparedReturnValue.Actual[1] | Should -BeOfType 'CimInstance'
+                    $comparedReturnValue.Actual[2] | Should -BeOfType 'CimInstance'
+
+                    $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Grant' })
+                    $grantPermission | Should -Not -BeNullOrEmpty
+                    $grantPermission.Ensure | Should -Be 'Present'
+                    $grantPermission.Permission | Should -HaveCount 2
+                    $grantPermission.Permission | Should -Contain @('Select')
+                    $grantPermission.Permission | Should -Contain @('Update')
+
+                    $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Deny' })
+                    $grantPermission | Should -Not -BeNullOrEmpty
+                    $grantPermission.Ensure | Should -Be 'Present'
+                    $grantPermission.Permission | Should -HaveCount 1
+                    $grantPermission.Permission | Should -Contain @('Delete')
+
+                    $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'GrantWithGrant' })
+                    $grantPermission | Should -Not -BeNullOrEmpty
+                    $grantPermission.Ensure | Should -Be 'Absent'
+                    $grantPermission.Permission | Should -HaveCount 1
+                    $grantPermission.Permission | Should -Contain @('Drop')
+
+                    # Expected permissions
+                    $comparedReturnValue.Expected | Should -HaveCount 3
+                    $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+                    $comparedReturnValue.Expected[1] | Should -BeOfType 'CimInstance'
+                    $comparedReturnValue.Expected[2] | Should -BeOfType 'CimInstance'
+
+                    $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                    $grantPermission | Should -Not -BeNullOrEmpty
+                    $grantPermission.Ensure | Should -Be 'Present'
+                    $grantPermission.Permission | Should -HaveCount 2
+                    $grantPermission.Permission | Should -Contain @('Select')
+                    $grantPermission.Permission | Should -Contain @('Update')
+
+                    $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                    $grantPermission | Should -Not -BeNullOrEmpty
+                    $grantPermission.Ensure | Should -Be 'Present'
+                    $grantPermission.Permission | Should -HaveCount 1
+                    $grantPermission.Permission | Should -Contain @('Delete')
+
+                    $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                    $grantPermission | Should -Not -BeNullOrEmpty
+                    $grantPermission.Ensure | Should -Be 'Absent'
+                    $grantPermission.Permission | Should -HaveCount 1
+                    $grantPermission.Permission | Should -Contain @('Drop')
+
+                    Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                Context 'When the permission state is already present in the current state but not in the desired state' {
+                    BeforeAll {
+                        # Holds the current permissions.
+                        $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                        # Using all lower-case on 'update' intentionally.
+                        $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                            -Permission @('Select', 'update') `
+                            -PermissionState 'Grant' `
+                            -Ensure 'Present'
+
+                        $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                            -Permission @('Delete') `
+                            -PermissionState 'Deny' `
+                            -Ensure 'Present'
+
+                        $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                            -Permission @('Drop') `
+                            -PermissionState 'GrantWithGrant' `
+                            -Ensure 'Present'
+
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $currentCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+                        }
+                    }
+
+                    <#
+                        We test the actual permission that are reused in the nested
+                        Context-blocks so that we don't have to test that for each test.
+                    #>
+                    It 'Should return the correct actual permissions for the ''Permission'' property' {
+                        $compareTargetResourceParameters = @{
+                            InstanceName = 'sql2014'
+                            DatabaseName = 'AdventureWorks'
+                            SchemaName   = 'dbo'
+                            ObjectName   = 'Table1'
+                            ObjectType   = 'Table'
+                            Name         = 'TestAppRole'
+                            Permission   = $currentCimInstancePermissionCollection
+                            ServerName   = 'testclu01a'
+                        }
+
+                        $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                        $compareTargetResourceStateResult | Should -HaveCount 1
+
+                        $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                        $comparedReturnValue | Should -Not -BeNullOrEmpty
+
+                        $comparedReturnValue.Actual | Should -HaveCount 3
+                        $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+                        $comparedReturnValue.Actual[1] | Should -BeOfType 'CimInstance'
+                        $comparedReturnValue.Actual[2] | Should -BeOfType 'CimInstance'
+
+                        # Actual permissions
+                        $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Grant' })
+                        $grantPermission | Should -Not -BeNullOrEmpty
+                        $grantPermission.Ensure | Should -Be 'Present'
+                        $grantPermission.Permission | Should -HaveCount 2
+                        $grantPermission.Permission | Should -Contain @('Select')
+                        $grantPermission.Permission | Should -Contain @('Update')
+
+                        $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Deny' })
+                        $grantPermission | Should -Not -BeNullOrEmpty
+                        $grantPermission.Ensure | Should -Be 'Present'
+                        $grantPermission.Permission | Should -HaveCount 1
+                        $grantPermission.Permission | Should -Contain @('Delete')
+
+                        $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'GrantWithGrant' })
+                        $grantPermission | Should -Not -BeNullOrEmpty
+                        $grantPermission.Ensure | Should -Be 'Present'
+                        $grantPermission.Permission | Should -HaveCount 1
+                        $grantPermission.Permission | Should -Contain @('Drop')
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+
+                    Context 'When the permission state ''Grant'' is ''Present'' but desired state is ''Absent''' {
+                        BeforeAll {
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select', 'update') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Absent'
+
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Delete') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Drop') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            $comparedReturnValue.Expected | Should -HaveCount 3
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+                            $comparedReturnValue.Expected[1] | Should -BeOfType 'CimInstance'
+                            $comparedReturnValue.Expected[2] | Should -BeOfType 'CimInstance'
+
+                            # Expected permissions
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Absent'
+                            $grantPermission.Permission | Should -HaveCount 2
+                            $grantPermission.Permission | Should -Contain @('Select')
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Delete')
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Drop')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''GrantWithGrant'' is ''Present'' but desired state is ''Absent''' {
+                        BeforeAll {
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select', 'update') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Delete') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Drop') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Absent'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            $comparedReturnValue.Expected | Should -HaveCount 3
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+                            $comparedReturnValue.Expected[1] | Should -BeOfType 'CimInstance'
+                            $comparedReturnValue.Expected[2] | Should -BeOfType 'CimInstance'
+
+                            # Expected permissions
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 2
+                            $grantPermission.Permission | Should -Contain @('Select')
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Delete')
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Absent'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Drop')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''Deny'' is ''Present'' but desired state is ''Absent''' {
+                        BeforeAll {
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select', 'update') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Delete') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Absent'
+
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Drop') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            $comparedReturnValue.Expected | Should -HaveCount 3
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+                            $comparedReturnValue.Expected[1] | Should -BeOfType 'CimInstance'
+                            $comparedReturnValue.Expected[2] | Should -BeOfType 'CimInstance'
+
+                            # Expected permissions
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 2
+                            $grantPermission.Permission | Should -Contain @('Select')
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Absent'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Delete')
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Drop')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permissions for the permission state ''Grant'' is not in desired state' {
+                        BeforeAll {
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('CreateTable') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            # Expected permissions
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('CreateTable')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permissions for the permission state ''GrantWithGrant'' is not in desired state' {
+                        BeforeAll {
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('CreateTable') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            # Expected permissions
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('CreateTable')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permissions for the permission state ''Deny'' is not in desired state' {
+                        BeforeAll {
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('CreateTable') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            # Expected permissions
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('CreateTable')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+
+                Context 'When the specified permission state is missing in the current state' {
+                    Context 'When the permission state ''Grant'' is ''Absent'' but desired state is ''Present''' {
+                        BeforeAll {
+                            # Empty collection to mock no existing permissions in the current state.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select', 'update') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -BeNullOrEmpty
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 2
+                            $grantPermission.Permission | Should -Contain @('Select')
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''GrantWithGrant'' is ''Absent'' but desired state is ''Present''' {
+                        BeforeAll {
+                            # Empty collection to mock no existing permissions in the current state.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select', 'update') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -BeNullOrEmpty
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 2
+                            $grantPermission.Permission | Should -Contain @('Select')
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''Deny'' is ''Absent'' but desired state is ''Present''' {
+                        BeforeAll {
+                            # Empty collection to mock no existing permissions in the current state.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select', 'update') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -BeNullOrEmpty
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 2
+                            $grantPermission.Permission | Should -Contain @('Select')
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+
+                Context 'When there already are other existing permissions for specified permission state' {
+                    Context 'When the permission state ''Grant'' should include the permission ''Update''' {
+                        BeforeAll {
+                            # Holds the current permissions.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Update') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -HaveCount 1
+                            $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Select')
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''GrantWithGrant'' should include the permission ''Update''' {
+                        BeforeAll {
+                            # Holds the current permissions.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Present'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Update') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -HaveCount 1
+                            $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Select')
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''Deny'' should include the permission ''Update''' {
+                        BeforeAll {
+                            # Holds the current permissions.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Update') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -HaveCount 1
+                            $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Select')
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+
+                Context 'When there exist other permission states than the one that is desired' {
+                    Context 'When the permission state ''Grant'' should exist' {
+                        BeforeAll {
+                            # Holds the current permissions.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Update') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -HaveCount 1
+                            $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Select')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''GrantWithGrant'' should exist' {
+                        BeforeAll {
+                            # Holds the current permissions.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Update') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select') `
+                                -PermissionState 'GrantWithGrant' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -HaveCount 1
+                            $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'GrantWithGrant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Select')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+
+                    Context 'When the permission state ''Deny'' should exist' {
+                        BeforeAll {
+                            # Holds the current permissions.
+                            $currentCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $currentCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Select') `
+                                -PermissionState 'Grant' `
+                                -Ensure 'Present'
+
+                            Mock -CommandName Get-TargetResource -MockWith {
+                                return @{
+                                    InstanceName = 'sql2014'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $currentCimInstancePermissionCollection
+                                    ServerName   = 'testclu01a'
+                                }
+                            }
+
+                            # Holds the desired permissions.
+                            $desiredCimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            # Using all lower-case on 'update' intentionally.
+                            $desiredCimInstancePermissionCollection += ConvertTo-CimDatabaseObjectPermission `
+                                -Permission @('Update') `
+                                -PermissionState 'Deny' `
+                                -Ensure 'Present'
+                        }
+
+                        It 'Should return the correct metadata for the ''Permission'' property' {
+                            $compareTargetResourceParameters = @{
+                                InstanceName = 'sql2014'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $desiredCimInstancePermissionCollection
+                                ServerName   = 'testclu01a'
+                            }
+
+                            $compareTargetResourceStateResult = Compare-TargetResourceState @compareTargetResourceParameters
+                            $compareTargetResourceStateResult | Should -HaveCount 1
+
+                            $comparedReturnValue = $compareTargetResourceStateResult.Where( { $_.ParameterName -eq 'Permission' })
+                            $comparedReturnValue | Should -Not -BeNullOrEmpty
+                            $comparedReturnValue.InDesiredState | Should -BeFalse
+
+                            # Actual permissions
+                            $comparedReturnValue.Actual | Should -HaveCount 1
+                            $comparedReturnValue.Actual[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Actual.Where( { $_.State -eq 'Grant' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Select')
+
+                            # Expected permissions
+                            $comparedReturnValue.Expected | Should -HaveCount 1
+                            $comparedReturnValue.Expected[0] | Should -BeOfType 'CimInstance'
+
+                            $grantPermission = $comparedReturnValue.Expected.Where( { $_.State -eq 'Deny' })
+                            $grantPermission | Should -Not -BeNullOrEmpty
+                            $grantPermission.Ensure | Should -Be 'Present'
+                            $grantPermission.Permission | Should -HaveCount 1
+                            $grantPermission.Permission | Should -Contain @('Update')
+
+                            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                        }
+                    }
+                }
+            }
+        }
+
+        Describe 'DSC_SqlDatabaseObjectPermission\Set-TargetResource' -Tag 'Set' {
+            Context 'When the system is in the desired state' {
+                BeforeAll {
+                    Mock -CommandName Get-DatabaseObject
+                    Mock -CommandName Compare-TargetResourceState -MockWith {
+                        return @(
+                            @{
+                                ParameterName  = 'Permission'
+                                InDesiredState = $true
+                                Actual         = @(
+                                    (New-Object -TypeName PSCustomObject |
+                                        Add-Member -MemberType NoteProperty -Name 'State' -Value 'Grant' -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Present' -PassThru -Force)
+                                )
+                            }
+                        )
+                    }
+
+                    # Create an empty collection of CimInstance that we can return.
+                    $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                    <#
+                        Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                        to increase code coverage.
+                    #>
+                    $cimInstancePermissionCollection += New-CimInstance `
+                        -ClassName 'DSC_DatabaseObjectPermission' `
+                        -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                        -Property @{
+                            State      = 'Grant'
+                            Permission = @('Select', 'Update')
+                            Ensure     = '' # Must be empty string to hit a line in the code.
+                        } `
+                        -ClientOnly
+
+                    $setTargetResourceParameters = @{
+                        InstanceName = 'DSCTEST'
+                        DatabaseName = 'AdventureWorks'
+                        SchemaName   = 'dbo'
+                        ObjectName   = 'Table1'
+                        ObjectType   = 'Table'
+                        Name         = 'TestAppRole'
+                        Permission   = $cimInstancePermissionCollection
+                    }
+                }
+
+                It 'Should not try to set any values and should not throw an exception' {
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                    Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 0 -Scope It
+                }
+            }
+
+            Context 'When the system is not in the desired state' {
+                Context 'When the database object is not found' {
+                    BeforeAll {
+                        Mock -CommandName Compare-TargetResourceState -MockWith {
+                            return @(
+                                @{
+                                    ParameterName  = 'Permission'
+                                    InDesiredState = $false
+                                }
+                            )
+                        }
+
+                        Mock -CommandName Get-DatabaseObject
+
+                        # Create an empty collection of CimInstance that we can return.
+                        $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                        <#
+                            Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                            to increase code coverage.
+                        #>
+                        $cimInstancePermissionCollection += New-CimInstance `
+                            -ClassName 'DSC_DatabaseObjectPermission' `
+                            -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                            -Property @{
+                                State      = 'Grant'
+                                Permission = @('Select', 'Update')
+                                Ensure     = '' # Must be empty string to hit a line in the code.
+                            } `
+                            -ClientOnly
+
+                        $setTargetResourceParameters = @{
+                            InstanceName = 'DSCTEST'
+                            DatabaseName = 'AdventureWorks'
+                            SchemaName   = 'dbo'
+                            ObjectName   = 'Table1'
+                            ObjectType   = 'Table'
+                            Name         = 'TestAppRole'
+                            Permission   = $cimInstancePermissionCollection
+                        }
+                    }
+
+                    It 'Should throw the correct exception' {
+                        $mockErrorMessage = $script:localizedData.FailedToGetDatabaseObject -f @(
+                            ('{0}.{1}' -f $setTargetResourceParameters.SchemaName, $setTargetResourceParameters.ObjectName),
+                            $setTargetResourceParameters.ObjectType,
+                            $setTargetResourceParameters.DatabaseName
+                        )
+
+                        { Set-TargetResource @setTargetResourceParameters } | Should -Throw $mockErrorMessage
+                    }
+                }
+
+                Context 'When setting permission for a permission state' {
+                    BeforeAll {
+                        Mock -CommandName New-Object -ParameterFilter {
+                            $TypeName -eq 'Microsoft.SqlServer.Management.Smo.ObjectPermissionSet'
+                        } -MockWith {
+                            return New-Object -TypeName PSCustomObject |
+                            Add-Member -MemberType NoteProperty -Name 'Alter' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Connect' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Control' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'CreateSequence' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Delete' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Execute' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Impersonate' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Insert' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Receive' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'References' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Select' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Send' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'TakeOwnership' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Update' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'ViewChangeTracking' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'ViewDefinition' -Value $false -PassThru -Force
+                        }
+
+                        Mock -CommandName Get-DatabaseObject -MockWith {
+                            # Should mock a database object, e.g. Schema, Table, View.
+                            return New-Object -TypeName PSCustomObject |
+                                Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
+                                    $script:mockMethodGrantRanTimes += 1
+                                } -PassThru |
+                                Add-Member -MemberType ScriptMethod -Name 'Deny' -Value {
+                                    $script:mockMethodDenyRanTimes += 1
+                                } -PassThru -Force
+                        }
+                    }
+
+                    BeforeEach {
+                        $script:mockMethodGrantRanTimes = 0
+                        $script:mockMethodDenyRanTimes = 0
+                    }
+
+                    Context 'When setting permission for the permission state ''Grant''' {
+                        BeforeAll {
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName  = 'Permission'
+                                        InDesiredState = $false
+                                        Actual         = @(
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'Grant' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Absent' -PassThru -Force)
+                                        )
+                                    }
+                                )
+                            }
+
+                            # Create an empty collection of CimInstance that we can return.
+                            $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            <#
+                                Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                to increase code coverage.
+                            #>
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'Grant'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Present'
+                                } `
+                                -ClientOnly
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = 'DSCTEST'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $cimInstancePermissionCollection
+                                Verbose      = $true
+                            }
+                        }
+
+                        It 'Should set the permissions without throwing an exception' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                            $script:mockMethodGrantRanTimes | Should -Be 1
+                            $script:mockMethodDenyRanTimes  | Should -Be 0
+                        }
+                    }
+
+                    Context 'When setting permission for the permission state ''GrantWithGrant''' {
+                        BeforeAll {
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName  = 'Permission'
+                                        InDesiredState = $false
+                                        Actual         = @(
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'GrantWithGrant' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Absent' -PassThru -Force)
+                                        )
+                                    }
+                                )
+                            }
+
+                            # Create an empty collection of CimInstance that we can return.
+                            $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            <#
+                                Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                to increase code coverage.
+                            #>
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'GrantWithGrant'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Present'
+                                } `
+                                -ClientOnly
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = 'DSCTEST'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $cimInstancePermissionCollection
+                            }
+                        }
+
+                        It 'Should set the permissions without throwing an exception' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                            $script:mockMethodGrantRanTimes | Should -Be 1
+                            $script:mockMethodDenyRanTimes  | Should -Be 0
+                        }
+                    }
+
+                    Context 'When setting permission for the permission state ''Deny''' {
+                        BeforeAll {
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName  = 'Permission'
+                                        InDesiredState = $false
+                                        Actual         = @(
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'Deny' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Absent' -PassThru -Force)
+                                        )
+                                    }
+                                )
+                            }
+
+                            # Create an empty collection of CimInstance that we can return.
+                            $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            <#
+                                Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                to increase code coverage.
+                            #>
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'Deny'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Present'
+                                } `
+                                -ClientOnly
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = 'DSCTEST'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $cimInstancePermissionCollection
+                            }
+                        }
+
+                        It 'Should set the permissions without throwing an exception' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                            $script:mockMethodGrantRanTimes | Should -Be 0
+                            $script:mockMethodDenyRanTimes  | Should -Be 1
+                        }
+                    }
+
+                    Context 'When one of the permission states is already in desired state' {
+                        BeforeAll {
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName  = 'Permission'
+                                        InDesiredState = $false
+                                        Actual         = @(
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'Deny' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Absent' -PassThru -Force)
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'Grant' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Present' -PassThru -Force)
+                                        )
+                                    }
+                                )
+                            }
+
+                            # Create an empty collection of CimInstance that we can return.
+                            $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            <#
+                                Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                to increase code coverage.
+                            #>
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'Grant'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Present'
+                                } `
+                                -ClientOnly
+
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'Deny'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Present'
+                                } `
+                                -ClientOnly
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = 'DSCTEST'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $cimInstancePermissionCollection
+                            }
+                        }
+
+                        It 'Should set the permissions without throwing an exception' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                            $script:mockMethodGrantRanTimes | Should -Be 0
+                            $script:mockMethodDenyRanTimes  | Should -Be 1
+                        }
+                    }
+                }
+
+                Context 'When revoking permission for a permission state' {
+                    BeforeAll {
+                        Mock -CommandName New-Object -ParameterFilter {
+                            $TypeName -eq 'Microsoft.SqlServer.Management.Smo.ObjectPermissionSet'
+                        } -MockWith {
+                            return New-Object -TypeName PSCustomObject |
+                            Add-Member -MemberType NoteProperty -Name 'Alter' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Connect' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Control' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'CreateSequence' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Delete' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Execute' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Impersonate' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Insert' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Receive' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'References' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Select' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Send' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'TakeOwnership' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Update' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'ViewChangeTracking' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'ViewDefinition' -Value $false -PassThru -Force
+                        }
+
+                        Mock -CommandName Get-DatabaseObject -MockWith {
+                            # Should mock a database object, e.g. Schema, Table, View.
+                            return New-Object -TypeName PSCustomObject |
+                                Add-Member -MemberType ScriptMethod -Name 'Revoke' -Value {
+                                    $script:mockMethodRevokeRanTimes += 1
+                                } -PassThru -Force
+                        }
+                    }
+
+                    BeforeEach {
+                        $script:mockMethodRevokeRanTimes = 0
+                    }
+
+                    Context 'When revoking permission for the permission state ''Grant''' {
+                        BeforeAll {
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName  = 'Permission'
+                                        InDesiredState = $false
+                                        Actual         = @(
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'Grant' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Present' -PassThru -Force)
+                                        )
+                                    }
+                                )
+                            }
+
+                            # Create an empty collection of CimInstance that we can return.
+                            $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            <#
+                                Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                to increase code coverage.
+                            #>
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'Grant'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Absent'
+                                } `
+                                -ClientOnly
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = 'DSCTEST'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $cimInstancePermissionCollection
+                                Verbose      = $true
+                            }
+                        }
+
+                        It 'Should revoke the permissions without throwing an exception' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                            $script:mockMethodRevokeRanTimes | Should -Be 1
+                        }
+                    }
+
+                    Context 'When revoking permission for the permission state ''GrantWithGrant''' {
+                        BeforeAll {
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName  = 'Permission'
+                                        InDesiredState = $false
+                                        Actual         = @(
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'GrantWithGrant' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Present' -PassThru -Force)
+                                        )
+                                    }
+                                )
+                            }
+
+                            # Create an empty collection of CimInstance that we can return.
+                            $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            <#
+                                Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                to increase code coverage.
+                            #>
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'GrantWithGrant'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Absent'
+                                } `
+                                -ClientOnly
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = 'DSCTEST'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $cimInstancePermissionCollection
+                            }
+                        }
+
+                        It 'Should revoke the permissions without throwing an exception' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                            $script:mockMethodRevokeRanTimes | Should -Be 1
+                        }
+                    }
+
+                    Context 'When revoking permission for the permission state ''Deny''' {
+                        BeforeAll {
+                            Mock -CommandName Compare-TargetResourceState -MockWith {
+                                return @(
+                                    @{
+                                        ParameterName  = 'Permission'
+                                        InDesiredState = $false
+                                        Actual         = @(
+                                            (New-Object -TypeName PSCustomObject |
+                                                Add-Member -MemberType NoteProperty -Name 'State' -Value 'Deny' -PassThru |
+                                                Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Present' -PassThru -Force)
+                                        )
+                                    }
+                                )
+                            }
+
+                            # Create an empty collection of CimInstance that we can return.
+                            $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                            <#
+                                Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                to increase code coverage.
+                            #>
+                            $cimInstancePermissionCollection += New-CimInstance `
+                                -ClassName 'DSC_DatabaseObjectPermission' `
+                                -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                -Property @{
+                                    State      = 'Deny'
+                                    Permission = @('Delete')
+                                    Ensure     = 'Absent'
+                                } `
+                                -ClientOnly
+
+                            $setTargetResourceParameters = @{
+                                InstanceName = 'DSCTEST'
+                                DatabaseName = 'AdventureWorks'
+                                SchemaName   = 'dbo'
+                                ObjectName   = 'Table1'
+                                ObjectType   = 'Table'
+                                Name         = 'TestAppRole'
+                                Permission   = $cimInstancePermissionCollection
+                            }
+                        }
+
+                        It 'Should revoke the permissions without throwing an exception' {
+                            { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                            $script:mockMethodRevokeRanTimes | Should -Be 1
+                        }
+                    }
+                }
+
+                Context 'When failing to change permissions' {
+                    BeforeAll {
+                        Mock -CommandName Compare-TargetResourceState -MockWith {
+                            return @(
+                                @{
+                                    ParameterName  = 'Permission'
+                                    InDesiredState = $false
+                                }
+                            )
+                        }
+
+                        Mock -CommandName New-Object -ParameterFilter {
+                            $TypeName -eq 'Microsoft.SqlServer.Management.Smo.ObjectPermissionSet'
+                        } -MockWith {
+                            return New-Object -TypeName PSCustomObject |
+                            Add-Member -MemberType NoteProperty -Name 'Alter' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Connect' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Control' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'CreateSequence' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Delete' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Execute' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Impersonate' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Insert' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Receive' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'References' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Select' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Send' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'TakeOwnership' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Update' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'ViewChangeTracking' -Value $false -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'ViewDefinition' -Value $false -PassThru -Force
+                        }
+
+                        Mock -CommandName Get-DatabaseObject -MockWith {
+                            # Should mock a database object, e.g. Schema, Table, View.
+                            return New-Object -TypeName PSCustomObject |
+                                Add-Member -MemberType ScriptMethod -Name 'Revoke' -Value {
+                                    throw 'Mocked error'
+                                } -PassThru -Force
+                        }
+
+                        # Create an empty collection of CimInstance that we can return.
+                        $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                        <#
+                            Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                            to increase code coverage.
+                        #>
+                        $cimInstancePermissionCollection += New-CimInstance `
+                            -ClassName 'DSC_DatabaseObjectPermission' `
+                            -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                            -Property @{
+                                State      = 'Grant'
+                                Permission = @('Delete')
+                                Ensure     = 'Absent'
+                            } `
+                            -ClientOnly
+
+                        $setTargetResourceParameters = @{
+                            InstanceName = 'DSCTEST'
+                            DatabaseName = 'AdventureWorks'
+                            SchemaName   = 'dbo'
+                            ObjectName   = 'Table1'
+                            ObjectType   = 'Table'
+                            Name         = 'TestAppRole'
+                            Permission   = $cimInstancePermissionCollection
+                        }
+                    }
+
+                    It 'Should throw the correct exception' {
+                        $mockErrorMessage = $script:localizedData.FailedToSetDatabaseObjectPermission -f @(
+                            $setTargetResourceParameters.Name,
+                            ('{0}.{1}' -f $setTargetResourceParameters.SchemaName, $setTargetResourceParameters.ObjectName),
+                            $setTargetResourceParameters.DatabaseName
+                        )
+
+                        { Set-TargetResource @setTargetResourceParameters } | Should -Throw $mockErrorMessage
+                    }
+                }
+            }
+        }
+
+        Describe 'SqlDatabaseObjectPermission\Get-DatabaseObject' -Tag 'Helper' {
+            BeforeAll {
+                Mock -Command Connect-SQL -MockWith {
+                    return New-Object -TypeName PSObject |
+                        Add-Member -MemberType NoteProperty -Name 'Databases' -Value @{
+                            'AdventureWorks' = New-Object -TypeName PSObject |
+                                Add-Member -MemberType NoteProperty -Name 'Schemas' -Value (
+                                    New-Object -TypeName PSObject |
+                                        Add-Member -MemberType ScriptMethod -Name 'Item' -Value {
+                                            return 'Schema'
+                                        } -PassThru -Force
+                                ) -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'Tables' -Value (
+                                    New-Object -TypeName PSObject |
+                                        Add-Member -MemberType ScriptMethod -Name 'Item' -Value {
+                                            return 'Table'
+                                        } -PassThru -Force
+                                ) -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'StoredProcedures' -Value (
+                                    New-Object -TypeName PSObject |
+                                        Add-Member -MemberType ScriptMethod -Name 'Item' -Value {
+                                            return 'StoredProcedure'
+                                        } -PassThru -Force
+                                ) -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'Views' -Value (
+                                    New-Object -TypeName PSObject |
+                                        Add-Member -MemberType ScriptMethod -Name 'Item' -Value {
+                                            return 'View'
+                                        } -PassThru -Force
+                                ) -PassThru -Force
+                        } -PassThru -Force
+                }
+
+                $testCases = @(
+                    @{
+                        ObjectType = 'Schema'
+                    }
+                    @{
+                        ObjectType = 'Table'
+                    }
+                    @{
+                        ObjectType = 'StoredProcedure'
+                    }
+                    @{
+                        ObjectType = 'View'
+                    }
+                )
+            }
+
+            It 'Should call the correct mocked method to get object type ''<ObjectType>''' -TestCases $testCases {
+                param
+                (
+                    [Parameter()]
+                    [System.String]
+                    $ObjectType
+                )
+
+                $getDatabaseObjectParameters = @{
+                    ServerName = $env:COMPUTERNAME
+                    InstanceName = 'DSCTEST'
+                    DatabaseName = 'AdventureWorks'
+                    SchemaName   = 'dbo'
+                    ObjectName   = 'Table1'
+                    ObjectType   = $ObjectType
+                }
+
+                # The methods that was mocked returns the expect object type.
+                Get-DatabaseObject @getDatabaseObjectParameters | Should -Be $ObjectType
+            }
+        }
+    }
+}
+finally
+{
+    Invoke-TestCleanup
+}

--- a/tests/Unit/DSC_SqlProtocolTcpIp.Tests.ps1
+++ b/tests/Unit/DSC_SqlProtocolTcpIp.Tests.ps1
@@ -923,14 +923,14 @@ try
                         Mock -CommandName Get-ServerProtocolObject -MockWith {
                             return New-Object -TypeName PSObject |
                                     Add-Member -MemberType NoteProperty -Name 'IPAddresses' -Value @{
-                                            Name  = 'IPAll'
-                                            IPAll = New-Object -TypeName PSObject |
-                                                        Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
-                                                            TcpPort = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '1433' -PassThru -Force
-                                                            TcpDynamicPorts = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '' -PassThru -Force
-                                                        } -PassThru -Force
+                                        Name  = 'IPAll'
+                                        IPAll = New-Object -TypeName PSObject |
+                                            Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
+                                                TcpPort = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value '1433' -PassThru -Force
+                                                TcpDynamicPorts = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value '' -PassThru -Force
+                                            } -PassThru -Force
                                     } -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                                         <#
@@ -988,14 +988,14 @@ try
                         Mock -CommandName Get-ServerProtocolObject -MockWith {
                             return New-Object -TypeName PSObject |
                                     Add-Member -MemberType NoteProperty -Name 'IPAddresses' -Value @{
-                                            Name  = 'IPAll'
-                                            IPAll = New-Object -TypeName PSObject |
-                                                        Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
-                                                            TcpPort = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '' -PassThru -Force
-                                                            TcpDynamicPorts = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '50000' -PassThru -Force
-                                                        } -PassThru -Force
+                                        Name  = 'IPAll'
+                                        IPAll = New-Object -TypeName PSObject |
+                                            Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
+                                                TcpPort = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value '' -PassThru -Force
+                                                TcpDynamicPorts = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'Value' -Value '50000' -PassThru -Force
+                                            } -PassThru -Force
                                     } -PassThru |
                                     Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                                         <#
@@ -1054,12 +1054,12 @@ try
                             Mock -CommandName Get-ServerProtocolObject -MockWith {
                                 return New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'IPAddresses' -Value @{
-                                                Name  = 'IP1'
-                                                IP1 = New-Object -TypeName PSObject |
-                                                        Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
-                                                            Enabled = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
-                                                        } -PassThru -Force
+                                            Name  = 'IP1'
+                                            IP1 = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
+                                                        Enabled = New-Object -TypeName PSObject |
+                                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
+                                                    } -PassThru -Force
                                         } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                                             <#
@@ -1116,12 +1116,12 @@ try
                             Mock -CommandName Get-ServerProtocolObject -MockWith {
                                 return New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'IPAddresses' -Value @{
-                                                Name  = 'IP1'
-                                                IP1 = New-Object -TypeName PSObject |
-                                                        Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
-                                                            Enabled = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $true -PassThru -Force
-                                                        } -PassThru -Force
+                                            Name  = 'IP1'
+                                            IP1 = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
+                                                        Enabled = New-Object -TypeName PSObject |
+                                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value $true -PassThru -Force
+                                                    } -PassThru -Force
                                         } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                                             <#
@@ -1179,12 +1179,12 @@ try
                             Mock -CommandName Get-ServerProtocolObject -MockWith {
                                 return New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'IPAddresses' -Value @{
-                                                Name  = 'IP1'
-                                                IP1 = New-Object -TypeName PSObject |
-                                                        Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
-                                                            IpAddress = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value '10.0.0.1' -PassThru -Force
-                                                        } -PassThru -Force
+                                            Name  = 'IP1'
+                                            IP1 = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
+                                                        IpAddress = New-Object -TypeName PSObject |
+                                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value '10.0.0.1' -PassThru -Force
+                                                    } -PassThru -Force
                                         } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                                             <#
@@ -1242,12 +1242,12 @@ try
                             Mock -CommandName Get-ServerProtocolObject -MockWith {
                                 return New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'IPAddresses' -Value @{
-                                                Name  = 'IP1'
-                                                IP1 = New-Object -TypeName PSObject |
-                                                        Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
-                                                            Enabled = New-Object -TypeName PSObject |
-                                                                Add-Member -MemberType NoteProperty -Name 'Value' -Value $true -PassThru -Force
-                                                        } -PassThru -Force
+                                            Name  = 'IP1'
+                                            IP1 = New-Object -TypeName PSObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'IPAddressProperties' -Value @{
+                                                        Enabled = New-Object -TypeName PSObject |
+                                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value $true -PassThru -Force
+                                                    } -PassThru -Force
                                         } -PassThru |
                                         Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {} -PassThru -Force
                             }

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -3482,6 +3482,684 @@ InModuleScope $script:subModuleName {
             }
         }
 
+        Context 'When comparing a CIM instance' {
+            BeforeAll {
+                $mockClassName = 'DSC_MockResourceClassName'
+                $mockNamespace = 'root/microsoft/Windows/DesiredStateConfiguration'
+            }
+
+            It 'Should return true when evaluating properties of a CIM instance' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Deny'
+                        Permission = @('Delete','Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Deny'
+                        Permission = @('Delete', 'Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeTrue
+            }
+
+            It 'Should return false when evaluating a CIM instance property that is an array with wrong values' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Deny'
+                        Permission = @('Delete','Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Deny'
+                        Permission = @('Delete', 'Update')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating a CIM instance property that is a string with wrong value' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Deny'
+                        Permission = @('Delete','Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Grant'
+                        Permission = @('Delete', 'Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating a CIM instance, but the current value is $null' {
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Grant'
+                        Permission = @('Delete', 'Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = $null
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating a CIM instance, but the desired value is $null' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Deny'
+                        Permission = @('Delete','Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = $null
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating a CIM instance, but the current CIM instance does not have any properties' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{}
+                    ClientOnly = $true
+                }
+
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Grant'
+                        Permission = @('Delete', 'Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating a CIM instance, but the desired CIM instance does not have any properties' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Grant'
+                        Permission = @('Delete', 'Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{}
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            It 'Should return false when evaluating a CIM instance, but the current CIM instance is missing a property' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Grant'
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{
+                        State      = 'Grant'
+                        Permission = @('Delete', 'Select')
+                        Ensure     = 'Present'
+                    }
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeFalse
+            }
+
+            Context 'When the desired CIM instance has less properties than the current CIM properties' {
+                It 'Should return true when evaluating a CIM instance where all CIM properties are in desired state' {
+                    $currentCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property   = @{
+                            State      = 'Grant'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly = $true
+                    }
+
+                    $desiredCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property   = @{
+                            State      = 'Grant'
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly = $true
+                    }
+
+                    $mockValues = @{
+                        CurrentValue = New-CimInstance @currentCimInstanceParameters
+                        DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeTrue
+                }
+
+                It 'Should return false when evaluating a CIM instance when a CIM property is not in desired state' {
+                    $currentCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property   = @{
+                            State      = 'Grant'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly = $true
+                    }
+
+                    $desiredCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property   = @{
+                            State      = 'Deny'
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly = $true
+                    }
+
+                    $mockValues = @{
+                        CurrentValue = New-CimInstance @currentCimInstanceParameters
+                        DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeFalse
+                }
+            }
+
+            It 'Should return true when evaluating a CIM instance, when both current and desired value does not have any CIM properties' {
+                $currentCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{}
+                    ClientOnly = $true
+                }
+
+                $desiredCimInstanceParameters = @{
+                    ClassName   = $mockClassName
+                    Namespace   = $mockNamespace
+                    Property   = @{}
+                    ClientOnly = $true
+                }
+
+                $mockValues = @{
+                    CurrentValue = New-CimInstance @currentCimInstanceParameters
+                    DesiredValue = New-CimInstance @desiredCimInstanceParameters
+                }
+
+                Test-DscPropertyState -Values $mockValues | Should -BeTrue
+            }
+        }
+
+        Context 'When comparing a CIM instance collection' {
+            BeforeAll {
+                $mockTypeName = 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+                $mockClassName = 'DSC_MockResourceClassName'
+                $mockNamespace = 'root/microsoft/Windows/DesiredStateConfiguration'
+            }
+
+            BeforeEach {
+                $currentCimInstancePermissionCollection = New-Object -TypeName $mockTypeName
+                $desiredCimInstancePermissionCollection = New-Object -TypeName $mockTypeName
+            }
+
+            Context 'When not passing the key ''KeyProperties'' in the hashtable' {
+                It 'Should throw the correct error message' {
+                    $currentCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Delete','Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                    }
+
+                    { Test-DscPropertyState -Values $mockValues } | Should -Throw $script:localizedData.KeyPropertiesMissing
+                }
+            }
+
+            Context 'When current value contain two CIM instances that have the same ''KeyProperties''' {
+                It 'Should throw the correct error message' {
+                    $currentCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Delete','Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters
+
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                        KeyProperties = @('State')
+                    }
+
+                    { Test-DscPropertyState -Values $mockValues } | Should -Throw $script:localizedData.TooManyCimInstances
+                }
+            }
+
+            Context 'When current and desired collection contain one CIM instance each with equally property values' {
+                It 'Should return true when evaluating properties of each CIM instance of a collection of CIM instances' {
+                    $currentCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Delete','Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                        KeyProperties = @('State')
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeTrue
+                }
+            }
+
+            Context 'When current and desired collection contain two CIM instance each with equally property values' {
+                It 'Should return true when evaluating properties of each CIM instance of a collection of CIM instances' {
+                    $currentCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete','Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstanceParameters2 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Drop')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters2 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Drop')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters1
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters2
+
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters1
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters2
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                        KeyProperties = @('State')
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeTrue
+                }
+            }
+
+            Context 'When current CIM instance collection have more CIM instance than the desired state, but with equally property values' {
+                It 'Should return true when evaluating properties of each CIM instance of a collection of CIM instances' {
+                    $currentCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete','Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstanceParameters2 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Drop')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters1
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters2
+
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters1
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                        KeyProperties = @('State')
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeTrue
+                }
+            }
+
+            Context 'When desired CIM instance collection have more CIM instance than the current state' {
+                It 'Should return false when evaluating properties of each CIM instance of a collection of CIM instances' {
+                    $currentCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete','Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+
+                    $desiredCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete', 'Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters2 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Drop')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters1
+
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters1
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters2
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                        KeyProperties = @('State')
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeFalse
+                }
+            }
+
+            Context 'When desired CIM instance collection have more CIM instance than the current state, and the CIM instances in the current state is not in desired state' {
+                It 'Should return false when evaluating properties of each CIM instance of a collection of CIM instances' {
+                    $currentCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete','Select')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+
+                    $desiredCimInstanceParameters1 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete', 'Select', 'Update')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstanceParameters2 = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Deny'
+                            Permission = @('Drop')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $currentCimInstancePermissionCollection += New-CimInstance @currentCimInstanceParameters1
+
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters1
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters2
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                        KeyProperties = @('State')
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeFalse
+                }
+            }
+
+            <#
+                There is only need to test empty collection in the current state
+                because the desired state must always provide at least one item.
+            #>
+            Context 'When current CIM instance collection have no CIM instances' {
+                It 'Should return false when evaluating properties of each CIM instance of a collection of CIM instances' {
+                    $desiredCimInstanceParameters = @{
+                        ClassName   = $mockClassName
+                        Namespace   = $mockNamespace
+                        Property    = @{
+                            State      = 'Grant'
+                            Permission = @('Delete', 'Select', 'Update')
+                            Ensure     = 'Present'
+                        }
+                        ClientOnly  = $true
+                    }
+
+                    $desiredCimInstancePermissionCollection += New-CimInstance @desiredCimInstanceParameters
+
+                    $mockValues = @{
+                        CurrentValue = $currentCimInstancePermissionCollection
+                        DesiredValue = $desiredCimInstancePermissionCollection
+                        KeyProperties = @('State')
+                    }
+
+                    Test-DscPropertyState -Values $mockValues | Should -BeFalse
+                }
+            }
+        }
+
         Context -Name 'When passing invalid types for DesiredValue' {
             It 'Should write a warning when DesiredValue contain an unsupported type' {
                 Mock -CommandName Write-Warning
@@ -3553,6 +4231,11 @@ InModuleScope $script:subModuleName {
                 $mockDesiredValues = @{
                     ComputerName = 'DC01'
                     Location     = 'Sweden'
+                    <#
+                        This is used to increase code coverage so that the code
+                        that removes common parameters are hit.
+                    #>
+                    ErrorAction = 'Stop'
                 }
             }
 


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc
  - Added new resource SqlDatabaseObjectPermission (issue #1119).
- SqlServerDsc.Common
  - The helper function `Compare-ResourcePropertyState` was improved to
    handle embedded instances by adding a parameter `CimInstanceKeyProperties`
    that can be used to identify the unique parameter for each embedded
    instance in a collection.
  - The helper function `Test-DscPropertyState` was improved to evaluate
    the properties in a single CIM instance or a collection of CIM instances
    by recursively call itself.
  - When the helper function `Test-DscPropertyState` evaluated an array
    the verbose messages was not very descriptive. Instead of outputting
    the side indicator from the compare it now outputs a descriptive
    message.

#### This Pull Request (PR) fixes the following issues

- Fixes #1119

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1563)
<!-- Reviewable:end -->
