### PR TITLE
SqlDatabaseMail: Do not enforce parameters not part of configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The verbose messages now correctly show that `$env:COMPUTERNAME` is used
     to get or set the configuration, while parameter **ServerName** is used
     to restart the instance.
+- SqlDatabaseMail
+  - Now if a non-mandatory property is not part of the configuration it will
+    not be enforced ([issue #1661](https://github.com/dsccommunity/SqlServerDsc/issues/1661)).
 - SqlServerDsc.Common
   - Updated `Get-ServerProtocolObject`, helper function to ensure an exception is
     thrown if the specified instance cannot be obtained ([issue #1628](https://github.com/dsccommunity/SqlServerDsc/issues/1628)).

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
@@ -385,7 +385,7 @@ function Set-TargetResource
                     )
 
                     $currentDisplayName = $databaseMailAccount.DisplayName
-                    if ($currentDisplayName -ne $DisplayName)
+                    if ($PSBoundParameters.ContainsKey('DisplayName') -and $currentDisplayName -ne $DisplayName)
                     {
                         Write-Verbose -Message (
                             $script:localizedData.UpdatingPropertyOfMailServer -f @(
@@ -400,7 +400,7 @@ function Set-TargetResource
                     }
 
                     $currentDescription = $databaseMailAccount.Description
-                    if ($currentDescription -ne $Description)
+                    if ($PSBoundParameters.ContainsKey('Description') -and $currentDescription -ne $Description)
                     {
                         Write-Verbose -Message (
                             $script:localizedData.UpdatingPropertyOfMailServer -f @(
@@ -415,7 +415,7 @@ function Set-TargetResource
                     }
 
                     $currentEmailAddress = $databaseMailAccount.EmailAddress
-                    if ($currentEmailAddress -ne $EmailAddress)
+                    if ($PSBoundParameters.ContainsKey('EmailAddress') -and $currentEmailAddress -ne $EmailAddress)
                     {
                         Write-Verbose -Message (
                             $script:localizedData.UpdatingPropertyOfMailServer -f @(
@@ -430,7 +430,7 @@ function Set-TargetResource
                     }
 
                     $currentReplyToAddress = $databaseMailAccount.ReplyToAddress
-                    if ($currentReplyToAddress -ne $ReplyToAddress)
+                    if ($PSBoundParameters.ContainsKey('ReplyToAddress') -and $currentReplyToAddress -ne $ReplyToAddress)
                     {
                         Write-Verbose -Message (
                             $script:localizedData.UpdatingPropertyOfMailServer -f @(
@@ -447,7 +447,7 @@ function Set-TargetResource
                     $mailServer = $databaseMailAccount.MailServers | Select-Object -First 1
 
                     $currentMailServerName = $mailServer.Name
-                    if ($currentMailServerName -ne $MailServerName)
+                    if ($PSBoundParameters.ContainsKey('MailServerName') -and $currentMailServerName -ne $MailServerName)
                     {
                         Write-Verbose -Message (
                             $script:localizedData.UpdatingPropertyOfMailServer -f @(
@@ -462,7 +462,7 @@ function Set-TargetResource
                     }
 
                     $currentTcpPort = $mailServer.Port
-                    if ($currentTcpPort -ne $TcpPort)
+                    if ($PSBoundParameters.ContainsKey('TcpPort') -and $currentTcpPort -ne $TcpPort)
                     {
                         Write-Verbose -Message (
                             $script:localizedData.UpdatingPropertyOfMailServer -f @(


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlDatabaseMail
  - Now if a non-mandatory property is not part of the configuration it will
    not be enforced (issue #1661).

The unit tests covers this change. The unit test that is converted for Pester 5 will make the tests more obvious.

#### This Pull Request (PR) fixes the following issues

- Fixes #1661

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1662)
<!-- Reviewable:end -->
