### PR TITLE
SqlSetup: Fix error message how to find setup logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlDatabaseMail
   - Now if a non-mandatory property is not part of the configuration it will
     not be enforced ([issue #1661](https://github.com/dsccommunity/SqlServerDsc/issues/1661)).
+- SqlSetup
+  - When the SqlSetup detects that the expected components was not installed
+    and consequently throws an exception, that exception message now presents
+    a link to an article on how to find the SQL Server setup logs ([issue #1420](https://github.com/dsccommunity/SqlServerDsc/issues/1420)).
 - SqlServerDsc.Common
   - Updated `Get-ServerProtocolObject`, helper function to ensure an exception is
     thrown if the specified instance cannot be obtained ([issue #1628](https://github.com/dsccommunity/SqlServerDsc/issues/1628)).

--- a/source/DSCResources/DSC_SqlSetup/en-US/DSC_SqlSetup.strings.psd1
+++ b/source/DSCResources/DSC_SqlSetup/en-US/DSC_SqlSetup.strings.psd1
@@ -52,7 +52,7 @@ ConvertFrom-StringData @'
     SetupFailed = Please see the 'Summary.txt' log file in the 'Setup Bootstrap\\Log' folder.
     Reboot = Rebooting target node.
     SuppressReboot = Suppressing reboot of target node.
-    TestFailedAfterSet = Test-TargetResource function returned false when Set-TargetResource function verified the desired state. This indicates that the Set-TargetResource did not correctly set the desired state, or that the function Test-TargetResource does not correctly evaluate the desired state.
+    TestFailedAfterSet = Test-TargetResource function returned false when Set-TargetResource function verified the desired state. This indicates that the Set-TargetResource did not correctly set the desired state, or that the function Test-TargetResource does not correctly evaluate the desired state. Please look for reported errors from the setup.exe in the SQL Server setup logs, see more information on how to do that in the article https://docs.microsoft.com/en-us/sql/database-engine/install-windows/view-and-read-sql-server-setup-log-files (View and Read SQL Server Setup Log Files).
     FeaturesFound = Found features already installed: {0}
     NoFeaturesFound = No features are installed.
     UnableToFindFeature = Unable to find feature '{0}' among the installed features: '{1}'.

--- a/source/DSCResources/DSC_SqlSetup/sv-SE/DSC_SqlSetup.strings.psd1
+++ b/source/DSCResources/DSC_SqlSetup/sv-SE/DSC_SqlSetup.strings.psd1
@@ -52,7 +52,7 @@ ConvertFrom-StringData @'
     SetupFailed = Vänligen titta i loggfilen 'Summary.txt' i sökvägen 'Setup Bootstrap\\Log'.
     Reboot = Startar om målnod.
     SuppressReboot = Förhindrar omstart av målnod.
-    TestFailedAfterSet = Funktionen Test-TargetResource returnerade falskt när funktionen Set-TargetResource verifierade önskad konfiguration. Detta indikerar att funktionen Set-TargetResource inte på ett korrekt sätt kunde sätta önskad konfiguration, eller att funktionen Test-TargetResource inte utvärderar önskad konfiguration på korrekt sätt.
+    TestFailedAfterSet = Funktionen Test-TargetResource returnerade falskt när funktionen Set-TargetResource verifierade önskad konfiguration. Detta indikerar att funktionen Set-TargetResource inte på ett korrekt sätt kunde sätta önskad konfiguration, eller att funktionen Test-TargetResource inte utvärderar önskad konfiguration på korrekt sätt. Vänligen titta efter rapporterade fel från setup.exe i SQL Server installationsloggarna, för information hur man gör det se artikeln https://docs.microsoft.com/en-us/sql/database-engine/install-windows/view-and-read-sql-server-setup-log-files (View and Read SQL Server Setup Log Files).
     FeaturesFound = Funktioner funna: {0}
     NoFeaturesFound = Inga funktioner är installerad.
     UnableToFindFeature = Kunde inte hitta funktion '{0}' bland som installerade funktionerna: '{1}'.


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlSetup
  - When the SqlSetup detects that the expected components was not installed
    and consequently throws an exception, that exception message now presents
    a link to an article on how to find the SQL Server setup logs (issue #1420).

#### This Pull Request (PR) fixes the following issues

- Fixes #1420

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1664)
<!-- Reviewable:end -->
