### PR TITLE
SqlServerDsc: Fix gitversion in pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SqlServerDsc
+  - The component `gitversion` that is used in the pipeline was wrongly
+    configured when the repository moved to the new default branch `main`.
+    It no longer throws an error when using newer versions of GitVersion
+    ([issue #1674](https://github.com/dsccommunity/SqlServerDsc/issues/1674),
 - SqlLogin
   - Added integration tests to assert `LoginPasswordExpirationEnabled`,
   `LoginPasswordPolicyEnforced` and `LoginMustChangePassword` properties/parameters

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -15,12 +15,12 @@ branches:
     tag: useBranchName
     increment: Minor
     regex: f(eature(s)?)?[\/-]
-    source-branches: ['main']
+    source-branches: ['master']
   hotfix:
     tag: fix
     increment: Patch
     regex: (hot)?fix(es)?[\/-]
-    source-branches: ['main']
+    source-branches: ['master']
 
 ignore:
   sha: []


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc
  - The component `gitversion` that is used in the pipeline was wrongly configured
    when the repository moved to the new default branch `main`. It no longer throws
    an error when using newer versions of GitVersion (issue #1674),

#### This Pull Request (PR) fixes the following issues

- Fixes #1674

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1675)
<!-- Reviewable:end -->
