### PR TITLE
SqlRole: Fix default for ServerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     a access denied error during install of the _SQL Server Database Engine_
     ([issue #1559](https://github.com/dsccommunity/SqlServerDsc/issues/1559)).
 - SqlRole
-  - Fixed the `ServerName` parameter to work with default value of `$env.COMPUTERNAME` ([issue #1592](https://github.com/dsccommunity/SqlServerDsc/issues/1592)).
+  - Fixed the `ServerName` parameter to work with default value of
+    `$env:COMPUTERNAME` ([issue #1592](https://github.com/dsccommunity/SqlServerDsc/issues/1592)).
 
 ## [14.1.0] - 2020-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     _Restrict clients allowed to make remote calls to SAM_ can result in
     a access denied error during install of the _SQL Server Database Engine_
     ([issue #1559](https://github.com/dsccommunity/SqlServerDsc/issues/1559)).
+- SqlRole
+  - Fixed the `ServerName` parameter to work with default value of `$env.COMPUTERNAME` ([issue #1592](https://github.com/dsccommunity/SqlServerDsc/issues/1592)).
 
 ## [14.1.0] - 2020-07-06
 

--- a/source/DSCResources/DSC_SqlRole/DSC_SqlRole.psm1
+++ b/source/DSCResources/DSC_SqlRole/DSC_SqlRole.psm1
@@ -422,7 +422,7 @@ function Test-TargetResource
 
     $getTargetResourceParameters = @{
         InstanceName     = $PSBoundParameters.InstanceName
-        ServerName       = $PSBoundParameters.ServerName
+        ServerName       = $ServerName
         ServerRoleName   = $PSBoundParameters.ServerRoleName
         Members          = $PSBoundParameters.Members
         MembersToInclude = $PSBoundParameters.MembersToInclude


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description

Fixed: 
* The `ServerName` paramer is optional and defaults to `$env:COMPUTERNAME`, but `Test-TargetResource` uses the `$PSBoundParameters` automatic variable which ignores default values for parameters. Looks like this was fixed by #1503 in several other places such as `SqlDatabasePermission` but was missed here.

<!--
    Replace this comment block with a description of your PR.
    Also, make sure you have updated the CHANGELOG.md, see the
    task list below. An entry in the CHANGELOG.md is mandatory
    for all PRs.
-->

#### This Pull Request (PR) fixes the following issues

- Fixes #1592

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1597)
<!-- Reviewable:end -->
