### PR TITLE
SqlSetup,SqlWindowsFirewall: Fix duplicate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlDatabaseObjectPermission
   - New integration tests to verify scenarios when passing a single permission.
 
+### Changed
+
+- SqlServerDsc
+  - Minor document changes in the file `build.yml`.
+- SqlSetup
+  - Duplicate function Get-SqlMajorVersion was removed and instead the
+    helper function `Get-FilePathMajorVersion` from the helper module
+    SqlServerDsc.Common is used.
+- SqlWindowsFirewall
+  - Duplicate function Get-SqlMajorVersion was removed and instead the
+    helper function `Get-FilePathMajorVersion` from the helper module
+    SqlServerDsc.Common is used.
+- SqlServerDsc.Common
+  - Function `Get-FilePathMajorVersion` was added. The function `Get-SqlMajorVersion`
+    from the resources _SqlSetup_ and _SqlWindowsFirewall_ was moved and
+    renamed without any functional changes.
+
 ### Fixed
 
 - SqlServerDsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlSetup
   - Duplicate function Get-SqlMajorVersion was removed and instead the
     helper function `Get-FilePathMajorVersion` from the helper module
-    SqlServerDsc.Common is used.
+    SqlServerDsc.Common is used ([issue #1178](https://github.com/PowerShell/SqlServerDsc/issues/1178)).
 - SqlWindowsFirewall
   - Duplicate function Get-SqlMajorVersion was removed and instead the
     helper function `Get-FilePathMajorVersion` from the helper module
-    SqlServerDsc.Common is used.
+    SqlServerDsc.Common is used ([issue #1178](https://github.com/PowerShell/SqlServerDsc/issues/1178)).
 - SqlServerDsc.Common
   - Function `Get-FilePathMajorVersion` was added. The function `Get-SqlMajorVersion`
     from the resources _SqlSetup_ and _SqlWindowsFirewall_ was moved and
-    renamed without any functional changes.
+    renamed without any functional changes ([issue #1178](https://github.com/PowerShell/SqlServerDsc/issues/1178)).
 
 ### Fixed
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,43 +1,6 @@
 ---
 ####################################################
-#          ModuleBuilder Configuration             #
-####################################################
-CopyPaths:
-  - DSCResources
-  - en-US
-  - Modules
-Encoding: UTF8
-VersionedOutputDirectory: true
-
-ModuleBuildTasks:
-  Sampler:
-    - '*.build.Sampler.ib.tasks'
-  DscResource.DocGenerator:
-    - 'Task.*'
-
-TaskHeader: |
-  param($Path)
-  ""
-  "=" * 79
-  Write-Build Cyan "`t`t`t$($Task.Name.replace("_"," ").ToUpper())"
-  Write-Build DarkGray  "$(Get-BuildSynopsis $Task)"
-  "-" * 79
-  Write-Build DarkGray "  $Path"
-  Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
-  ""
-
-####################################################
-#   ModuleBuilder Dependent Modules Configuration  #
-####################################################
-NestedModule:
-  DscResource.Common:
-    CopyOnly: true
-    Path: ./output/RequiredModules/DscResource.Common
-    AddToManifest: false
-    Exclude: PSGetModuleInfo.xml
-
-####################################################
-#           Pipeline Configuration                 #
+# Pipeline Build Task Configuration (Invoke-Build) #
 ####################################################
 BuildWorkflow:
   '.':
@@ -69,7 +32,44 @@ BuildWorkflow:
     - Publish_GitHub_Wiki_Content
 
 ####################################################
-#              PESTER Configuration                #
+#           ModuleBuilder Configuration            #
+####################################################
+CopyPaths:
+  - DSCResources
+  - en-US
+  - Modules
+Encoding: UTF8
+VersionedOutputDirectory: true
+
+ModuleBuildTasks:
+  Sampler:
+    - '*.build.Sampler.ib.tasks'
+  DscResource.DocGenerator:
+    - 'Task.*'
+
+TaskHeader: |
+  param($Path)
+  ""
+  "=" * 79
+  Write-Build Cyan "`t`t`t$($Task.Name.replace("_"," ").ToUpper())"
+  Write-Build DarkGray  "$(Get-BuildSynopsis $Task)"
+  "-" * 79
+  Write-Build DarkGray "  $Path"
+  Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
+  ""
+
+####################################################
+#     Dependent Modules Configuration (Sampler)    #
+####################################################
+NestedModule:
+  DscResource.Common:
+    CopyOnly: true
+    Path: ./output/RequiredModules/DscResource.Common
+    AddToManifest: false
+    Exclude: PSGetModuleInfo.xml
+
+####################################################
+#          Pester Configuration (Sampler)          #
 ####################################################
 Pester:
   OutputFormat: NUnitXML
@@ -88,6 +88,9 @@ Pester:
   CodeCoverageOutputFile: JaCoCo_coverage.xml
   CodeCoverageOutputFileEncoding: ascii
 
+####################################################
+#      Pester Configuration (DscResource.Test)     #
+####################################################
 DscTest:
   ExcludeTag:
     - "Common Tests - New Error-Level Script Analyzer Rules"

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -172,7 +172,7 @@ function Get-TargetResource
 
     Write-Verbose -Message ($script:localizedData.UsingPath -f $pathToSetupExecutable)
 
-    $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
+    $sqlVersion = Get-FilePathMajorVersion -Path $pathToSetupExecutable
 
     if ($SourceCredential)
     {
@@ -984,7 +984,7 @@ function Set-TargetResource
 
     Write-Verbose -Message ($script:localizedData.UsingPath -f $pathToSetupExecutable)
 
-    $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
+    $sqlVersion = Get-FilePathMajorVersion -Path $pathToSetupExecutable
 
     # Determine features to install
     $featuresToInstall = ''
@@ -2192,7 +2192,7 @@ function Test-TargetResource
 
     if ($getTargetResourceParameters.Action -eq 'Upgrade')
     {
-        $installerSqlVersion = Get-SqlMajorVersion -Path (Join-Path -Path $sourcePath -ChildPath 'setup.exe')
+        $installerSqlVersion = Get-FilePathMajorVersion -Path (Join-Path -Path $sourcePath -ChildPath 'setup.exe')
         $instanceSqlVersion = Get-SQLInstanceMajorVersion -InstanceName $InstanceName
 
         if ($installerSQLVersion -gt $instanceSqlVersion)
@@ -2206,26 +2206,6 @@ function Test-TargetResource
     }
 
     return $result
-}
-
-<#
-    .SYNOPSIS
-        Returns the SQL Server major version from the setup.exe executable provided in the Path parameter.
-
-    .PARAMETER Path
-        String containing the path to the SQL Server setup.exe executable.
-#>
-function Get-SqlMajorVersion
-{
-    [CmdletBinding()]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $Path
-    )
-
-    (Get-Item -Path $Path).VersionInfo.ProductVersion.Split('.')[0]
 }
 
 <#

--- a/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
+++ b/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
@@ -78,7 +78,7 @@ function Get-TargetResource
         $script:localizedData.UsingPath -f $pathToSetupExecutable
     )
 
-    $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
+    $sqlVersion = Get-FilePathMajorVersion -Path $pathToSetupExecutable
 
     Write-Verbose -Message (
         $script:localizedData.MajorVersion -f $sqlVersion
@@ -401,7 +401,7 @@ function Set-TargetResource
         $script:localizedData.UsingPath -f $pathToSetupExecutable
     )
 
-    $sqlVersion = Get-SqlMajorVersion -Path $pathToSetupExecutable
+    $sqlVersion = Get-FilePathMajorVersion -Path $pathToSetupExecutable
 
     Write-Verbose -Message (
         $script:localizedData.MajorVersion -f $sqlVersion
@@ -862,27 +862,6 @@ function Test-IsFirewallRuleInDesiredState
     }
 
     return $isRuleInDesiredState
-}
-
-<#
-    .SYNOPSIS
-        Returns the SQL Server major version from the setup.exe executable provided
-        in the Path parameter.
-
-    .PARAMETER Path
-        String containing the path to the SQL Server setup.exe executable.
-#>
-function Get-SqlMajorVersion
-{
-    [CmdletBinding()]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $path
-    )
-
-    (Get-Item -Path $path).VersionInfo.ProductVersion.Split('.')[0]
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
@@ -54,6 +54,7 @@
         'Import-Assembly'
         'Set-PSModulePath'
         'ConvertTo-ServerInstanceName'
+        'Get-FilePathMajorVersion'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -2374,3 +2374,24 @@ function ConvertTo-ServerInstanceName
 
     return $serverInstance
 }
+
+<#
+    .SYNOPSIS
+        Returns the SQL Server major version from the setup.exe executable provided
+        in the Path parameter.
+
+    .PARAMETER Path
+        String containing the path to the SQL Server setup.exe executable.
+#>
+function Get-FilePathMajorVersion
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path
+    )
+
+    (Get-Item -Path $Path).VersionInfo.ProductVersion.Split('.')[0]
+}

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -193,7 +193,7 @@ try
 
                 # General mocks
                 Mock -CommandName Get-PSDrive
