### PR TITLE
SqlServerDsc.Common\Get-ServerProtocolObject: Updated to throw error/exception if no 'ServerInstances' returned (Fixes #1628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes ([issue #396](https://github.com/dsccommunity/SqlServerDsc/issues/396)).
     Added three return values in Get-Target resource.
 - SqlProtocol
-  - Changed KeepAlive Type from UInt16 to Int32 to reflect te actual WMI.ManagementObject
+  - Changed KeepAlive Type from UInt16 to Int32 to reflect the actual WMI.ManagementObject
     Fixes #1645 ([issue #1645](https://github.com/dsccommunity/SqlServerDsc/issues/1645)).
+- SqlServerDsc.Common
+  - Updated `Get-ServerProtocolObject`, helper function to ensure an exception is
+    thrown if the specified instance cannot be obtained ([issue #1628](https://github.com/dsccommunity/SqlServerDsc/issues/1628)).
 
 ## [15.0.0] - 2020-12-06
 

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -2333,6 +2333,11 @@ function Get-ServerProtocolObject
 
         $serverProtocolProperties = $serverInstance.ServerProtocols[$protocolNameProperties.Name]
     }
+    else
+    {
+        $errorMessage = $script:localizedData.FailedToObtainServerInstance -f $InstanceName
+        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+    }
 
     return $serverProtocolProperties
 }

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -2336,7 +2336,7 @@ function Get-ServerProtocolObject
     else
     {
         $errorMessage = $script:localizedData.FailedToObtainServerInstance -f $InstanceName, $ServerName
-        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+        New-InvalidOperationException -Message $errorMessage
     }
 
     return $serverProtocolProperties

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -2335,7 +2335,7 @@ function Get-ServerProtocolObject
     }
     else
     {
-        $errorMessage = $script:localizedData.FailedToObtainServerInstance -f $InstanceName
+        $errorMessage = $script:localizedData.FailedToObtainServerInstance -f $InstanceName, $ServerName
         New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
     }
 

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -55,5 +55,5 @@ ConvertFrom-StringData @'
     NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0067)
     LoadedAssembly = Loaded the assembly '{0}'. (SQLCOMMON0068)
     FailedToLoadAssembly = Failed to load the assembly '{0}'. (SQLCOMMON0069)
-    FailedToObtainServerInstance = Failed to obtain a 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer' object for instance/name '{0}'. Ensure the instance exists on the server and that the 'SQLServer' module references a version of the 'Microsoft.SqlServer.Management.Smo.Wmi' library supports the version of SQL Server. (SQLCOMMON0070)
+    FailedToObtainServerInstance = Failed to obtain a SQL Server instance with name '{0}' on server '{1}'. Ensure the SQL Server instance exists on the server and that the 'SQLServer' module references a version of the 'Microsoft.SqlServer.Management.Smo.Wmi' library that supports the version of the SQL Server instance. (SQLCOMMON0070)
 '@

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -55,4 +55,5 @@ ConvertFrom-StringData @'
     NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0067)
     LoadedAssembly = Loaded the assembly '{0}'. (SQLCOMMON0068)
     FailedToLoadAssembly = Failed to load the assembly '{0}'. (SQLCOMMON0069)
+    FailedToObtainServerInstance = Failed to obtain a 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer' object for instance/name '{0}'. Ensure the instance exists on the server and that the 'SQLServer' module references a version of the 'Microsoft.SqlServer.Management.Smo.Wmi' library supports the version of SQL Server. (SQLCOMMON0070)
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -61,4 +61,5 @@ ConvertFrom-StringData @'
     NotOwnerOfClusterResource = The node '{0}' is not the owner of the cluster resource '{1}'. The owner is '{2}' so no restart is needed. (SQLCOMMON0067)
     LoadedAssembly = Loaded the assembly '{0}'. (SQLCOMMON0068)
     FailedToLoadAssembly = Failed to load the assembly '{0}'. (SQLCOMMON0069)
+    FailedToObtainServerInstance = Failed to obtain a SQL Server instance with name '{0}' on server '{1}'. Ensure the SQL Server instance exists on the server and that the 'SQLServer' module references a version of the 'Microsoft.SqlServer.Management.Smo.Wmi' library that supports the version of the SQL Server instance. (SQLCOMMON0070)
 '@

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -3431,6 +3431,35 @@ InModuleScope $script:subModuleName {
             $result.ProtocolProperties.ListenOnAllIPs | Should -BeTrue
             $result.ProtocolProperties.KeepAlive | Should -Be 30000
         }
+
+        Context "When ManagedComputer object has an empty array, 'ServerInstances' value" {
+            BeforeAll {
+                $mockServerName = 'TestServerName'
+                $mockInstanceName = 'TestInstance'
+
+                Mock -CommandName New-Object -MockWith {
+                    return @{
+                        ServerInstances = @()
+                    }
+                }
+            }
+
+            It 'Should throw the correct error message' {
+                $mockGetServerProtocolObjectParameters = @{
+                    ServerName   = $mockServerName
+                    Instance     = $mockInstanceName
+                    ProtocolName = 'TcpIp'
+                }
+
+                $mockErrorRecord = Get-InvalidOperationRecord -Message (
+                    $script:localizedData.FailedToObtainServerInstance -f $mockInstanceName, $mockServerName
+                )
+
+                $mockErrorRecord.Exception.Message | Should -Not -BeNullOrEmpty
+
+                { Get-ServerProtocolObject @mockGetServerProtocolObjectParameters } | Should -Throw -ExpectedMessage $mockErrorRecord.Exception.Message
+            }
+        }
     }
 
     Describe 'SqlServerDsc.Common\ConvertTo-ServerInstanceName' {


### PR DESCRIPTION
#### Pull Request (PR) description

Updated `Get-ServerProtocolObject`, helper function in `SqlServerDsc.Common`, helper module to ensure that if there are no instances returned in the `ServerInstances` property's array, an error/exception is thrown (to fix issue #1628).


#### This Pull Request (PR) fixes the following issues

Fixes #1628


#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1651)
<!-- Reviewable:end -->
