### PR TITLE
SqlSetup: Updated documentation for BrowserSvcStartupType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - SqlRole
-  - Major overhaul of resource
-  - BREAKING CHANGE: Removed decision making from get-TargetResource; this prevented a simple solution for
-    issue #550. it now just tels if a role exists or not. And what members are in that 
-    role. MembersToInclude and MembersToExclude now always return $null
-  - Added sanitize function (Get-CorrectedMemberParameters) to make it so for the
-    sysadmin role SA does not get altered. ([issue #550](https://github.com/dsccommunity/SqlServerDsc/issues/550))
-  - added lots of tests.
+  - Major overhaul of resource.
+  - BREAKING CHANGE: Removed decision making from get-TargetResource; this
+    prevented a simple solution for issue #550. it now just tels if a role
+    exists or not. And what members are in that role. MembersToInclude and
+    MembersToExclude now always return $null.
+  - Added sanitize function (`Get-CorrectedMemberParameters`) to make it
+    so for the sysadmin role SA does not get altered ([issue #550](https://github.com/dsccommunity/SqlServerDsc/issues/550)).
+  - Added lots of tests.
+- SqlSetup
+  - Added a note to the documentation that the parameter `BrowserSvcStartupType`
+    cannot be used for configurations that utilize the `'InstallFailoverCluster'`
+    action ([issue #1627](https://github.com/dsccommunity/SqlServerDsc/issues/1627)).
+  - Minor change to the evaluation of the parameter `BrowserSvcStartupType`,
+    if it has an assigned a value or not.
 
 ### Added
 

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -1033,7 +1033,7 @@ function Set-TargetResource
 
     $setupArguments = @{}
 
-    if ($PSBoundParameters.ContainsKey('SkipRule') )
+    if ($PSBoundParameters.ContainsKey('SkipRule'))
     {
         $setupArguments['SkipRules'] = @($SkipRule)
     }
@@ -1237,7 +1237,7 @@ function Set-TargetResource
         )
     }
 
-    if ($null -ne $BrowserSvcStartupType)
+    if ($PSBoundParameters.ContainsKey('BrowserSvcStartupType'))
     {
         $argumentVars += 'BrowserSvcStartupType'
     }

--- a/source/DSCResources/DSC_SqlSetup/README.md
+++ b/source/DSCResources/DSC_SqlSetup/README.md
@@ -5,30 +5,33 @@ The `SqlSetup` DSC resource installs SQL Server on the target node.
 ## Requirements
 
 - Target machine must be running Windows Server 2012 or later.
-- For configurations that utilize the 'InstallFailoverCluster' action, the following
+- For configurations that utilize the `'InstallFailoverCluster'` action, the following
   parameters are required (beyond those required for the standalone installation).
-  See the article [Install SQL Server from the Command Prompt](https://msdn.microsoft.com/en-us/library/ms144259.aspx)
-  under the section [Failover Cluster Parameters](https://msdn.microsoft.com/en-us/library/ms144259.aspx#Anchor_8)
+  See the article [Install SQL Server from the Command Prompt](https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt)
+  under the section [Failover Cluster Parameters](https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt#ClusterInstall)
   for more information.
-  - InstanceName (can be MSSQLSERVER if you want to install a default clustered
-    instance).
-  - FailoverClusterNetworkName
-  - FailoverClusterIPAddress
+  - `InstanceName` (can be `'MSSQLSERVER'` if you want to install a default
+    clustered instance).
+  - `FailoverClusterNetworkName`
+  - `FailoverClusterIPAddress`
   - Additional parameters needed when installing Database Engine.
-    - InstallSQLDataDir
-    - AgtSvcAccount
-    - SQLSvcAccount
-    - SQLSysAdminAccounts
+    - `InstallSQLDataDir`
+    - `AgtSvcAccount`
+    - `SQLSvcAccount`
+    - `SQLSysAdminAccounts`
   - Additional parameters needed when installing Analysis Services.
-    - ASSysAdminAccounts
-    - AsSvcAccount
+    - `ASSysAdminAccounts`
+    - `AsSvcAccount`
+- These parameters cannot be used for configurations that utilize the
+  `'InstallFailoverCluster'` action:
+  - `BrowserSvcStartupType`
 - The parameters below can only be used when installing SQL Server 2016 or
   later:
-  - SqlTempdbFileCount
-  - SqlTempdbFileSize
-  - SqlTempdbFileGrowth
-  - SqlTempdbLogFileSize
-  - SqlTempdbLogFileGrowth
+  - `SqlTempDbFileCount`
+  - `SqlTempDbFileSize`
+  - `SqlTempDbFileGrowth`
+  - `SqlTempDbLogFileSize`
+  - `SqlTempDbLogFileGrowth`
 - When installing _SQL Server Analysis Services_ the account used to start
   the service must have the correct permissions in directory tree for the
   data folders. If not the service can fail with an access denied error.

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -2145,6 +2145,7 @@ try
                                 SqlTempDbFileGrowth = 128
                                 SqlTempDbLogFileSize = 128
                                 SqlTempDbLogFileGrowth = 128
+                                BrowserSvcStartupType = 'Automatic'
                             }
 
                             if ( $mockSqlMajorVersion -in (13,14) )
@@ -2179,6 +2180,7 @@ try
                                 SqlTempDbFileGrowth = 128
                                 SqlTempDbLogFileSize = 128
                                 SqlTempDbLogFileGrowth = 128
+                                BrowserSvcStartupType = 'Automatic'
                             }
 
                             { Set-TargetResource @testParameters } | Should -Not -Throw


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlSetup
  - Added a note to the documentation that the parameter `BrowserSvcStartupType`
    cannot be used for configurations that utilize the `'InstallFailoverCluster'`
    action (issue #1627).
  - Minor change to the evaluation of the parameter `BrowserSvcStartupType`,
    if it has an assigned a value or not.

#### This Pull Request (PR) fixes the following issues

- Fixes #1627

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1635)
<!-- Reviewable:end -->
