### PR TITLE
SqlServerDsc: Supports authenticate using both NetBIOS and FQDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update resource parameter documentation ([issue #1568](https://github.com/dsccommunity/SqlServerDsc/issues/1568)).
   - Documentation is now published to the GitHub Wiki.
     - Deploy task was updated with the correct name.
+- SqlServerDsc.Common
+  - Connect-UncPath
+    - Now support to authenticate using both NetBIOS domain and Fully Qualified
+      Domain Name (FQDN) ([issue #1223](https://github.com/dsccommunity/SqlServerDsc/issues/1223)).
+  - Connect-SQL
+    - Now support to authenticate using both NetBIOS domain and Fully Qualified
+      Domain Name (FQDN) ([issue #1223](https://github.com/dsccommunity/SqlServerDsc/issues/1223)).
+  - Connect-SQLAnalysis
+    - Now support to authenticate using both NetBIOS domain and Fully Qualified
+      Domain Name (FQDN) ([issue #1223](https://github.com/dsccommunity/SqlServerDsc/issues/1223)).
+- SqlWindowsFirewall
+  - Now support to authenticate using both NetBIOS domain and Fully Qualified
+    Domain Name (FQDN) ([issue #1223](https://github.com/dsccommunity/SqlServerDsc/issues/1223)).
 
 ## [14.0.0] - 2020-06-12
 

--- a/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
+++ b/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
@@ -55,7 +55,7 @@ function Get-TargetResource
 
     if ($SourceCredential)
     {
-        $userName = "$($SourceCredential.GetNetworkCredential().Domain)\$($SourceCredential.GetNetworkCredential().UserName)"
+        $userName = $SourceCredential.UserName
 
         Write-Verbose -Message (
             $script:localizedData.ConnectUsingCredential -f $SourcePath, $userName
@@ -375,7 +375,7 @@ function Set-TargetResource
 
     if ($SourceCredential)
     {
-        $userName = "$($SourceCredential.GetNetworkCredential().Domain)\$($SourceCredential.GetNetworkCredential().UserName)"
+        $userName = $SourceCredential.UserName
 
         Write-Verbose -Message (
             $script:localizedData.ConnectUsingCredential -f $SourcePath, $userName

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -314,7 +314,7 @@ function Connect-UncPath
 
     if ($PSBoundParameters.ContainsKey('SourceCredential'))
     {
-        $newSmbMappingParameters['UserName'] = "$($SourceCredential.GetNetworkCredential().Domain)\$($SourceCredential.GetNetworkCredential().UserName)"
+        $newSmbMappingParameters['UserName'] = $SourceCredential.UserName
         $newSmbMappingParameters['Password'] = $SourceCredential.GetNetworkCredential().Password
     }
 
@@ -527,7 +527,7 @@ function Connect-SQL
     }
     else
     {
-        $connectUserName = $SetupCredential.GetNetworkCredential().UserName
+        $connectUserName = $SetupCredential.UserName
 
         Write-Verbose -Message (
             $script:localizedData.ConnectingUsingImpersonation -f $connectUsername, $LoginType
@@ -633,7 +633,7 @@ function Connect-SQLAnalysis
 
     if ($SetupCredential)
     {
-        $userName = $SetupCredential.GetNetworkCredential().UserName
+        $userName = $SetupCredential.UserName
         $password = $SetupCredential.GetNetworkCredential().Password
 
         $analysisServicesDataSource = "Data Source=$analysisServiceInstance;User ID=$userName;Password=$password"


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc.Common
  - Connect-UncPath
    - Now support to authenticate using both NetBIOS domain and Fully Qualified
      Domain Name (FQDN) (issue #1223).
  - Connect-SQL
    - Now support to authenticate using both NetBIOS domain and Fully Qualified
      Domain Name (FQDN) (issue #1223).
  - Connect-SQLAnalysis
    - Now support to authenticate using both NetBIOS domain and Fully Qualified
      Domain Name (FQDN) (issue #1223).
- SqlWindowsFirewall
  - Now support to authenticate using both NetBIOS domain and Fully Qualified
    Domain Name (FQDN) (issue #1223).

#### This Pull Request (PR) fixes the following issues
- Fixes #1223

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1575)
<!-- Reviewable:end -->