-                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion
+                Mock -CommandName Get-FilePathMajorVersion -MockWith $mockGetSqlMajorVersion
 
                 Mock -CommandName Get-RegistryPropertyValue -ParameterFilter {
                     $Name -eq 'ImagePath'
@@ -1610,7 +1610,7 @@ try
                             }
                         }
 
-                        Mock -CommandName Get-SqlMajorVersion -MockWith {
+                        Mock -CommandName Get-FilePathMajorVersion -MockWith {
                             return '15'
                         }
 
@@ -2071,7 +2071,7 @@ try
                 # General mocks
                 Mock -CommandName Get-PSDrive
                 Mock -CommandName Import-SQLPSModule
-                Mock -CommandName Get-SqlMajorVersion -MockWith $mockGetSqlMajorVersion
+                Mock -CommandName Get-FilePathMajorVersion -MockWith $mockGetSqlMajorVersion
 
                 # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
                 Mock -CommandName Get-ItemProperty

--- a/tests/Unit/DSC_SqlWindowsFirewall.Tests.ps1
+++ b/tests/Unit/DSC_SqlWindowsFirewall.Tests.ps1
@@ -411,18 +411,9 @@ try
         }
         $mockSetNetFirewallRule = $mockNewNetFirewallRule
 
-        $mockGetItem_SqlMajorVersion = {
-            return New-Object -TypeName Object |
-                        Add-Member -MemberType ScriptProperty -Name VersionInfo -Value {
-                            return New-Object -TypeName Object |
-                                        Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value ('{0}.0.0000.00000' -f $mockCurrentSqlMajorVersion) -PassThru -Force
-                        } -PassThru -Force
+        $mockGetSqlMajorVersion = {
+            return $mockCurrentSqlMajorVersion
         }
-
-        $mockGetItem_SqlMajorVersion_ParameterFilter = {
-            $Path -eq $mockCurrentPathToSetupExecutable
-        }
-
         #endregion Function mocks
 
         # Default parameters that are used for the It-blocks
@@ -438,7 +429,7 @@ try
 
             BeforeEach {
                 # General mocks
-                Mock -CommandName Get-Item -ParameterFilter $mockGetItem_SqlMajorVersion_ParameterFilter -MockWith $mockGetItem_SqlMajorVersion -Verifiable
+                Mock -CommandName Get-FilePathMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
 
                 # Mock SQL Server Database Engine registry for Instance ID.
                 Mock -CommandName Get-ItemProperty `
@@ -1028,7 +1019,7 @@ try
 
             BeforeEach {
                 # General mocks
-                Mock -CommandName Get-Item -ParameterFilter $mockGetItem_SqlMajorVersion_ParameterFilter -MockWith $mockGetItem_SqlMajorVersion -Verifiable
+                Mock -CommandName Get-FilePathMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
 
                 # Mock SQL Server Database Engine registry for Instance ID.
                 Mock -CommandName Get-ItemProperty `
@@ -1323,7 +1314,7 @@ try
 
             BeforeEach {
                 # General mocks
-                Mock -CommandName Get-Item -ParameterFilter $mockGetItem_SqlMajorVersion_ParameterFilter -MockWith $mockGetItem_SqlMajorVersion -Verifiable
+                Mock -CommandName Get-FilePathMajorVersion -MockWith $mockGetSqlMajorVersion -Verifiable
 
                 # Mock SQL Server Database Engine registry for Instance ID.
                 Mock -CommandName Get-ItemProperty `

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -3446,4 +3446,24 @@ InModuleScope $script:subModuleName {
             $result | Should -BeExactly ('{0}\{1}' -f $env:COMPUTERNAME, 'MyInstance')
         }
     }
+
+    Describe 'SqlServerDsc.Common\Get-FilePathMajorVersion' {
+        BeforeAll {
+            $mockGetItem_SqlMajorVersion = {
+                return New-Object -TypeName Object |
+                            Add-Member -MemberType ScriptProperty -Name VersionInfo -Value {
+                                return New-Object -TypeName Object |
+                                            Add-Member -MemberType NoteProperty -Name 'ProductVersion' -Value '10.0.0000.00000' -PassThru -Force
+                            } -PassThru -Force
+            }
+
+            Mock -CommandName Get-Item -MockWith $mockGetItem_SqlMajorVersion
+        }
+
+        It 'Should return correct version' {
+            $result = Get-FilePathMajorVersion -Path 'C:\AnyPath\Setup.exe'
+
+            $result | Should -Be '10'
+        }
+    }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc
  - Document changes in the file `build.yml`.
- SqlSetup
  - Duplicate function Get-SqlMajorVersion was removed and instead the
    helper function Get-FilePathMajorVersion from the helper module
    SqlServerDsc.Common is used (issue #1178).
- SqlWindowsFirewall
  - Duplicate function Get-SqlMajorVersion was removed and instead the
    helper function Get-FilePathMajorVersio` from the helper module
    SqlServerDsc.Common is used (issue #1178).
- SqlServerDsc.Common
  - Function Get-FilePathMajorVersion was added. The function Get-SqlMajorVersion
    from the resources SqlSetup and SqlWindowsFirewall was moved and
    renamed without any functional changes (issue #1178).

#### This Pull Request (PR) fixes the following issues

- Fixes #1178


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1608)
<!-- Reviewable:end -->
