### PR TITLE
SqlSetup: Update comment-based help in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- SqlDatabaseObjectPermission
-  - New integration tests to verify scenarios when passing a single permission.
-
 ### Changed
 
 - SqlServerDsc
-  - Minor document changes in the file `build.yml`.
+  - Document changes in the file `build.yml`.
+  - The regular expression for `major-version-bump-message` in the file
+    `GitVersion.yml` was changed to only raise major version when the
+    commit message contain the phrase `breaking change`, or when it contain
+    the word `breaking` or `major`.
 - SqlSetup
   - Duplicate function Get-SqlMajorVersion was removed and instead the
     helper function `Get-FilePathMajorVersion` from the helper module
@@ -35,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     _DscResource.Common_.
 - SqlDatabaseObjectPermission
   - Fixed method invocation failed because of missing `Where()` method ([issue #1600](https://github.com/PowerShell/SqlServerDsc/issues/1600)).
+    - Added new integration tests to verify scenarios when passing a single permission.
+- SqlSetup
+  - The example `4-InstallNamedInstanceInFailoverClusterFirstNode.ps1` was
+    updated to no longer reference the issue #405 and issue #444 in the
+    comment-based help. The issues was fixed a while back and _SqlSetup_
+    now supports the built-in parameter `PsDscRunAsCredential` ([issue #975](https://github.com/PowerShell/SqlServerDsc/issues/975)).
 
 ## [14.2.0] - 2020-07-23
 

--- a/source/Examples/Resources/SqlSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
+++ b/source/Examples/Resources/SqlSetup/4-InstallNamedInstanceInFailoverClusterFirstNode.ps1
@@ -22,9 +22,6 @@
         The media will be copied locally, using impersonation with the credentials provided in SourceCredential, so
         that the impersonated credentials in SetupCredential can access the media locally.
 
-        Setup cannot be run using PsDscRunAsCredential at this time (see issue #405 and issue #444). That
-        also means that at this time PsDscRunAsCredential can not be used to access media on the UNC share.
-
         There is currently a bug that prevents the resource to logon to the instance if the current node is not the
         active node. This is because the resource tries to logon using the SYSTEM account instead of the credentials
         in SetupCredential, and the resource does not currently support the built-in PsDscRunAsCredential either (see


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlSetup
  - The example `4-InstallNamedInstanceInFailoverClusterFirstNode.ps1` was
    updated to no longer reference the issue #405 and issue #444 in the
    comment-based help. The issues was fixed a while back and _SqlSetup_
    now supports the built-in parameter `PsDscRunAsCredential` (issue #975).

#### This Pull Request (PR) fixes the following issues

- Fixes #975

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [x] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1609)
<!-- Reviewable:end -->
