### PR TITLE
SqlSetup: Connect-SQLAnalysis no longer using LoadWithPartialName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,28 +19,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - SqlSetup
-  - The helper function `Connect-SqlAnalysis` is using `LoadWithPartial()`
-    to load the assembly **`Microsoft.AnalysisServices`**. On a node where multiple
+  - The helper function `Connect-SqlAnalysis` was using `LoadWithPartial()`
+    to load the assembly _Microsoft.AnalysisServices_. On a node where multiple
     instances with different versions of SQL Server (regardless of features)
     is installed, this will result in the first assembly found in the
-    GAC will be loaded into the session, regardless of version. This can
-    result in an assembly being loaded that is not compatible with the
-    version of SQL Server it should be used to connect to.
-    A new method of loading the assembly **`Microsoft.AnalysisServices`** was
+    GAC will be loaded into the session, not taking versions into account.
+    This can result in an assembly version being loaded that is not compatible
+    with the version of SQL Server it was meant to be used with.
+    A new method of loading the assembly _Microsoft.AnalysisServices_ was
     introduced under a feature flag; `'AnalysisServicesConnection'`.
-    This new functionality depends on the SqlServer module, and must be
-    present on the node. The [SqlServer module](https://www.powershellgallery.com/packages/SqlServer)
-    can be installed on the node by leveraging the new DSC resources in the
-    [PowerShellGet (v2.1.2)](https://www.powershellgallery.com/packages/PowerShellGet/2.1.2)
-    module. This new method does not work with the SQLPS module due to
-    the SQLPS module does not load the correct assembly, while
-    [SqlServer module](https://www.powershellgallery.com/packages/SqlServer)
-    (v21.1.18080 and above) does.
-    The detection of a successful connection to the Sql Server Analysis
-    Services has also been changed. Now it actually evaluates the property
-    `Connected` of the returned `Microsoft.AnalysisServices.Server` object.
-    The new functionality is used when the parameter `FeatureFlag` is set
-    to `'AnalysisServicesConnection'`.
+    This new functionality depends on the [SqlServer](https://www.powershellgallery.com/packages/SqlServer)
+    module, and must be present on the node. The [SqlServer](https://www.powershellgallery.com/packages/SqlServer)
+    module can be installed on the node by leveraging the new DSC resource
+    `PSModule` in the [PowerShellGet](https://www.powershellgallery.com/packages/PowerShellGet/2.1.2)
+    module (v2.1.2 and higher). This new method does not work with the
+    SQLPS module due to the SQLPS module does not load the correct assembly,
+    while [SqlServer](https://www.powershellgallery.com/packages/SqlServer)
+    module (v21.1.18080 and above) does. The new functionality is used
+    when the parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
+    This functionality will be the default in a future breaking release.
+  - Under a feature flag; `'AnalysisServicesConnection'`. The detection of
+    a successful connection to the SQL Server Analysis Services has also been
+    changed. Now it actually evaluates the property `Connected` of the returned
+    `Microsoft.AnalysisServices.Server` object. The new functionality is used
+    when the parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
     This functionality will be the default in a future breaking release.
 
 ## [15.1.0] - 2021-02-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [15.1.1] - 2021-02-12
-
-### Fixed
-
-- SqlTraceFlag
-  - Fixed `$null` reference error when no actual trace flags are present.
-    Added two arrays to prevent a `$null` reference at compare-object
-    ([issue #1688](https://github.com/dsccommunity/SqlServerDsc/issues/1688)).
-- SqlServerDsc
-  - Removed a left-over comment in the file `analyzersettings.psd1`.
-
 ### Changed
 
 - SqlSetup
@@ -38,12 +27,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     module (v21.1.18080 and above) does. The new functionality is used
     when the parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
     This functionality will be the default in a future breaking release.
-  - Under a feature flag; `'AnalysisServicesConnection'`. The detection of
+  - Under a feature flag `'AnalysisServicesConnection'`. The detection of
     a successful connection to the SQL Server Analysis Services has also been
     changed. Now it actually evaluates the property `Connected` of the returned
     `Microsoft.AnalysisServices.Server` object. The new functionality is used
     when the parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
     This functionality will be the default in a future breaking release.
+
+## [15.1.1] - 2021-02-12
+
+### Fixed
+
+- SqlTraceFlag
+  - Fixed `$null` reference error when no actual trace flags are present.
+    Added two arrays to prevent a `$null` reference at compare-object
+    ([issue #1688](https://github.com/dsccommunity/SqlServerDsc/issues/1688)).
+- SqlServerDsc
+  - Removed a left-over comment in the file `analyzersettings.psd1`.
 
 ## [15.1.0] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ([issue #1688](https://github.com/dsccommunity/SqlServerDsc/issues/1688)).
 - SqlServerDsc
   - Removed a left-over comment in the file `analyzersettings.psd1`.
+- SqlSetup
+  - Now the correct assembly should load when using the helper function
+    Connect-SQLAnalysis. Previously is was using LoadWithPartialName() which
+    meant that it would load the first assembly in GAC, regardless of which
+    PowerShell module was used (SQLPS or SqlSever).
 
 ## [15.1.0] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ([issue #1688](https://github.com/dsccommunity/SqlServerDsc/issues/1688)).
 - SqlServerDsc
   - Removed a left-over comment in the file `analyzersettings.psd1`.
+
+### Changed
+
 - SqlSetup
-  - Now the correct assembly should load when using the helper function
-    Connect-SQLAnalysis. Previously is was using LoadWithPartialName() which
-    meant that it would load the first assembly in GAC, regardless of which
-    PowerShell module was used (SQLPS or SqlSever).
+  - The helper function `Connect-SqlAnalysis` is using `LoadWithPartial()`
+    to load the assembly **`Microsoft.AnalysisServices`**. On a node where multiple
+    instances with different versions of SQL Server (regardless of features)
+    is installed, this will result in the first assembly found in the
+    GAC will be loaded into the session, regardless of version. This can
+    result in an assembly being loaded that is not compatible with the
+    version of SQL Server it should be used to connect to.
+    A new method of loading the assembly **`Microsoft.AnalysisServices`** was
+    introduced under a feature flag; `'AnalysisServicesConnection'`.
+    This new functionality depends on the SqlServer module, and must be
+    present on the node. The [SqlServer module](https://www.powershellgallery.com/packages/SqlServer)
+    can be installed on the node by leveraging the new DSC resources in the
+    [PowerShellGet (v2.1.2)](https://www.powershellgallery.com/packages/PowerShellGet/2.1.2)
+    module. This new method does not work with the SQLPS module due to
+    the SQLPS module does not load the correct assembly, while
+    [SqlServer module](https://www.powershellgallery.com/packages/SqlServer)
+    (v21.1.18080 and above) does. The new functionality is used when the
+    parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
+    This functionality will be the default in a future breaking release.
 
 ## [15.1.0] - 2021-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     module. This new method does not work with the SQLPS module due to
     the SQLPS module does not load the correct assembly, while
     [SqlServer module](https://www.powershellgallery.com/packages/SqlServer)
-    (v21.1.18080 and above) does. The new functionality is used when the
-    parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
+    (v21.1.18080 and above) does.
+    The detection of a successful connection to the Sql Server Analysis
+    Services has also been changed. Now it actually evaluates the property
+    `Connected` of the returned `Microsoft.AnalysisServices.Server` object.
+    The new functionality is used when the parameter `FeatureFlag` is set
+    to `'AnalysisServicesConnection'`.
     This functionality will be the default in a future breaking release.
 
 ## [15.1.0] - 2021-02-02

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -29,5 +29,6 @@
     PSDscResources              = '2.12.0.0'
     StorageDsc                  = '4.9.0.0'
     NetworkingDsc               = '7.4.0.0'
+    PowerShellGet               = '2.1.2'
 }
 

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -339,12 +339,10 @@ function Get-TargetResource
 
         $serviceAnalysisService = Get-ServiceProperties -ServiceName $serviceNames.AnalysisService
 
-        $analysisServer = Connect-SQLAnalysis -SQLServer $sqlHostName -SQLInstanceName $InstanceName -FeatureFlag $FeatureFlag
-
         $getTargetResourceReturnValue.ASSvcAccountUsername = $serviceAnalysisService.UserName
         $getTargetResourceReturnValue.AsSvcStartupType = $serviceAnalysisService.StartupType
 
-        $analysisServer = Connect-SQLAnalysis -ServerName $sqlHostName -InstanceName $InstanceName
+        $analysisServer = Connect-SQLAnalysis -ServerName $sqlHostName -InstanceName $InstanceName -FeatureFlag $FeatureFlag
 
         $getTargetResourceReturnValue.ASCollation = $analysisServer.ServerProperties['CollationName'].Value
         $getTargetResourceReturnValue.ASDataDir = $analysisServer.ServerProperties['DataDir'].Value

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -2507,36 +2507,6 @@ function Get-InstalledSharedFeatures
 
 <#
     .SYNOPSIS
-        Test if the specific feature flag should be enabled.
-
-    .PARAMETER FeatureFlag
-        An array of feature flags that should be compared against.
-
-    .PARAMETER TestFlag
-        The feature flag that is being check if it should be enabled.
-#>
-function Test-FeatureFlag
-{
-    [CmdletBinding()]
-    [OutputType([System.Boolean])]
-    param
-    (
-        [Parameter()]
-        [System.String[]]
-        $FeatureFlag,
-
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $TestFlag
-    )
-
-    $flagEnabled = $FeatureFlag -and ($FeatureFlag -and $FeatureFlag.Contains($TestFlag))
-
-    return $flagEnabled
-}
-
-<#
-    .SYNOPSIS
         Get current properties for the feature SQLENGINE.
 
     .PARAMETER ServerName

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -339,6 +339,8 @@ function Get-TargetResource
 
         $serviceAnalysisService = Get-ServiceProperties -ServiceName $serviceNames.AnalysisService
 
+        $analysisServer = Connect-SQLAnalysis -SQLServer $sqlHostName -SQLInstanceName $InstanceName -FeatureFlag $FeatureFlag
+
         $getTargetResourceReturnValue.ASSvcAccountUsername = $serviceAnalysisService.UserName
         $getTargetResourceReturnValue.AsSvcStartupType = $serviceAnalysisService.StartupType
 

--- a/source/DSCResources/DSC_SqlSetup/README.md
+++ b/source/DSCResources/DSC_SqlSetup/README.md
@@ -145,9 +145,10 @@ more feature flags can be added to the parameter `FeatureFlag`, i.e.
 >from one release to another, including having breaking changes.
 
 <!-- markdownlint-disable MD013 -->
-Flag | Description
+Feature flag | Description
 --- | ---
-\- | -
+DetectionSharedFeatures | A new way of detecting if the shared features is installed or not. This was implemented because the previous implementation did not work fully with SQL Server 2017.
+AnalysisServicesConnection | A new method of loading the assembly *Microsoft.AnalysisServices*. Using this, no longer is the helper function `Connect-SqlAnalysis` using `LoadWithPartial()` to load the assembly **Microsoft.AnalysisServices**. This requires the [SqlServer module](https://www.powershellgallery.com/packages/SqlServer) to be present on the node.
 <!-- markdownlint-enable MD013 -->
 
 ## Known issues

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
@@ -55,6 +55,7 @@
         'Set-PSModulePath'
         'ConvertTo-ServerInstanceName'
         'Get-FilePathMajorVersion'
+        'Test-FeatureFlag'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -653,6 +653,7 @@ function Connect-SQLAnalysis
             Import-SQLPSModule
 
             $analysisServicesObject = New-Object -TypeName 'Microsoft.AnalysisServices.Server'
+
             if ($analysisServicesObject)
             {
                 $analysisServicesObject.Connect($analysisServicesDataSource)
@@ -661,6 +662,7 @@ function Connect-SQLAnalysis
             if ((-not $analysisServicesObject) -or ($analysisServicesObject -and $analysisServicesObject.Connected -eq $false))
             {
                 $errorMessage = $script:localizedData.FailedToConnectToAnalysisServicesInstance -f $analysisServiceInstance
+
                 New-InvalidOperationException -Message $errorMessage
             }
             else
@@ -670,9 +672,10 @@ function Connect-SQLAnalysis
         }
         else
         {
-            $null = [System.Reflection.Assembly]::LoadWithPartialName('Microsoft.AnalysisServices')
+            $null = Import-Assembly -Name 'Microsoft.AnalysisServices' -LoadWithPartialName
 
-            $analysisServicesObject = New-Object -TypeName Microsoft.AnalysisServices.Server
+            $analysisServicesObject = New-Object -TypeName 'Microsoft.AnalysisServices.Server'
+
             if ($analysisServicesObject)
             {
                 $analysisServicesObject.Connect($analysisServicesDataSource)
@@ -680,6 +683,7 @@ function Connect-SQLAnalysis
             else
             {
                 $errorMessage = $script:localizedData.FailedToConnectToAnalysisServicesInstance -f $analysisServiceInstance
+
                 New-InvalidOperationException -Message $errorMessage
             }
 

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -621,7 +621,7 @@ function Connect-SQLAnalysis
         $SetupCredential
     )
 
-    $null = Import-Assembly -Name 'Microsoft.AnalysisServices' -LoadWithPartialName
+    Import-SQLPSModule
 
     if ($InstanceName -eq 'MSSQLSERVER')
     {

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -2459,5 +2459,3 @@ function Test-FeatureFlag
 
     return $flagEnabled
 }
-
-$script:localizedData = Get-LocalizedData -ResourceName 'SqlServerDsc.Common' -ScriptRoot $PSScriptRoot

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -652,14 +652,17 @@ function Connect-SQLAnalysis
         {
             $analysisServicesObject.Connect($analysisServicesDataSource)
         }
-        else
+
+        if ((-not $analysisServicesObject) -or ($analysisServicesObject -and $analysisServicesObject.Connected -eq $false))
         {
             $errorMessage = $script:localizedData.FailedToConnectToAnalysisServicesInstance -f $analysisServiceInstance
 
             New-InvalidOperationException -Message $errorMessage
         }
-
-        Write-Verbose -Message ($script:localizedData.ConnectedToAnalysisServicesInstance -f $analysisServiceInstance) -Verbose
+        else
+        {
+            Write-Verbose -Message ($script:localizedData.ConnectedToAnalysisServicesInstance -f $analysisServiceInstance) -Verbose
+        }
     }
     catch
     {

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -14,7 +14,7 @@ ConvertFrom-StringData @'
     ConnectedToDatabaseEngineInstance = Connected to SQL instance '{0}'. (SQLCOMMON0018)
     FailedToConnectToDatabaseEngineInstance = Failed to connect to SQL instance '{0}'. (SQLCOMMON0019)
     ConnectedToAnalysisServicesInstance = Connected to Analysis Services instance '{0}'. (SQLCOMMON0020)
-    FailedToConnectToAnalysisServicesInstance = Failed to connected to Analysis Services instance '{0}'. (SQLCOMMON0021)
+    FailedToConnectToAnalysisServicesInstance = Failed to connect to Analysis Services instance '{0}'. (SQLCOMMON0021)
     SqlServerVersionIsInvalid = Could not get the SQL version for the instance '{0}'. (SQLCOMMON0022)
     PreferredModuleFound = Preferred module SqlServer found. (SQLCOMMON0023)
     PreferredModuleNotFound = Information: PowerShell module SqlServer not found, trying to use older SQLPS module. (SQLCOMMON0024)

--- a/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
@@ -98,7 +98,7 @@ try
 
         Write-Verbose -Message "Start downloading the SQL Server media at $(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')" -Verbose
 
-        if($script:mockSourceDownloadExeUrl)
+        if ($script:mockSourceDownloadExeUrl)
         {
             # Download the EXE used to download the ISO
             Invoke-WebRequest -Uri $script:mockSourceDownloadExeUrl -OutFile $ConfigurationData.AllNodes.DownloadExePath | Out-Null

--- a/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
@@ -755,38 +755,6 @@ try
             }
         }
 
-        # $configurationName = "$($script:dscResourceName)_UninstallSqlServerModule_Config"
-
-        # Context ('When using configuration {0}' -f $configurationName) {
-        #     It 'Should compile and apply the MOF without throwing' {
-        #         {
-        #             $configurationParameters = @{
-        #                 OutputPath        = $TestDrive
-        #                 # The variable $ConfigurationData was dot-sourced above.
-        #                 ConfigurationData = $ConfigurationData
-        #             }
-
-        #             & $configurationName @configurationParameters
-
-        #             $startDscConfigurationParameters = @{
-        #                 Path         = $TestDrive
-        #                 ComputerName = 'localhost'
-        #                 Wait         = $true
-        #                 Verbose      = $true
-        #                 Force        = $true
-        #                 ErrorAction  = 'Stop'
-        #             }
-
-        #             Start-DscConfiguration @startDscConfigurationParameters
-        #         } | Should -Not -Throw
-        #     }
-
-        #     # Make sure the SqlServer module is uninstalled for all the other tests.
-        #     It 'Should return $true when Test-DscConfiguration is run' {
-        #         Test-DscConfiguration -Verbose | Should -Be 'True'
-        #     }
-        # }
-
         $configurationName = "$($script:dscResourceName)_StartServicesInstance_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {

--- a/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
@@ -173,6 +173,39 @@ try
             }
         }
 
+
+        $configurationName = "$($script:dscResourceName)_InstallSqlServerModule_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            # Make sure the module was installed.
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
         $configurationName = "$($script:dscResourceName)_InstallDatabaseEngineNamedInstanceAsSystem_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
@@ -458,38 +491,6 @@ try
             }
         }
 
-        $configurationName = "$($script:dscResourceName)_InstallSqlServerModule_Config"
-
-        Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    $configurationParameters = @{
-                        OutputPath        = $TestDrive
-                        # The variable $ConfigurationData was dot-sourced above.
-                        ConfigurationData = $ConfigurationData
-                    }
-
-                    & $configurationName @configurationParameters
-
-                    $startDscConfigurationParameters = @{
-                        Path         = $TestDrive
-                        ComputerName = 'localhost'
-                        Wait         = $true
-                        Verbose      = $true
-                        Force        = $true
-                        ErrorAction  = 'Stop'
-                    }
-
-                    Start-DscConfiguration @startDscConfigurationParameters
-                } | Should -Not -Throw
-            }
-
-            # Make sure the module was installed.
-            It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be 'True'
-            }
-        }
-
         $configurationName = "$($script:dscResourceName)_InstallMultiDimensionalAnalysisServicesAsSystem_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
@@ -534,7 +535,7 @@ try
                     -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.Action                     | Should -BeNullOrEmpty
+                $resourceCurrentState.Action                     | Should -Be 'Install'
                 $resourceCurrentState.AgtSvcAccount              | Should -BeNullOrEmpty
                 $resourceCurrentState.AgtSvcAccountUsername      | Should -BeNullOrEmpty
                 $resourceCurrentState.ASServerMode               | Should -Be $ConfigurationData.AllNodes.AnalysisServicesMultiServerMode
@@ -754,37 +755,37 @@ try
             }
         }
 
-        $configurationName = "$($script:dscResourceName)_UninstallSqlServerModule_Config"
+        # $configurationName = "$($script:dscResourceName)_UninstallSqlServerModule_Config"
 
-        Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    $configurationParameters = @{
-                        OutputPath        = $TestDrive
-                        # The variable $ConfigurationData was dot-sourced above.
-                        ConfigurationData = $ConfigurationData
-                    }
+        # Context ('When using configuration {0}' -f $configurationName) {
+        #     It 'Should compile and apply the MOF without throwing' {
+        #         {
+        #             $configurationParameters = @{
+        #                 OutputPath        = $TestDrive
+        #                 # The variable $ConfigurationData was dot-sourced above.
+        #                 ConfigurationData = $ConfigurationData
+        #             }
 
-                    & $configurationName @configurationParameters
+        #             & $configurationName @configurationParameters
 
-                    $startDscConfigurationParameters = @{
-                        Path         = $TestDrive
-                        ComputerName = 'localhost'
-                        Wait         = $true
-                        Verbose      = $true
-                        Force        = $true
-                        ErrorAction  = 'Stop'
-                    }
+        #             $startDscConfigurationParameters = @{
+        #                 Path         = $TestDrive
+        #                 ComputerName = 'localhost'
+        #                 Wait         = $true
+        #                 Verbose      = $true
+        #                 Force        = $true
+        #                 ErrorAction  = 'Stop'
+        #             }
 
-                    Start-DscConfiguration @startDscConfigurationParameters
-                } | Should -Not -Throw
-            }
+        #             Start-DscConfiguration @startDscConfigurationParameters
+        #         } | Should -Not -Throw
+        #     }
 
-            # Make sure the SqlServer module is uninstalled for all the other tests.
-            It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be 'True'
-            }
-        }
+        #     # Make sure the SqlServer module is uninstalled for all the other tests.
+        #     It 'Should return $true when Test-DscConfiguration is run' {
+        #         Test-DscConfiguration -Verbose | Should -Be 'True'
+        #     }
+        # }
 
         $configurationName = "$($script:dscResourceName)_StartServicesInstance_Config"
 

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -271,6 +271,9 @@ Configuration DSC_SqlSetup_CreateDependencies_Config
         This module might already be installed on the build worker. This is needed
         to install SQL Server Analysis Services instances.
 
+        Thre SqlServer module is purposely not added to 'RequiredModule.psd1' so
+        that it does not conflict with the SqlServerStubs module that is used by
+        unit tests.
 #>
 Configuration DSC_SqlSetup_InstallSqlServerModule_Config
 {
@@ -281,6 +284,7 @@ Configuration DSC_SqlSetup_InstallSqlServerModule_Config
         PSModule 'InstallSqlServerModule'
         {
             Name               = 'SqlServer'
+            MinimumVersion     = '21.1.18235' # Analysis Services works at least with this version.
             InstallationPolicy = 'Trusted'
             AllowClobber       = $true
         }

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -278,7 +278,7 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
     {
         SqlSetup 'Integration_Test'
         {
-            FeatureFlag            = @('DetectionSharedFeatures')
+            FeatureFlag            = @()
 
             InstanceName           = $Node.DatabaseEngineNamedInstanceName
             Features               = $Node.DatabaseEngineNamedInstanceFeatures
@@ -333,7 +333,7 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
 #>
 Configuration DSC_SqlSetup_StopServicesInstance_Config
 {
-    Import-DscResource -ModuleName 'PSDscResources' -ModuleVersion '2.12.0.0'
+    Import-DscResource -ModuleName 'PSDscResources'
 
     node $AllNodes.NodeName
     {
@@ -371,7 +371,7 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineDefaultInstanceAsUser_Config
     {
         SqlSetup 'Integration_Test'
         {
-            FeatureFlag          = @('DetectionSharedFeatures')
+            FeatureFlag          = @()
 
             InstanceName         = $Node.DatabaseEngineDefaultInstanceName
             Features             = $Node.DatabaseEngineDefaultInstanceFeatures
@@ -452,7 +452,7 @@ Configuration MSFT_SqlSetup_InstallMultiDimensionalAnalysisServicesAsSystem_Conf
     {
         SqlSetup 'Integration_Test'
         {
-            FeatureFlag         = @('DetectionSharedFeatures','AnalysisServicesConnection')
+            FeatureFlag         = @('AnalysisServicesConnection')
 
             InstanceName        = $Node.AnalysisServicesMultiInstanceName
             Features            = $Node.AnalysisServicesMultiFeatures
@@ -506,7 +506,7 @@ Configuration DSC_SqlSetup_InstallTabularAnalysisServicesAsSystem_Config
     {
         SqlSetup 'Integration_Test'
         {
-            FeatureFlag         = @('DetectionSharedFeatures','AnalysisServicesConnection')
+            FeatureFlag         = @('AnalysisServicesConnection')
 
             InstanceName        = $Node.AnalysisServicesTabularInstanceName
             Features            = $Node.AnalysisServicesTabularFeatures

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -265,6 +265,30 @@ Configuration DSC_SqlSetup_CreateDependencies_Config
 
 <#
     .SYNOPSIS
+        Installing the latest SqlServer module from PowerShell Gallery.
+
+    .NOTES
+        This module might already be installed on the build worker. This is needed
+        to install SQL Server Analysis Services instances.
+
+#>
+Configuration DSC_SqlSetup_InstallSqlServerModule_Config
+{
+    Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
+
+    node $AllNodes.NodeName
+    {
+        PSModule 'InstallSqlServerModule'
+        {
+            Name               = 'SqlServer'
+            InstallationPolicy = 'Trusted'
+            AllowClobber       = $true
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
         Installs a named instance of Database Engine and Analysis Services.
 
     .NOTES
@@ -420,28 +444,6 @@ Configuration DSC_SqlSetup_StopSqlServerDefaultInstance_Config
 
 <#
     .SYNOPSIS
-        Installing the latest SqlServer module from PowerShell Gallery.
-
-    .NOTES
-        This is needed to install SQL Server Analysis Services instances.
-#>
-Configuration DSC_SqlSetup_InstallSqlServerModule_Config
-{
-    Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
-
-    node $AllNodes.NodeName
-    {
-        PSModule 'InstallSqlServerModule'
-        {
-            Name               = 'SqlServer'
-            InstallationPolicy = 'Trusted'
-            AllowClobber       = $true
-        }
-    }
-}
-
-<#
-    .SYNOPSIS
         Installs a named instance of Analysis Services in multi-dimensional mode.
 #>
 Configuration DSC_SqlSetup_InstallMultiDimensionalAnalysisServicesAsSystem_Config
@@ -552,21 +554,22 @@ Configuration DSC_SqlSetup_StopTabularAnalysisServices_Config
         Installing the latest SqlServer module from PowerShell Gallery.
 
     .NOTES
-        This is needed to install SQL Server Analysis Services instances.
+        Returns the error:
+        Expected no exception to be thrown, but an exception "Access to the path 'DataSec.PAL.Interfaces.dll' is denied." was thrown from D:\a\1\s\tests\Integration\DSC_SqlSetup.Integration.Tests.ps1:779 char:21
 #>
-Configuration DSC_SqlSetup_UninstallSqlServerModule_Config
-{
-    Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
+# Configuration DSC_SqlSetup_UninstallSqlServerModule_Config
+# {
+#     Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
 
-    node $AllNodes.NodeName
-    {
-        PSModule 'UninstallSqlServerModule'
-        {
-            Ensure = 'Absent'
-            Name   = 'SqlServer'
-        }
-    }
-}
+#     node $AllNodes.NodeName
+#     {
+#         PSModule 'UninstallSqlServerModule'
+#         {
+#             Ensure = 'Absent'
+#             Name   = 'SqlServer'
+#         }
+#     }
+# }
 
 <#
     .SYNOPSIS

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -356,12 +356,6 @@ Configuration DSC_SqlSetup_StopServicesInstance_Config
             Name   = ('MSSQL${0}' -f $Node.DatabaseEngineNamedInstanceName)
             State  = 'Stopped'
         }
-
-        Service ('StopMultiAnalysisServicesInstance{0}' -f $Node.DatabaseEngineNamedInstanceName)
-        {
-            Name  = ('MSOLAP${0}' -f $Node.DatabaseEngineNamedInstanceName)
-            State = 'Stopped'
-        }
     }
 }
 
@@ -440,6 +434,7 @@ Configuration MSFT_SqlSetup_InstallSqlServerModule_Config
         PSModule 'InstallSqlServerModule'
         {
             Name = 'SqlServer'
+            InstallationPolicy = 'Trusted'
         }
     }
 }

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -65,7 +65,7 @@ else
 
                 # Database Engine properties.
                 DatabaseEngineNamedInstanceName         = 'DSCSQLTEST'
-                DatabaseEngineNamedInstanceFeatures     = 'SQLENGINE,REPLICATION,AS,CONN,BC,SDK'
+                DatabaseEngineNamedInstanceFeatures     = 'SQLENGINE,REPLICATION,CONN,BC,SDK'
 
                 <#
                     Analysis Services Multi-dimensional properties.
@@ -425,7 +425,7 @@ Configuration DSC_SqlSetup_StopSqlServerDefaultInstance_Config
     .NOTES
         This is needed to install SQL Server Analysis Services instances.
 #>
-Configuration MSFT_SqlSetup_InstallSqlServerModule_Config
+Configuration DSC_SqlSetup_InstallSqlServerModule_Config
 {
     Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
 
@@ -444,7 +444,7 @@ Configuration MSFT_SqlSetup_InstallSqlServerModule_Config
     .SYNOPSIS
         Installs a named instance of Analysis Services in multi-dimensional mode.
 #>
-Configuration MSFT_SqlSetup_InstallMultiDimensionalAnalysisServicesAsSystem_Config
+Configuration DSC_SqlSetup_InstallMultiDimensionalAnalysisServicesAsSystem_Config
 {
     Import-DscResource -ModuleName 'SqlServerDsc'
 
@@ -479,7 +479,7 @@ Configuration MSFT_SqlSetup_InstallMultiDimensionalAnalysisServicesAsSystem_Conf
         Stopping the Analysis Services multi-dimensional named instance to save
         memory on the build worker.
 #>
-Configuration MSFT_SqlSetup_StopMultiDimensionalAnalysisServices_Config
+Configuration DSC_SqlSetup_StopMultiDimensionalAnalysisServices_Config
 {
     Import-DscResource -ModuleName 'PSDscResources' -ModuleVersion '2.12.0.0'
 
@@ -554,7 +554,7 @@ Configuration DSC_SqlSetup_StopTabularAnalysisServices_Config
     .NOTES
         This is needed to install SQL Server Analysis Services instances.
 #>
-Configuration MSFT_SqlSetup_UninstallSqlServerModule_Config
+Configuration DSC_SqlSetup_UninstallSqlServerModule_Config
 {
     Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
 

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -333,7 +333,7 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
 #>
 Configuration DSC_SqlSetup_StopServicesInstance_Config
 {
-    Import-DscResource -ModuleName 'PSDscResources'
+    Import-DscResource -ModuleName 'PSDscResources' -ModuleVersion '2.12.0.0'
 
     node $AllNodes.NodeName
     {
@@ -481,7 +481,7 @@ Configuration MSFT_SqlSetup_InstallMultiDimensionalAnalysisServicesAsSystem_Conf
 #>
 Configuration MSFT_SqlSetup_StopMultiDimensionalAnalysisServices_Config
 {
-    Import-DscResource -ModuleName 'PSDscResources'
+    Import-DscResource -ModuleName 'PSDscResources' -ModuleVersion '2.12.0.0'
 
     node $AllNodes.NodeName
     {

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -66,7 +66,17 @@ else
                 # Database Engine properties.
                 DatabaseEngineNamedInstanceName         = 'DSCSQLTEST'
                 DatabaseEngineNamedInstanceFeatures     = 'SQLENGINE,REPLICATION,AS,CONN,BC,SDK'
-                AnalysisServicesMultiServerMode         = 'MULTIDIMENSIONAL'
+
+                <#
+                    Analysis Services Multi-dimensional properties.
+                    The features CONN,BC,SDK is installed with the DSCSQLTEST so those
+                    features will found for DSCTABULAR instance as well.
+                    The features is added here so the same property can be used to
+                    evaluate the result in the test.
+                #>
+                AnalysisServicesMultiInstanceName     = 'DSCMULTI'
+                AnalysisServicesMultiFeatures         = 'AS,CONN,BC,SDK'
+                AnalysisServicesMultiServerMode       = 'MULTIDIMENSIONAL'
 
                 <#
                     Analysis Services Tabular properties.
@@ -281,10 +291,6 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
             SQLCollation           = $Node.Collation
             SQLSvcAccount          = $SqlServicePrimaryCredential
             AgtSvcAccount          = $SqlAgentServicePrimaryCredential
-            ASServerMode           = $Node.AnalysisServicesMultiServerMode
-            AsSvcStartupType       = 'Automatic'
-            ASCollation            = $Node.Collation
-            ASSvcAccount           = $SqlServicePrimaryCredential
             InstanceDir            = $Node.InstanceDir
             InstallSharedDir       = $Node.InstallSharedDir
             InstallSharedWOWDir    = $Node.InstallSharedWOWDir
@@ -313,11 +319,6 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineNamedInstanceAsSystem_Config
                     IsHadrEnable for SqlAlwaysOnService.
                 #>
                 Split-Path -Path $SqlInstallCredential.UserName -Leaf
-            )
-
-            # This must be set if using SYSTEM account to install.
-            ASSysAdminAccounts    = @(
-                Split-Path -Path $SqlAdministratorCredential.UserName -Leaf
             )
         }
     }
@@ -376,7 +377,7 @@ Configuration DSC_SqlSetup_InstallDatabaseEngineDefaultInstanceAsUser_Config
     {
         SqlSetup 'Integration_Test'
         {
-            FeatureFlag            = @('DetectionSharedFeatures')
+            FeatureFlag          = @('DetectionSharedFeatures')
 
             InstanceName         = $Node.DatabaseEngineDefaultInstanceName
             Features             = $Node.DatabaseEngineDefaultInstanceFeatures
@@ -425,6 +426,80 @@ Configuration DSC_SqlSetup_StopSqlServerDefaultInstance_Config
 
 <#
     .SYNOPSIS
+        Installing the latest SqlServer module from PowerShell Gallery.
+
+    .NOTES
+        This is needed to install SQL Server Analysis Services instances.
+#>
+Configuration MSFT_SqlSetup_InstallSqlServerModule_Config
+{
+    Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
+
+    node $AllNodes.NodeName
+    {
+        PSModule 'InstallSqlServerModule'
+        {
+            Name = 'SqlServer'
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Installs a named instance of Analysis Services in multi-dimensional mode.
+#>
+Configuration MSFT_SqlSetup_InstallMultiDimensionalAnalysisServicesAsSystem_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlSetup 'Integration_Test'
+        {
+            FeatureFlag         = @('DetectionSharedFeatures','AnalysisServicesConnection')
+
+            InstanceName        = $Node.AnalysisServicesMultiInstanceName
+            Features            = $Node.AnalysisServicesMultiFeatures
+            SourcePath          = "$($Node.DriveLetter):\"
+            ASServerMode        = $Node.AnalysisServicesMultiServerMode
+            ASCollation         = $Node.Collation
+            ASSvcAccount        = $SqlServicePrimaryCredential
+            InstallSharedDir    = $Node.InstallSharedDir
+            InstallSharedWOWDir = $Node.InstallSharedWOWDir
+            UpdateEnabled       = $Node.UpdateEnabled
+            SuppressReboot      = $Node.SuppressReboot
+            ForceReboot         = $Node.ForceReboot
+
+            # This must be set if using SYSTEM account to install.
+            ASSysAdminAccounts  = @(
+                Split-Path -Path $SqlAdministratorCredential.UserName -Leaf
+            )
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Stopping the Analysis Services multi-dimensional named instance to save
+        memory on the build worker.
+#>
+Configuration MSFT_SqlSetup_StopMultiDimensionalAnalysisServices_Config
+{
+    Import-DscResource -ModuleName 'PSDscResources'
+
+    node $AllNodes.NodeName
+    {
+        Service ('StopMultiDimensionalAnalysisServicesInstance{0}' -f $Node.AnalysisServicesMultiInstanceName)
+        {
+            Name  = ('MSOLAP${0}' -f $Node.AnalysisServicesMultiInstanceName)
+            State = 'Stopped'
+        }
+    }
+}
+
+
+<#
+    .SYNOPSIS
         Installs a named instance of Analysis Services in tabular mode.
 #>
 Configuration DSC_SqlSetup_InstallTabularAnalysisServicesAsSystem_Config
@@ -435,7 +510,7 @@ Configuration DSC_SqlSetup_InstallTabularAnalysisServicesAsSystem_Config
     {
         SqlSetup 'Integration_Test'
         {
-            FeatureFlag            = @('DetectionSharedFeatures')
+            FeatureFlag         = @('DetectionSharedFeatures','AnalysisServicesConnection')
 
             InstanceName        = $Node.AnalysisServicesTabularInstanceName
             Features            = $Node.AnalysisServicesTabularFeatures
@@ -470,8 +545,29 @@ Configuration DSC_SqlSetup_StopTabularAnalysisServices_Config
     {
         Service ('StopTabularAnalysisServicesInstance{0}' -f $Node.AnalysisServicesTabularInstanceName)
         {
-            Name  = ('MSOLAP${0}' -f $Node.DatabaseEngineNamedInstanceName)
+            Name  = ('MSOLAP${0}' -f $Node.AnalysisServicesTabularInstanceName)
             State = 'Stopped'
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Installing the latest SqlServer module from PowerShell Gallery.
+
+    .NOTES
+        This is needed to install SQL Server Analysis Services instances.
+#>
+Configuration MSFT_SqlSetup_UninstallSqlServerModule_Config
+{
+    Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
+
+    node $AllNodes.NodeName
+    {
+        PSModule 'UninstallSqlServerModule'
+        {
+            Ensure = 'Absent'
+            Name   = 'SqlServer'
         }
     }
 }

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -433,8 +433,9 @@ Configuration MSFT_SqlSetup_InstallSqlServerModule_Config
     {
         PSModule 'InstallSqlServerModule'
         {
-            Name = 'SqlServer'
+            Name               = 'SqlServer'
             InstallationPolicy = 'Trusted'
+            AllowClobber       = $true
         }
     }
 }

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -555,28 +555,6 @@ Configuration DSC_SqlSetup_StopTabularAnalysisServices_Config
 
 <#
     .SYNOPSIS
-        Installing the latest SqlServer module from PowerShell Gallery.
-
-    .NOTES
-        Returns the error:
-        Expected no exception to be thrown, but an exception "Access to the path 'DataSec.PAL.Interfaces.dll' is denied." was thrown from D:\a\1\s\tests\Integration\DSC_SqlSetup.Integration.Tests.ps1:779 char:21
-#>
-# Configuration DSC_SqlSetup_UninstallSqlServerModule_Config
-# {
-#     Import-DscResource -ModuleName 'PowerShellGet' -ModuleVersion '2.1.2'
-
-#     node $AllNodes.NodeName
-#     {
-#         PSModule 'UninstallSqlServerModule'
-#         {
-#             Ensure = 'Absent'
-#             Name   = 'SqlServer'
-#         }
-#     }
-# }
-
-<#
-    .SYNOPSIS
         Restarting the Database Engine named instance.
 
     .NOTES

--- a/tests/Integration/README.md
+++ b/tests/Integration/README.md
@@ -31,7 +31,8 @@ AppVeyor build worker for other integration tests to use.
 
 Instance | Feature | AS server mode | State
 --- | --- | --- | ---
-DSCSQLTEST | SQLENGINE,AS,CONN,BC,SDK | MULTIDIMENSIONAL | Running
+DSCSQLTEST | SQLENGINE,AS,CONN,BC,SDK | - | Running
+DSCMULTI | AS,CONN,BC,SDK | MULTIDIMENSIONAL | Stopped
 DSCTABULAR | AS,CONN,BC,SDK | TABULAR | Stopped
 MSSQLSERVER | SQLENGINE,CONN,BC,SDK | - | Stopped
 

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -1495,6 +1495,19 @@ InModuleScope $script:subModuleName {
                 }
             }
 
+            Context 'When connecting to the default instance using the correct service instance but does not return a correct Analysis Service object' {
+                It 'Should throw the correct error' {
+                    $mockExpectedDataSource = ''
+
+                    Mock -CommandName New-Object `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter `
+                        -Verifiable
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                }
+            }
+
             Context 'When authentication using NetBIOS domain' {
                 It 'Should not throw when connecting' {
                     $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockNetBiosSqlCredentialUserName;Password=$mockNetBiosSqlCredentialPassword"

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -1401,7 +1401,7 @@ InModuleScope $script:subModuleName {
 
             $mockNewObject_MicrosoftAnalysisServicesServer = {
                 return New-Object -TypeName Object |
-                            Add-Member -MemberType 'NoteProperty' -Name 'Connected' -Value $mockDynamicConnectedStatus |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Connected' -Value $mockDynamicConnectedStatus -PassThru |
                             Add-Member -MemberType 'ScriptMethod' -Name 'Connect' -Value {
                                 param
                                 (
@@ -1413,7 +1413,7 @@ InModuleScope $script:subModuleName {
 
                                 if ($DataSource -ne $mockExpectedDataSource)
                                 {
-                                    throw ("Datasource was expected to be '{0}', but was '{1}'." -f $mockExpectedDataSource,$dataSource)
+                                    throw ("Datasource was expected to be '{0}', but was '{1}'." -f $mockExpectedDataSource, $dataSource)
                                 }
 
                                 if ($mockThrowInvalidOperation)
@@ -1445,6 +1445,8 @@ InModuleScope $script:subModuleName {
             $mockFqdnSqlCredentialPassword = 'StrongOne7.'
             $mockFqdnSqlCredentialSecurePassword = ConvertTo-SecureString -String $mockFqdnSqlCredentialPassword -AsPlainText -Force
             $mockFqdnSqlCredential = New-Object -TypeName PSCredential -ArgumentList ($mockFqdnSqlCredentialUserName, $mockFqdnSqlCredentialSecurePassword)
+
+            $mockComputerName = Get-ComputerName
         }
 
         BeforeEach {
@@ -1458,7 +1460,7 @@ InModuleScope $script:subModuleName {
             BeforeAll {
                 Mock -CommandName Import-SQLPSModule
 
-                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+                $mockExpectedDataSource = "Data Source=$mockComputerName"
             }
 
             Context 'When connecting to the default instance using Windows Authentication' {
@@ -1480,7 +1482,7 @@ InModuleScope $script:subModuleName {
                     }
 
                     It 'Should throw the correct error' {
-                        $mockExpectedErrorMessage = $script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME
+                        $mockExpectedErrorMessage = $script:localizedData.FailedToConnectToAnalysisServicesInstance -f $mockComputerName
 
                         { Connect-SQLAnalysis -FeatureFlag 'AnalysisServicesConnection' } | Should -Throw
                     }
@@ -1489,7 +1491,7 @@ InModuleScope $script:subModuleName {
 
             Context 'When connecting to the named instance using Windows Authentication' {
                 It 'Should not throw when connecting' {
-                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName"
+                    $mockExpectedDataSource = "Data Source=$mockComputerName\$mockInstanceName"
 
                     { Connect-SQLAnalysis -InstanceName $mockInstanceName -FeatureFlag 'AnalysisServicesConnection' } | Should -Not -Throw
                 }
@@ -1497,7 +1499,7 @@ InModuleScope $script:subModuleName {
 
             Context 'When connecting to the named instance using Windows Authentication impersonation' {
                 It 'Should not throw when connecting' {
-                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockSqlCredentialUserName;Password=$mockSqlCredentialPassword"
+                    $mockExpectedDataSource = "Data Source=$mockComputerName\$mockInstanceName;User ID=$mockSqlCredentialUserName;Password=$mockSqlCredentialPassword"
 
                     { Connect-SQLAnalysis -InstanceName $mockInstanceName -SetupCredential $mockSqlCredential -FeatureFlag 'AnalysisServicesConnection' } | Should -Not -Throw
                 }
@@ -1511,7 +1513,7 @@ InModuleScope $script:subModuleName {
 
             Context 'When connecting to the default instance using Windows Authentication' {
                 It 'Should not throw when connecting' {
-                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+                    $mockExpectedDataSource = "Data Source=$mockComputerName"
 
                     { Connect-SQLAnalysis } | Should -Not -Throw
 
@@ -1522,7 +1524,7 @@ InModuleScope $script:subModuleName {
 
             Context 'When connecting to the named instance using Windows Authentication' {
                 It 'Should not throw when connecting' {
-                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName"
+                    $mockExpectedDataSource = "Data Source=$mockComputerName\$mockInstanceName"
 
                     { Connect-SQLAnalysis -InstanceName $mockInstanceName } | Should -Not -Throw
 
@@ -1534,7 +1536,7 @@ InModuleScope $script:subModuleName {
             Context 'When connecting to the named instance using Windows Authentication impersonation' {
                 Context 'When authentication without NetBIOS domain and Fully Qualified Domain Name (FQDN)' {
                     It 'Should not throw when connecting' {
-                        $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockSqlCredentialUserName;Password=$mockSqlCredentialPassword"
+                        $mockExpectedDataSource = "Data Source=$mockComputerName\$mockInstanceName;User ID=$mockSqlCredentialUserName;Password=$mockSqlCredentialPassword"
 
                         { Connect-SQLAnalysis -InstanceName $mockInstanceName -SetupCredential $mockSqlCredential } | Should -Not -Throw
 
@@ -1545,7 +1547,7 @@ InModuleScope $script:subModuleName {
 
                 Context 'When authentication using NetBIOS domain' {
                     It 'Should not throw when connecting' {
-                        $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockNetBiosSqlCredentialUserName;Password=$mockNetBiosSqlCredentialPassword"
+                        $mockExpectedDataSource = "Data Source=$mockComputerName\$mockInstanceName;User ID=$mockNetBiosSqlCredentialUserName;Password=$mockNetBiosSqlCredentialPassword"
 
                         { Connect-SQLAnalysis -InstanceName $mockInstanceName -SetupCredential $mockNetBiosSqlCredential } | Should -Not -Throw
 
@@ -1556,7 +1558,7 @@ InModuleScope $script:subModuleName {
 
                 Context 'When authentication using Fully Qualified Domain Name (FQDN)' {
                     It 'Should not throw when connecting' {
-                        $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockFqdnSqlCredentialUserName;Password=$mockFqdnSqlCredentialPassword"
+                        $mockExpectedDataSource = "Data Source=$mockComputerName\$mockInstanceName;User ID=$mockFqdnSqlCredentialUserName;Password=$mockFqdnSqlCredentialPassword"
 
                         { Connect-SQLAnalysis -InstanceName $mockInstanceName -SetupCredential $mockFqdnSqlCredential } | Should -Not -Throw
 
@@ -1573,7 +1575,7 @@ InModuleScope $script:subModuleName {
                     Mock -CommandName New-Object `
                         -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
 
-                    $mockErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME)
+                    $mockErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $mockComputerName)
 
                     $mockErrorMessage | Should -Not -BeNullOrEmpty
 
@@ -1586,12 +1588,12 @@ InModuleScope $script:subModuleName {
 
             Context 'When connecting to the default instance using a Analysis Service instance that does not exist' {
                 It 'Should throw the correct error' {
-                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+                    $mockExpectedDataSource = "Data Source=$mockComputerName"
 
                     # Force the mock of Connect() method to throw 'Unable to connect.'
                     $mockThrowInvalidOperation = $true
 
-                    $mockErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME)
+                    $mockErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $mockComputerName)
 
                     $mockErrorMessage | Should -Not -BeNullOrEmpty
 

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -1444,7 +1444,7 @@ InModuleScope $script:subModuleName {
             $mockFqdnSqlCredentialSecurePassword = ConvertTo-SecureString -String $mockFqdnSqlCredentialPassword -AsPlainText -Force
             $mockFqdnSqlCredential = New-Object -TypeName PSCredential -ArgumentList ($mockFqdnSqlCredentialUserName, $mockFqdnSqlCredentialSecurePassword)
 
-            Mock -CommandName Import-Assembly
+            Mock -CommandName Import-SQLPSModule
         }
 
         BeforeEach {

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -1454,27 +1454,34 @@ InModuleScope $script:subModuleName {
                 -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
         }
 
-        Context 'When connecting to the default instance using Windows Authentication' {
-            It 'Should not throw when connecting' {
-                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+        Context 'When using feature flag ''AnalysisServicesConnection''' {
+            Context 'When connecting to the default instance using Windows Authentication' {
+                It 'Should not throw when connecting' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
 
-                { Connect-SQLAnalysis } | Should -Not -Throw
+                    { Connect-SQLAnalysis -FeatureFlag 'AnalysisServicesConnection' } | Should -Not -Throw
 
-                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
-                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                    Assert-MockCalled -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                }
             }
-        }
 
-        Context 'When connecting to the named instance using Windows Authentication' {
-            It 'Should not throw when connecting' {
-                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName"
+            Context 'When connecting to the named instance using Windows Authentication' {
+                It 'Should not throw when connecting' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName"
 
-                { Connect-SQLAnalysis -InstanceName $mockInstanceName } | Should -Not -Throw
-
-                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
-                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                    { Connect-SQLAnalysis -SQLInstanceName $mockInstanceName -FeatureFlag 'AnalysisServicesConnection' } | Should -Not -Throw
+                }
             }
-        }
+
+            Context 'When connecting to the named instance using Windows Authentication impersonation' {
+                It 'Should not throw when connecting' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockSetupCredentialUserName;Password=$mockSetupCredentialPassword"
+
+                    { Connect-SQLAnalysis -SQLInstanceName $mockInstanceName -SetupCredential $mockSetupCredential -FeatureFlag 'AnalysisServicesConnection' } | Should -Not -Throw
+                }
+            }
 
         Context 'When connecting to the named instance using Windows Authentication impersonation' {
             Context 'When authentication without NetBIOS domain and Fully Qualified Domain Name (FQDN)' {
@@ -1507,68 +1514,131 @@ InModuleScope $script:subModuleName {
 
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
                         -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+
+            Context 'When connecting to the default instance using a Analysis Service instance that does not exist' {
+                It 'Should throw the correct error' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+
+                    # Force the mock of Connect() method to throw 'Unable to connect.'
+                    $mockThrowInvalidOperation = $true
+
+                    $mockCorrectErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME)
+                    { Connect-SQLAnalysis -FeatureFlag 'AnalysisServicesConnection' } | Should -Throw $mockCorrectErrorMessage
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+
+                    # Setting it back to the default so it does not disturb other tests.
+                    $mockThrowInvalidOperation = $false
+                }
+            }
+
+            # This test is to test the mock so that it throws correct when data source is not the expected data source
+            Context 'When connecting to the named instance using another data source then expected' {
+                It 'Should throw the correct error' {
+                    $mockExpectedDataSource = "Force wrong data source"
+
+                    $testParameters = @{
+                        SQLServer = 'DummyHost'
+                        SQLInstanceName = $mockInstanceName
+                    }
+
+                    $mockCorrectErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f "$($testParameters.SQLServer)\$($testParameters.SQLInstanceName)")
+                    { Connect-SQLAnalysis @testParameters } | Should -Throw $mockCorrectErrorMessage
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
                 }
             }
         }
 
-        Context 'When connecting to the default instance using the correct service instance but does not return a correct Analysis Service object' {
-            It 'Should throw the correct error' {
-                $mockExpectedDataSource = ''
+        Context 'When not using feature flag ''AnalysisServicesConnection''' {
+            Context 'When connecting to the default instance using Windows Authentication' {
+                It 'Should not throw when connecting' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
 
-                Mock -CommandName New-Object `
-                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                    { Connect-SQLAnalysis } | Should -Not -Throw
 
-                $mockErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME)
-
-                $mockErrorMessage | Should -Not -BeNullOrEmpty
-
-                { Connect-SQLAnalysis } | Should -Throw -ExpectedMessage $mockErrorMessage
-
-                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
-                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
-            }
-        }
-
-        Context 'When connecting to the default instance using a Analysis Service instance that does not exist' {
-            It 'Should throw the correct error' {
-                $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
-
-                # Force the mock of Connect() method to throw 'Unable to connect.'
-                $mockThrowInvalidOperation = $true
-
-                $mockErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME)
-
-                $mockErrorMessage | Should -Not -BeNullOrEmpty
-
-                { Connect-SQLAnalysis } | Should -Throw -ExpectedMessage $mockErrorMessage
-
-                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
-                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
-
-                # Setting it back to the default so it does not disturb other tests.
-                $mockThrowInvalidOperation = $false
-            }
-        }
-
-        # This test is to test the mock so that it throws correct when data source is not the expected data source
-        Context 'When connecting to the named instance using another data source then expected' {
-            It 'Should throw the correct error' {
-                $mockExpectedDataSource = "Force wrong data source"
-
-                $testParameters = @{
-                    ServerName = 'DummyHost'
-                    InstanceName = $mockInstanceName
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
                 }
-
-                $mockErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f "$($testParameters.ServerName)\$($testParameters.InstanceName)")
-
-                $mockErrorMessage | Should -Not -BeNullOrEmpty
-
-                { Connect-SQLAnalysis @testParameters } | Should -Throw -ExpectedMessage $mockErrorMessage
-
-                Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
-                    -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
             }
+
+            Context 'When connecting to the named instance using Windows Authentication' {
+                It 'Should not throw when connecting' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName"
+
+                    { Connect-SQLAnalysis -SQLInstanceName $mockInstanceName } | Should -Not -Throw
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                }
+            }
+
+            Context 'When connecting to the named instance using Windows Authentication impersonation' {
+                It 'Should not throw when connecting' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME\$mockInstanceName;User ID=$mockSetupCredentialUserName;Password=$mockSetupCredentialPassword"
+
+                    { Connect-SQLAnalysis -SQLInstanceName $mockInstanceName -SetupCredential $mockSetupCredential } | Should -Not -Throw
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                }
+            }
+
+            Context 'When connecting to the default instance using the correct service instance but does not return a correct Analysis Service object' {
+                It 'Should throw the correct error' {
+                    $mockExpectedDataSource = ''
+
+                    Mock -CommandName New-Object `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter `
+                        -Verifiable
+
+                    $mockCorrectErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME)
+                    { Connect-SQLAnalysis } | Should -Throw $mockCorrectErrorMessage
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                }
+            }
+
+            Context 'When connecting to the default instance using a Analysis Service instance that does not exist' {
+                It 'Should throw the correct error' {
+                    $mockExpectedDataSource = "Data Source=$env:COMPUTERNAME"
+
+                    # Force the mock of Connect() method to throw 'Unable to connect.'
+                    $mockThrowInvalidOperation = $true
+
+                    $mockCorrectErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f $env:COMPUTERNAME)
+                    { Connect-SQLAnalysis } | Should -Throw $mockCorrectErrorMessage
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+
+                    # Setting it back to the default so it does not disturb other tests.
+                    $mockThrowInvalidOperation = $false
+                }
+            }
+
+            # This test is to test the mock so that it throws correct when data source is not the expected data source
+            Context 'When connecting to the named instance using another data source then expected' {
+                It 'Should throw the correct error' {
+                    $mockExpectedDataSource = "Force wrong data source"
+
+                    $testParameters = @{
+                        SQLServer = 'DummyHost'
+                        SQLInstanceName = $mockInstanceName
+                    }
+
+                    $mockCorrectErrorMessage = ($script:localizedData.FailedToConnectToAnalysisServicesInstance -f "$($testParameters.SQLServer)\$($testParameters.SQLInstanceName)")
+                    { Connect-SQLAnalysis @testParameters } | Should -Throw $mockCorrectErrorMessage
+
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It `
+                        -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
+                }
+            }
+
+            Assert-VerifiableMock
         }
     }
 
@@ -3493,6 +3563,28 @@ InModuleScope $script:subModuleName {
             $result = Get-FilePathMajorVersion -Path 'C:\AnyPath\Setup.exe'
 
             $result | Should -Be '10'
+        }
+
+        Assert-VerifiableMock
+    }
+
+    Describe 'Test-FeatureFlag' -Tag 'TestFeatureFlag' {
+        Context 'When no feature flags was provided' {
+            It 'Should return $false' {
+                Test-FeatureFlag -FeatureFlag $null -TestFlag 'MyFlag' | Should -Be $false
+            }
+        }
+
+        Context 'When feature flags was provided' {
+            It 'Should return $true' {
+                Test-FeatureFlag -FeatureFlag @('FirstFlag','SecondFlag') -TestFlag 'SecondFlag' | Should -Be $true
+            }
+        }
+
+        Context 'When feature flags was provided, but missing' {
+            It 'Should return $false' {
+                Test-FeatureFlag -FeatureFlag @('MyFlag2') -TestFlag 'MyFlag' | Should -Be $false
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlSetup
  - The helper function `Connect-SqlAnalysis` was using `LoadWithPartial()`
    to load the assembly _Microsoft.AnalysisServices_. On a node where multiple
    instances with different versions of SQL Server (regardless of features)
    is installed, this will result in the first assembly found in the
    GAC will be loaded into the session, not taking versions into account.
    This can result in an assembly version being loaded that is not compatible
    with the version of SQL Server it was meant to be used with.
    A new method of loading the assembly _Microsoft.AnalysisServices_ was
    introduced under a feature flag; `'AnalysisServicesConnection'`.
    This new functionality depends on the [SqlServer](https://www.powershellgallery.com/packages/SqlServer)
    module, and must be present on the node. The [SqlServer](https://www.powershellgallery.com/packages/SqlServer)
    module can be installed on the node by leveraging the new DSC resource
    `PSModule` in the [PowerShellGet](https://www.powershellgallery.com/packages/PowerShellGet/2.1.2)
    module (v2.1.2 and higher). This new method does not work with the
    SQLPS module due to the SQLPS module does not load the correct assembly,
    while [SqlServer](https://www.powershellgallery.com/packages/SqlServer)
    module (v21.1.18080 and above) does. The new functionality is used
    when the parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
    This functionality will be the default in a future breaking release.
  - Under a feature flag; `'AnalysisServicesConnection'`. The detection of
    a successful connection to the SQL Server Analysis Services has also been
    changed. Now it actually evaluates the property `Connected` of the returned
    `Microsoft.AnalysisServices.Server` object. The new functionality is used
    when the parameter `FeatureFlag` is set to `'AnalysisServicesConnection'`.
    This functionality will be the default in a future breaking release.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1692)
<!-- Reviewable:end -->
