### PR TITLE
SqlProtocol/SqlProtocolTcpIp: Fix verbose messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlAGDatabase
   - Fix for issue ([issue #1492](https://github.com/dsccommunity/SqlServerDsc/issues/1492))
     added AutomaticSeeding for this resource. In Set-TargetResource added logic that looks
-    at all replicas of an availability group. When automatic seedig is found, it will use that.
+    at all replicas of an availability group. When automatic seeding is found, it will use that.
   - Lots of extra tests to check AutomaticSeeding.
   - The parameter `BackupPath` is still needed just in case a database never has been backuped before.
 - SqlMaxDop
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlProtocol
   - Changed KeepAlive Type from UInt16 to Int32 to reflect the actual WMI.ManagementObject
     Fixes #1645 ([issue #1645](https://github.com/dsccommunity/SqlServerDsc/issues/1645)).
+  - The verbose messages now correctly show that `$env:COMPUTERNAME` is used
+    to get or set the configuration, while parameter **ServerName** is used
+    to restart the instance.
+- SqlProtocolTcpIp
+  - The verbose messages now correctly show that `$env:COMPUTERNAME` is used
+    to get or set the configuration, while parameter **ServerName** is used
+    to restart the instance.
 - SqlServerDsc.Common
   - Updated `Get-ServerProtocolObject`, helper function to ensure an exception is
     thrown if the specified instance cannot be obtained ([issue #1628](https://github.com/dsccommunity/SqlServerDsc/issues/1628)).

--- a/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
+++ b/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
@@ -82,8 +82,11 @@ function Get-TargetResource
 
     $protocolNameProperties = Get-ProtocolNameProperties -ProtocolName $ProtocolName
 
+    # Getting the server protocol properties by using the computer name.
+    $computerName = Get-ComputerName
+
     Write-Verbose -Message (
-        $script:localizedData.GetCurrentState -f $protocolNameProperties.DisplayName, $InstanceName, $ServerName
+        $script:localizedData.GetCurrentState -f $protocolNameProperties.DisplayName, $InstanceName, $computerName
     )
 
     Import-SQLPSModule
@@ -93,7 +96,7 @@ function Get-TargetResource
         to a cluster instance or availability group listener.
     #>
     $getServerProtocolObjectParameters = @{
-        ServerName   = Get-ComputerName
+        ServerName   = $computerName
         Instance     = $InstanceName
         ProtocolName = $ProtocolName
     }
@@ -239,8 +242,11 @@ function Set-TargetResource
 
     if ($propertiesNotInDesiredState.Count -gt 0)
     {
+        # Getting the server protocol properties by using the computer name.
+        $computerName = Get-ComputerName
+
         Write-Verbose -Message (
-            $script:localizedData.SetDesiredState -f $protocolNameProperties.DisplayName, $InstanceName
+            $script:localizedData.SetDesiredState -f $protocolNameProperties.DisplayName, $InstanceName, $computerName
         )
 
         <#
@@ -248,7 +254,7 @@ function Set-TargetResource
             to a cluster instance or availability group listener.
         #>
         $getServerProtocolObjectParameters = @{
-            ServerName   = Get-ComputerName
+            ServerName   = $computerName
             Instance     = $InstanceName
             ProtocolName = $ProtocolName
         }
@@ -339,6 +345,10 @@ function Set-TargetResource
 
         if (-not $SuppressRestart -and $isRestartNeeded)
         {
+            <#
+                This is using the $ServerName to be able to restart a cluster
+                instance or availability group listener.
+            #>
             $restartSqlServiceParameters = @{
                 ServerName   = $ServerName
                 InstanceName = $InstanceName

--- a/source/DSCResources/DSC_SqlProtocol/en-US/DSC_SqlProtocol.strings.psd1
+++ b/source/DSCResources/DSC_SqlProtocol/en-US/DSC_SqlProtocol.strings.psd1
@@ -1,6 +1,6 @@
 ConvertFrom-StringData @'
     GetCurrentState = Getting the current state of the protocol '{0}' for the instance '{1}' on the server '{2}'. (SSP0001)
-    SetDesiredState = Setting the desired state for the protocol '{0}' on the instance '{1}'. (SSP0002)
+    SetDesiredState = Setting the desired state for the protocol '{0}' on the instance '{1}' on the server '{2}'. (SSP0002)
     ProtocolIsInDesiredState = The protocol '{0}' on the instance '{1}' is already in desired state. (SSP0002)
     ProtocolHasBeenEnabled = The protocol '{0}' has been enabled on the SQL Server instance '{1}'. (SSP0003)
     ProtocolHasBeenDisabled = The protocol '{0}' has been disabled on the SQL Server instance '{1}'. (SSP0004)

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
@@ -90,8 +90,11 @@ function Get-TargetResource
         TcpDynamicPort    = $null
     }
 
+    # Getting the server protocol properties by using the computer name.
+    $computerName = Get-ComputerName
+
     Write-Verbose -Message (
-        $script:localizedData.GetCurrentState -f $IpAddressGroup, $InstanceName, $ServerName
+        $script:localizedData.GetCurrentState -f $IpAddressGroup, $InstanceName, $computerName
     )
 
     Import-SQLPSModule
@@ -101,7 +104,7 @@ function Get-TargetResource
         to a cluster instance or availability group listener.
     #>
     $getServerProtocolObjectParameters = @{
-        ServerName   = Get-ComputerName
+        ServerName   = $computerName
         Instance     = $InstanceName
         ProtocolName = 'TcpIp'
     }
@@ -281,8 +284,11 @@ function Set-TargetResource
 
     if ($propertiesNotInDesiredState.Count -gt 0)
     {
+        # Getting the server protocol properties by using the computer name.
+        $computerName = Get-ComputerName
+
         Write-Verbose -Message (
-            $script:localizedData.SetDesiredState -f $IpAddressGroup, $InstanceName
+            $script:localizedData.SetDesiredState -f $IpAddressGroup, $InstanceName, $computerName
         )
 
         <#
@@ -290,7 +296,7 @@ function Set-TargetResource
             to a cluster instance or availability group listener.
         #>
         $getServerProtocolObjectParameters = @{
-            ServerName   = Get-ComputerName
+            ServerName   = $computerName
             Instance     = $InstanceName
             ProtocolName = 'TcpIp'
         }
@@ -409,6 +415,10 @@ function Set-TargetResource
 
         if (-not $SuppressRestart -and $isRestartNeeded)
         {
+            <#
+                This is using the $ServerName to be able to restart a cluster
+                instance or availability group listener.
+            #>
             $restartSqlServiceParameters = @{
                 ServerName   = $ServerName
                 InstanceName = $InstanceName

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/en-US/DSC_SqlProtocolTcpIp.strings.psd1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/en-US/DSC_SqlProtocolTcpIp.strings.psd1
@@ -4,7 +4,7 @@ ConvertFrom-StringData @'
     TestDesiredState = Determining the current state of the TCP/IP address group '{0}' for the instance '{1}' on the server '{2}'. (SSPTI0003)
     NotInDesiredState = The TCP/IP address group '{0}' for the instance '{1}' is not in desired state. (SSPTI0004)
     InDesiredState = The TCP/IP address group '{0}' for the instance '{1}' is in desired state. (SSPTI0005)
-    SetDesiredState = Setting the desired state for the TCP/IP address group '{0}' for the instance '{1}'. (SSPTI0006)
+    SetDesiredState = Setting the desired state for the TCP/IP address group '{0}' for the instance '{1}' on the server '{2}'. (SSPTI0006)
     SetMissingIpAddressGroup = The specified IP address group '{0}' does not not exist. (SSPTI0007)
     TcpPortHasBeenSet = The TCP port(s) '{0}' has been set on the TCP/IP address group '{1}'. (SSPTI0008)
     TcpDynamicPortHasBeenSet = Dynamic TCP port has been enabled on the TCP/IP address group '{0}'. (SSPTI0009)


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlProtocol
  - The verbose messages now correctly show that `$env:COMPUTERNAME` is used
    to get or set the configuration, while parameter **ServerName** is used
    to restart the instance.
- SqlProtocolTcpIp
  - The verbose messages now correctly show that `$env:COMPUTERNAME` is used
    to get or set the configuration, while parameter **ServerName** is used
    to restart the instance.

There are already unit and integration tests that covers this change.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1658)
<!-- Reviewable:end -->
