### PR TITLE
SqlRSSetup: Fix SuppressRestart to not be added when $false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `SqlLogin`, integration tests to make use of amended `Wait-ForIdleLcm`,
     helper function, `-Clear` switch usage to remove intermittent, integration
     test failures ([issue #1634](https://github.com/dsccommunity/SqlServerDsc/issues/1634)).
+- SqlRSSetup
+  - If parameter `SuppressRestart` is set to `$false` the `/norestart`
+    argument is no longer wrongly added ([issue #1401](https://github.com/dsccommunity/SqlServerDsc/issues/1401)).
 
 ## [15.0.1] - 2021-01-09
 

--- a/source/DSCResources/DSC_SqlRSSetup/DSC_SqlRSSetup.psm1
+++ b/source/DSCResources/DSC_SqlRSSetup/DSC_SqlRSSetup.psm1
@@ -397,8 +397,11 @@ function Set-TargetResource
 
         'SuppressRestart'
         {
-            $setupArguments += @{
-                'norestart' = [System.Management.Automation.SwitchParameter] $true
+            if ($SuppressRestart -eq $true)
+            {
+                $setupArguments += @{
+                    'norestart' = [System.Management.Automation.SwitchParameter] $true
+                }
             }
         }
 

--- a/tests/Unit/DSC_SqlRSSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlRSSetup.Tests.ps1
@@ -652,6 +652,33 @@ try
                     }
                 }
 
+                Context 'When Reporting Services are installed with parameter SuppressRestart set to $false' {
+                    BeforeEach {
+                        $mockSetTargetResourceParameters['ProductKey'] = $mockProductKey
+                        $mockSetTargetResourceParameters['SuppressRestart'] = $false
+
+                        $mockStartSqlSetupProcess_ExpectedArgumentList = @{
+                            Quiet = [System.Management.Automation.SwitchParameter] $true
+                            IAcceptLicenseTerms = [System.Management.Automation.SwitchParameter] $true
+                            PID = $mockProductKey
+                        }
+
+                        Mock -CommandName Start-SqlSetupProcess -MockWith {
+                            Test-SetupArgument -Argument $ArgumentList -ExpectedArgument $mockStartSqlSetupProcess_ExpectedArgumentList
+
+                            return 0
+                        }
+                    }
+
+                    It 'Should call the correct mock with the expected arguments' {
+                        { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
+
+                        Assert-MockCalled -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $FilePath -eq $mockSetTargetResourceParameters.SourcePath
+                        } -Exactly -Times 1 -Scope 'It'
+                    }
+                }
+
                 Context 'When Reporting Services are installed with parameters EditionUpgrade set to $false' {
                     BeforeEach {
                         $mockSetTargetResourceParameters['ProductKey'] = $mockProductKey
@@ -681,7 +708,7 @@ try
 
                 Context 'When Reporting Services are installed using parameter SourceCredential' {
                     BeforeAll {
-                        $mockLocalPath = 'C:\LocalPath'
+                        $mockLocalPath = Join-Path -Path $TestDrive - -ChildPath 'LocalPath'
 
                         $mockShareCredentialUserName = 'COMPANY\SqlAdmin'
                         $mockShareCredentialPassword = 'dummyPassW0rd'


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlRSSetup
  - If parameter `SuppressRestart` is set to `$false` the `/norestart`
    argument is no longer wrongly added (issue #1401).

#### This Pull Request (PR) fixes the following issues

- Fixes #1401


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1673)
<!-- Reviewable:end -->
