### PR TITLE
SqlDatabaseObjectPermission: Fix transition "GrantWithGrant" to "Grant"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlDatabaseObjectPermission
   - Fixed method invocation failed because of missing `Where()` method ([issue #1600](https://github.com/PowerShell/SqlServerDsc/issues/1600)).
     - New integration tests to verify scenarios when passing a single permission.
-  - Fixed permission switch from _GrantWithGrant_ to _Grant_ permissions ([issue #1602](https://github.com/dsccommunity/SqlServerDsc/issues/1602)).
+  - To enforce a scenario where a permission must be changed from _GrantWithGrant_
+    to _Grant_ a new parameter **Force** was added ([issue #1602](https://github.com/dsccommunity/SqlServerDsc/issues/1602)).
+    The parameter **Force** is used to enforce the desired state in those
+    scenarios where revocations must be performed to enforce the desired
+    state, even if that encompasses cascading revocations. If parameter
+    **Force** is _not_ set to `$true` an exception is thrown in those
+    scenarios where a revocation must be performed to enforce the desired
+    state.
     - New integration tests to verify scenarios when current permission is
       GrantWithGrant but should be permission Grant.
 - SqlSetup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,16 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlDatabaseObjectPermission
   - Fixed method invocation failed because of missing `Where()` method ([issue #1600](https://github.com/PowerShell/SqlServerDsc/issues/1600)).
     - New integration tests to verify scenarios when passing a single permission.
-  - To enforce a scenario where a permission must be changed from _GrantWithGrant_
-    to _Grant_ a new parameter **Force** was added ([issue #1602](https://github.com/dsccommunity/SqlServerDsc/issues/1602)).
+  - To enforce a scenario where a permission must be changed from `'GrantWithGrant'`
+    to `'Grant'` a new parameter **Force** was added ([issue #1602](https://github.com/dsccommunity/SqlServerDsc/issues/1602)).
     The parameter **Force** is used to enforce the desired state in those
     scenarios where revocations must be performed to enforce the desired
     state, even if that encompasses cascading revocations. If parameter
     **Force** is _not_ set to `$true` an exception is thrown in those
     scenarios where a revocation must be performed to enforce the desired
     state.
-    - New integration tests to verify scenarios when current permission is
-      GrantWithGrant but should be permission Grant.
+    - New integration tests to verify scenarios when current state for a
+      permission is `'GrantWithGrant'` but desired state should be `'Grant'`.
 - SqlSetup
   - The example `4-InstallNamedInstanceInFailoverClusterFirstNode.ps1` was
     updated to no longer reference the issue #405 and issue #444 in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     _DscResource.Common_.
 - SqlDatabaseObjectPermission
   - Fixed method invocation failed because of missing `Where()` method ([issue #1600](https://github.com/PowerShell/SqlServerDsc/issues/1600)).
-    - Added new integration tests to verify scenarios when passing a single permission.
+    - New integration tests to verify scenarios when passing a single permission.
+  - Fixed permission switch from _GrantWithGrant_ to _Grant_ permissions ([issue #1602](https://github.com/dsccommunity/SqlServerDsc/issues/1602)).
+    - New integration tests to verify scenarios when current permission is
+      GrantWithGrant but should be permission Grant.
 - SqlSetup
   - The example `4-InstallNamedInstanceInFailoverClusterFirstNode.ps1` was
     updated to no longer reference the issue #405 and issue #444 in the
@@ -65,9 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlRole
   - Fixed the `ServerName` parameter to work with default value of
     `$env:COMPUTERNAME` ([issue #1592](https://github.com/dsccommunity/SqlServerDsc/issues/1592)).
-- SqlDatabaseObjectPermission
-  - Fixed permission switch from GrantwithGrant to Grant permissions ([issue #1602](https://github.com/dsccommunity/SqlServerDsc/issues/1602)).
-  
+
 ## [14.1.0] - 2020-07-06
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlRole
   - Fixed the `ServerName` parameter to work with default value of
     `$env:COMPUTERNAME` ([issue #1592](https://github.com/dsccommunity/SqlServerDsc/issues/1592)).
-
+- SqlDatabaseObjectPermission
+  - Fixed permission switch from GrantwithGrant to Grant permissions (issue #1602)
+  
 ## [14.1.0] - 2020-07-06
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed the `ServerName` parameter to work with default value of
     `$env:COMPUTERNAME` ([issue #1592](https://github.com/dsccommunity/SqlServerDsc/issues/1592)).
 - SqlDatabaseObjectPermission
-  - Fixed permission switch from GrantwithGrant to Grant permissions (issue #1602)
+  - Fixed permission switch from GrantwithGrant to Grant permissions ([issue #1602](https://github.com/dsccommunity/SqlServerDsc/issues/1602)).
   
 ## [14.1.0] - 2020-07-06
 

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -331,10 +331,23 @@ function Set-TargetResource
 
                                         'Grant'
                                         {
-                                            if ($sqlObject.EnumObjectPermissions($Name).PermissionState -contains 'GrantWithGrant')
+                                            <#
+                                                If the permission was previously granted using WithGrant then WithGrant
+                                                is revoked from all permissions since it is not the desired state.
+
+                                                Even if we just revoke the "WithGrant" and leaving the desired permission
+                                                the permissions must always be granted regardless because it is not known
+                                                if one or more permission existed with GrantWithGrant or did not exist at all.
+
+                                                It could be done if looping through each permission and evaluating WithGrant
+                                                but that would mean additional calls that did not seem necessary.
+                                            #>
+                                            if ($sqlObject.EnumObjectPermissions($Name, $permissionSet).PermissionState -contains 'GrantWithGrant')
                                             {
-                                                $sqlObject.Revoke($permissionSet, $Name, $false, $true)
+                                                # This must cascade the revoke.
+                                                $sqlObject.Revoke($permissionSet, $Name, $true, $true)
                                             }
+
                                             $sqlObject.Grant($permissionSet, $Name)
                                         }
 

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -42,7 +42,7 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
         Specifies that permissions that has parameter Ensure set to 'Present'
         (the default value for permissions) should always be enforced even if that
         encompasses cascading revocations. An example if the desired state is
-        'Grant' but the current state is GrantWithGrant. If parameter Force is set
+        'Grant' but the current state is 'GrantWithGrant'. If parameter Force is set
         to $true the With Grant permission is revoked, if set to $false an exception
         is thrown since the desired state could not be set. Default is to throw an
         exception.
@@ -229,7 +229,7 @@ function Get-TargetResource
         Specifies that permissions that has parameter Ensure set to 'Present'
         (the default value for permissions) should always be enforced even if that
         encompasses cascading revocations. An example if the desired state is
-        'Grant' but the current state is GrantWithGrant. If parameter Force is set
+        'Grant' but the current state is 'GrantWithGrant'. If parameter Force is set
         to $true the With Grant permission is revoked, if set to $false an exception
         is thrown since the desired state could not be set. Default is to throw an
         exception.
@@ -358,15 +358,14 @@ function Set-TargetResource
                                         'Grant'
                                         {
                                             <#
-                                                If the permission was previously granted using WithGrant then WithGrant
-                                                is revoked from all permissions since it is not the desired state.
+                                                If the permission was previously granted using With Grant then With Grant is
+                                                revoked from all permissions since it is not the desired state.
 
-                                                Even if we just revoke the "WithGrant" and leaving the desired permission
-                                                the permissions must always be granted regardless because it is not known
-                                                if one or more permission existed with GrantWithGrant or did not exist at all.
-                                                It could be known if looping through the permissions and evaluating WithGrant
-                                                for each, but that would mean additional calls that did not seem necessary at
-                                                the time.
+                                                Even if we just revoke the With Grant and leaving the desired permission the
+                                                permissions must always be granted regardless, this is because it is not known
+                                                which permissions existed with With Grant or did not exist at all. It could be
+                                                known if looping through the permissions and evaluating With Grant for each,
+                                                but that would mean additional calls that did not seem necessary at the time
                                             #>
                                             if ($sqlObject.EnumObjectPermissions($Name, $permissionSet).PermissionState -contains 'GrantWithGrant')
                                             {
@@ -511,7 +510,7 @@ function Set-TargetResource
         Specifies that permissions that has parameter Ensure set to 'Present'
         (the default value for permissions) should always be enforced even if that
         encompasses cascading revocations. An example if the desired state is
-        'Grant' but the current state is GrantWithGrant. If parameter Force is set
+        'Grant' but the current state is 'GrantWithGrant'. If parameter Force is set
         to $true the With Grant permission is revoked, if set to $false an exception
         is thrown since the desired state could not be set. Default is to throw an
         exception.
@@ -632,7 +631,7 @@ function Test-TargetResource
         Specifies that permissions that has parameter Ensure set to 'Present'
         (the default value for permissions) should always be enforced even if that
         encompasses cascading revocations. An example if the desired state is
-        'Grant' but the current state is GrantWithGrant. If parameter Force is set
+        'Grant' but the current state is 'GrantWithGrant'. If parameter Force is set
         to $true the With Grant permission is revoked, if set to $false an exception
         is thrown since the desired state could not be set. Default is to throw an
         exception.

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -338,12 +338,22 @@ function Set-TargetResource
                                                 Even if we just revoke the "WithGrant" and leaving the desired permission
                                                 the permissions must always be granted regardless because it is not known
                                                 if one or more permission existed with GrantWithGrant or did not exist at all.
-
-                                                It could be done if looping through each permission and evaluating WithGrant
-                                                but that would mean additional calls that did not seem necessary.
+                                                It could be known if looping through the permissions and evaluating WithGrant
+                                                for each, but that would mean additional calls that did not seem necessary at
+                                                the time.
                                             #>
                                             if ($sqlObject.EnumObjectPermissions($Name, $permissionSet).PermissionState -contains 'GrantWithGrant')
                                             {
+                                                Write-Verbose -Message (
+                                                    $script:localizedData.RevokePermissionWithGrant -f @(
+                                                        ($desiredPermissionState.Permission -join ','),
+                                                        $Name
+                                                        ('{0}.{1}' -f $SchemaName, $ObjectName),
+                                                        $ObjectType,
+                                                        $DatabaseName
+                                                    )
+                                                )
+
                                                 # This must cascade the revoke.
                                                 $sqlObject.Revoke($permissionSet, $Name, $true, $true)
                                             }

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -331,7 +331,7 @@ function Set-TargetResource
 
                                         'Grant'
                                         {
-                                            if ($sqlObject.EnumObjectPermissions($Name).PermissionState -eq 'GrantWithGrant')
+                                            if ($sqlObject.EnumObjectPermissions($Name).PermissionState -contains 'GrantWithGrant')
                                             {
                                                 $sqlObject.Revoke($permissionSet, $Name, $false, $true)
                                             }

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -331,7 +331,7 @@ function Set-TargetResource
 
                                         'Grant'
                                         {
-                                            if ($sqlObject.EnumObjectPermissions($Name).PermissionState -eq "GrantWithGrant")
+                                            if ($sqlObject.EnumObjectPermissions($Name).PermissionState -eq 'GrantWithGrant')
                                             {
                                                 $sqlObject.Revoke($permissionSet, $Name, $false, $true)
                                             }

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -331,6 +331,10 @@ function Set-TargetResource
 
                                         'Grant'
                                         {
+                                            if ($sqlObject.EnumObjectPermissions($Name).PermissionState -eq "GrantWithGrant")
+                                            {
+                                                $sqlObject.Revoke($permissionSet, $Name, $false, $true)
+                                            }
                                             $sqlObject.Grant($permissionSet, $Name)
                                         }
 

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -111,6 +111,7 @@ function Get-TargetResource
         ObjectType   = $ObjectType
         Name         = $Name
         Permission   = $cimInstancePermissionCollection
+        Force        = $Force
     }
 
     $getDatabaseObjectParameters = @{

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.schema.mof
@@ -9,7 +9,7 @@ class DSC_SqlDatabaseObjectPermission : OMI_BaseResource
     [Key, Description("Specifies the name of the database user, user-defined database role, or database application role that will have the permission.")] String Name;
     [Required, EmbeddedInstance("DSC_DatabaseObjectPermission"), Description("Specifies the permissions for the database object and the principal. The permissions is an array of embedded instances of the `DSC_DatabaseObjectPermission` CIM class.")] String Permission[];
     [Write, Description("Specifies the host name of the _SQL Server_ to be configured. Default value is `$env:COMPUTERNAME`.")] String ServerName;
-    [Write, Description("Specifies that permissions that has parameter **Ensure** set to `'Present'` (the default value for permissions) should always be enforced even if that encompasses cascading revocations. An example if the desired state is `'Grant'` but the current state is `GrantWithGrant`. If parameter **Force** is set to `$true` the _With Grant_ permission is revoked, if set to `$false` an exception is thrown since the desired state could not be set. Default is to throw an exception.")] Boolean Force;
+    [Write, Description("Specifies that permissions that has parameter **Ensure** set to `'Present'` (the default value for permissions) should always be enforced even if that encompasses cascading revocations. An example if the desired state is `'Grant'` but the current state is `'GrantWithGrant'`. If parameter **Force** is set to `$true` the _With Grant_ permission is revoked, if set to `$false` an exception is thrown since the desired state could not be set. Default is to throw an exception.")] Boolean Force;
 };
 
 [ClassVersion("1.0.0")]

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.schema.mof
@@ -9,6 +9,7 @@ class DSC_SqlDatabaseObjectPermission : OMI_BaseResource
     [Key, Description("Specifies the name of the database user, user-defined database role, or database application role that will have the permission.")] String Name;
     [Required, EmbeddedInstance("DSC_DatabaseObjectPermission"), Description("Specifies the permissions for the database object and the principal. The permissions is an array of embedded instances of the `DSC_DatabaseObjectPermission` CIM class.")] String Permission[];
     [Write, Description("Specifies the host name of the _SQL Server_ to be configured. Default value is `$env:COMPUTERNAME`.")] String ServerName;
+    [Write, Description("Specifies that permissions that has parameter **Ensure** set to `'Present'` (the default value for permissions) should always be enforced even if that encompasses cascading revocations. An example if the desired state is `'Grant'` but the current state is `GrantWithGrant`. If parameter **Force** is set to `$true` the _With Grant_ permission is revoked, if set to `$false` an exception is thrown since the desired state could not be set. Default is to throw an exception.")] Boolean Force;
 };
 
 [ClassVersion("1.0.0")]

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
@@ -10,5 +10,5 @@ ConvertFrom-StringData @'
     SetDesiredState = Setting the desired permissions for the database object '{0}'. (SDOP0009)
     FailedToSetDatabaseObjectPermission = Failed to set the permissions for the user '{0}' on the database object '{1}' in the database '{2}'. (SDOP0009)
     PermissionStateInDesiredState = The permission state '{0}' is already in desired state for database object '{1}'. (SDOP0010)
-    RevokePermissionWithGrant = One or more the permissions '{0}' had the 'WithGrant' permission. For the user '{1}' and those permissions the 'WithGrant' permission in revoked on the database object '{2}' of type '{3}' in the database '{4}'. The revoke is cascaded. (SDOP0011)
+    RevokePermissionWithGrant = One or more of the permissions was granted with the 'With Grant' permission for the user '{1}' on the database object '{2}' of type '{3}' in the database '{4}'. For the permissions ('{0}') the 'With Grant' permission is revoked, and the revoke is cascaded. (SDOP0011)
 '@

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
@@ -11,4 +11,5 @@ ConvertFrom-StringData @'
     FailedToSetDatabaseObjectPermission = Failed to set the permissions for the user '{0}' on the database object '{1}' in the database '{2}'. (SDOP0009)
     PermissionStateInDesiredState = The permission state '{0}' is already in desired state for database object '{1}'. (SDOP0010)
     RevokePermissionWithGrant = One or more of the permissions was granted with the 'With Grant' permission for the user '{1}' on the database object '{2}' of type '{3}' in the database '{4}'. For the permissions ('{0}') the 'With Grant' permission is revoked, and the revoke is cascaded. (SDOP0011)
+    GrantCantBeSetBecauseRevokeIsNotOptedIn = One or more of the permissions was granted with the 'With Grant' permission for the user '{1}' on the database object '{2}' of type '{3}' in the database '{4}'. For the permissions ('{0}') the 'With Grant' permission must be revoked, and the revoke must be cascaded, to enforce the desired state. If this desired state should be enforced then set the parameter Force to $true.
 '@

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
@@ -9,5 +9,6 @@ ConvertFrom-StringData @'
     RevokePermission = Revoking permissions '{0}' for the user '{1}' and the state '{2}' for the database object '{3}' of type '{4}' in the database '{5}' (SDOP0008)
     SetDesiredState = Setting the desired permissions for the database object '{0}'. (SDOP0009)
     FailedToSetDatabaseObjectPermission = Failed to set the permissions for the user '{0}' on the database object '{1}' in the database '{2}'. (SDOP0009)
-    PermissionStateInDesiredState = The permission state '{0}' is already in desired state for database object '{1}'.
+    PermissionStateInDesiredState = The permission state '{0}' is already in desired state for database object '{1}'. (SDOP0010)
+    RevokePermissionWithGrant = For the permissions '{0}' the 'WithGrant' permission is revoked for the user '{1}' on the database object '{2}' of type '{3}' in the database '{4}'. The revoke is cascaded. (SDOP0011)
 '@

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
@@ -10,5 +10,5 @@ ConvertFrom-StringData @'
     SetDesiredState = Setting the desired permissions for the database object '{0}'. (SDOP0009)
     FailedToSetDatabaseObjectPermission = Failed to set the permissions for the user '{0}' on the database object '{1}' in the database '{2}'. (SDOP0009)
     PermissionStateInDesiredState = The permission state '{0}' is already in desired state for database object '{1}'. (SDOP0010)
-    RevokePermissionWithGrant = For the permissions '{0}' the 'WithGrant' permission is revoked for the user '{1}' on the database object '{2}' of type '{3}' in the database '{4}'. The revoke is cascaded. (SDOP0011)
+    RevokePermissionWithGrant = One or more the permissions '{0}' had the 'WithGrant' permission. For the user '{1}' and those permissions the 'WithGrant' permission in revoked on the database object '{2}' of type '{3}' in the database '{4}'. The revoke is cascaded. (SDOP0011)
 '@

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -61,6 +61,76 @@ try
             }
         }
 
+        <#
+            This is a regression test for issue #1602. The next test should replace
+            the permission GrantWithGrant with the permission Grant.
+        #>
+        $configurationName = "$($script:dscResourceName)_Single_GrantWithGrant_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath           = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData    = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.ServerName | Should -Be $ConfigurationData.AllNodes.ServerName
+                $resourceCurrentState.InstanceName | Should -Be $ConfigurationData.AllNodes.InstanceName
+                $resourceCurrentState.DatabaseName | Should -Be $ConfigurationData.AllNodes.DatabaseName
+                $resourceCurrentState.SchemaName | Should -Be $ConfigurationData.AllNodes.SchemaName
+                $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.TableName
+                $resourceCurrentState.ObjectType | Should -Be 'Table'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+
+                $resourceCurrentState.Permission | Should -HaveCount 1
+                $resourceCurrentState.Permission[0] | Should -BeOfType 'CimInstance'
+
+                $grantPermission = $resourceCurrentState.Permission.Where( { $_.State -eq 'GrantWithGrant' })
+                $grantPermission | Should -Not -BeNullOrEmpty
+                $grantPermission.Ensure | Should -Be 'Present'
+                $grantPermission.Permission | Should -HaveCount 1
+                $grantPermission.Permission | Should -Contain @('Select')
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        <#
+            This test is used for the previous regression test for issue #1602. This
+            test should replace the previous test that set the permission GrantWithGrant
+            with the permission Grant.
+        #>
         $configurationName = "$($script:dscResourceName)_Single_Grant_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -110,6 +110,7 @@ try
                 $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.TableName
                 $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+                $resourceCurrentState.Force | Should -BeFalse
 
                 $resourceCurrentState.Permission | Should -HaveCount 1
                 $resourceCurrentState.Permission[0] | Should -BeOfType 'CimInstance'
@@ -176,6 +177,7 @@ try
                 $resourceCurrentState.ObjectName | Should -Be $ConfigurationData.AllNodes.TableName
                 $resourceCurrentState.ObjectType | Should -Be 'Table'
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.User1_Name
+                $resourceCurrentState.Force | Should -BeTrue
 
                 $resourceCurrentState.Permission | Should -HaveCount 1
                 $resourceCurrentState.Permission[0] | Should -BeOfType 'CimInstance'

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
@@ -172,6 +172,7 @@ Configuration DSC_SqlDatabaseObjectPermission_Single_Grant_Config
                     Permission = @('Select')
                 }
             )
+            Force                = $true
 
             PsDscRunAsCredential = New-Object `
                 -TypeName System.Management.Automation.PSCredential `

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.config.ps1
@@ -101,7 +101,54 @@ Configuration DSC_SqlDatabaseObjectPermission_Prerequisites_Config
 
 <#
     .SYNOPSIS
+        Grant a user single permission for a table in a database, also allows
+        the user to grant the permission (GrantWithGrant).
+
+    .NOTES
+        This is a regression test for issue #1602. The next test should replace
+        the permission GrantWithGrant with the permission Grant.
+#>
+Configuration DSC_SqlDatabaseObjectPermission_Single_GrantWithGrant_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlDatabaseObjectPermission 'Integration_Test'
+        {
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            DatabaseName         = $Node.DatabaseName
+            SchemaName           = $Node.SchemaName
+            ObjectName           = $Node.TableName
+            ObjectType           = 'Table'
+            Name                 = $Node.User1_Name
+            Permission           = @(
+                DSC_DatabaseObjectPermission
+                {
+                    State      = 'GrantWithGrant'
+                    Permission = @('Select')
+                }
+            )
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @(
+                    $Node.UserName,
+                    (ConvertTo-SecureString -String $Node.Password -AsPlainText -Force)
+                )
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
         Grant a user single permission for a table in a database.
+
+    .NOTES
+        This test is used for the previous regression test for issue #1602. This
+        test should replace the previous test that set the permission GrantWithGrant
+        with the permission Grant.
 #>
 Configuration DSC_SqlDatabaseObjectPermission_Single_Grant_Config
 {

--- a/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
@@ -1865,20 +1865,6 @@ try
                         # Regression test for issue #1602.
                         Context 'When setting permission for the permission state ''Grant'' and current permission state already is GrantWithGrant' {
                             BeforeAll {
-                                Mock -CommandName Compare-TargetResourceState -MockWith {
-                                    return @(
-                                        @{
-                                            ParameterName  = 'Permission'
-                                            InDesiredState = $false
-                                            Actual         = @(
-                                                (New-Object -TypeName PSCustomObject |
-                                                    Add-Member -MemberType NoteProperty -Name 'State' -Value 'Grant' -PassThru |
-                                                    Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Absent' -PassThru -Force)
-                                            )
-                                        }
-                                    )
-                                }
-
                                 Mock -CommandName Get-DatabaseObject -MockWith {
                                     # Should mock a database object, e.g. Schema, Table, View.
                                     return New-Object -TypeName PSCustomObject |
@@ -1902,34 +1888,6 @@ try
                                                     Add-Member -MemberType NoteProperty -Name 'PermissionState' -Value 'GrantWithGrant' -PassThru -Force
                                             )
                                         } -PassThru -Force
-                                }
-
-                                # Create an empty collection of CimInstance that we can return.
-                                $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
-
-                                <#
-                                    Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
-                                    to increase code coverage.
-                                #>
-                                $cimInstancePermissionCollection += New-CimInstance `
-                                    -ClassName 'DSC_DatabaseObjectPermission' `
-                                    -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
-                                    -Property @{
-                                        State      = 'Grant'
-                                        Permission = @('Delete')
-                                        Ensure     = 'Present'
-                                    } `
-                                    -ClientOnly
-
-                                $setTargetResourceParameters = @{
-                                    InstanceName = 'DSCTEST'
-                                    DatabaseName = 'AdventureWorks'
-                                    SchemaName   = 'dbo'
-                                    ObjectName   = 'Table1'
-                                    ObjectType   = 'Table'
-                                    Name         = 'TestAppRole'
-                                    Permission   = $cimInstancePermissionCollection
-                                    Verbose      = $true
                                 }
                             }
 

--- a/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
@@ -1786,22 +1786,12 @@ try
                             Add-Member -MemberType NoteProperty -Name 'ViewChangeTracking' -Value $false -PassThru |
                             Add-Member -MemberType NoteProperty -Name 'ViewDefinition' -Value $false -PassThru -Force
                         }
-
-                        Mock -CommandName Get-DatabaseObject -MockWith {
-                            # Should mock a database object, e.g. Schema, Table, View.
-                            return New-Object -TypeName PSCustomObject |
-                                Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
-                                    $script:mockMethodGrantRanTimes += 1
-                                } -PassThru |
-                                Add-Member -MemberType ScriptMethod -Name 'Deny' -Value {
-                                    $script:mockMethodDenyRanTimes += 1
-                                } -PassThru -Force
-                        }
                     }
 
                     BeforeEach {
                         $script:mockMethodGrantRanTimes = 0
                         $script:mockMethodDenyRanTimes = 0
+                        $script:mockMethodRevokeRanTimes = 0
                     }
 
                     Context 'When setting permission for the permission state ''Grant''' {
@@ -1818,6 +1808,20 @@ try
                                         )
                                     }
                                 )
+                            }
+
+                            Mock -CommandName Get-DatabaseObject -MockWith {
+                                # Should mock a database object, e.g. Schema, Table, View.
+                                return New-Object -TypeName PSCustomObject |
+                                    Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
+                                        $script:mockMethodGrantRanTimes += 1
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Deny' -Value {
+                                        $script:mockMethodDenyRanTimes += 1
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' -Value {
+                                        return $null
+                                    } -PassThru -Force
                             }
 
                             # Create an empty collection of CimInstance that we can return.
@@ -1857,6 +1861,88 @@ try
                             $script:mockMethodGrantRanTimes | Should -Be 1
                             $script:mockMethodDenyRanTimes  | Should -Be 0
                         }
+
+                        # Regression test for issue #1602.
+                        Context 'When setting permission for the permission state ''Grant'' and current permission state already is GrantWithGrant' {
+                            BeforeAll {
+                                Mock -CommandName Compare-TargetResourceState -MockWith {
+                                    return @(
+                                        @{
+                                            ParameterName  = 'Permission'
+                                            InDesiredState = $false
+                                            Actual         = @(
+                                                (New-Object -TypeName PSCustomObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'State' -Value 'Grant' -PassThru |
+                                                    Add-Member -MemberType NoteProperty -Name 'Ensure' -Value 'Absent' -PassThru -Force)
+                                            )
+                                        }
+                                    )
+                                }
+
+                                Mock -CommandName Get-DatabaseObject -MockWith {
+                                    # Should mock a database object, e.g. Schema, Table, View.
+                                    return New-Object -TypeName PSCustomObject |
+                                        Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
+                                            $script:mockMethodGrantRanTimes += 1
+                                        } -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name 'Deny' -Value {
+                                            $script:mockMethodDenyRanTimes += 1
+                                        } -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name 'Revoke' -Value {
+                                            $script:mockMethodRevokeRanTimes += 1
+                                        } -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name 'EnumObjectPermissions' -Value {
+                                            <#
+                                                Normally it returns an array of
+                                                Microsoft.SqlServer.Management.Smo.ObjectPermissionInfo[]
+                                                with the permissions that had the state 'GrantWithGrant'.
+                                            #>
+                                            return @(
+                                                New-Object -TypeName PSCustomObject |
+                                                    Add-Member -MemberType NoteProperty -Name 'PermissionState' -Value 'GrantWithGrant' -PassThru -Force
+                                            )
+                                        } -PassThru -Force
+                                }
+
+                                # Create an empty collection of CimInstance that we can return.
+                                $cimInstancePermissionCollection = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
+
+                                <#
+                                    Intentionally not using helper ConvertTo-CimDatabaseObjectPermission
+                                    to increase code coverage.
+                                #>
+                                $cimInstancePermissionCollection += New-CimInstance `
+                                    -ClassName 'DSC_DatabaseObjectPermission' `
+                                    -Namespace 'root/microsoft/Windows/DesiredStateConfiguration' `
+                                    -Property @{
+                                        State      = 'Grant'
+                                        Permission = @('Delete')
+                                        Ensure     = 'Present'
+                                    } `
+                                    -ClientOnly
+
+                                $setTargetResourceParameters = @{
+                                    InstanceName = 'DSCTEST'
+                                    DatabaseName = 'AdventureWorks'
+                                    SchemaName   = 'dbo'
+                                    ObjectName   = 'Table1'
+                                    ObjectType   = 'Table'
+                                    Name         = 'TestAppRole'
+                                    Permission   = $cimInstancePermissionCollection
+                                    Verbose      = $true
+                                }
+                            }
+
+                            It 'Should set the permissions without throwing an exception' {
+                                { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+
+                                Assert-MockCalled -CommandName Get-DatabaseObject -Exactly -Times 1 -Scope It
+
+                                $script:mockMethodRevokeRanTimes | Should -Be 1
+                                $script:mockMethodGrantRanTimes | Should -Be 1
+                                $script:mockMethodDenyRanTimes  | Should -Be 0
+                            }
+                        }
                     }
 
                     Context 'When setting permission for the permission state ''GrantWithGrant''' {
@@ -1873,6 +1959,17 @@ try
                                         )
                                     }
                                 )
+                            }
+
+                            Mock -CommandName Get-DatabaseObject -MockWith {
+                                # Should mock a database object, e.g. Schema, Table, View.
+                                return New-Object -TypeName PSCustomObject |
+                                    Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
+                                        $script:mockMethodGrantRanTimes += 1
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Deny' -Value {
+                                        $script:mockMethodDenyRanTimes += 1
+                                    } -PassThru -Force
                             }
 
                             # Create an empty collection of CimInstance that we can return.
@@ -1927,6 +2024,17 @@ try
                                         )
                                     }
                                 )
+                            }
+
+                            Mock -CommandName Get-DatabaseObject -MockWith {
+                                # Should mock a database object, e.g. Schema, Table, View.
+                                return New-Object -TypeName PSCustomObject |
+                                    Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
+                                        $script:mockMethodGrantRanTimes += 1
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Deny' -Value {
+                                        $script:mockMethodDenyRanTimes += 1
+                                    } -PassThru -Force
                             }
 
                             # Create an empty collection of CimInstance that we can return.
@@ -1984,6 +2092,17 @@ try
                                         )
                                     }
                                 )
+                            }
+
+                            Mock -CommandName Get-DatabaseObject -MockWith {
+                                # Should mock a database object, e.g. Schema, Table, View.
+                                return New-Object -TypeName PSCustomObject |
+                                    Add-Member -MemberType ScriptMethod -Name 'Grant' -Value {
+                                        $script:mockMethodGrantRanTimes += 1
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Deny' -Value {
+                                        $script:mockMethodDenyRanTimes += 1
+                                    } -PassThru -Force
                             }
 
                             # Create an empty collection of CimInstance that we can return.


### PR DESCRIPTION
#### Pull Request (PR) description
SqlDatabaseObjectPermission

Setting table permission from "GrantWithGrant" to "Grant" still results in "GrantWithGrant" permissions configured

#### This Pull Request (PR) fixes the following issues
Fixes #1602  

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [X ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1603)
<!-- Reviewable:end -->
