### PR TITLE
BREAKING CHANGE: SqlLogin: Parameters no longer enforce default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wiki
   - add introduction and links to DSC technology
 - SqlLogin
-  - `LoginMustChangePassword`, `LoginPasswordExpirationEnabled` and `LoginPasswordPolicyEnforced`
+  - BREAKING CHANGE: `LoginMustChangePassword`, `LoginPasswordExpirationEnabled` and `LoginPasswordPolicyEnforced`
     parameters no longer enforce default values ([issue #1669](https://github.com/dsccommunity/SqlServerDsc/issues/1669)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - add introduction and links to DSC technology
 - SqlLogin
   - `LoginMustChangePassword`, `LoginPasswordExpirationEnabled` and `LoginPasswordPolicyEnforced`
-    parameters no longer enforce default values [issue #1669](https://github.com/dsccommunity/SqlServerDsc/issues/1669).
+    parameters no longer enforce default values ([issue #1669](https://github.com/dsccommunity/SqlServerDsc/issues/1669)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bumped Stale task to v5 in the GitHub workflow.
 - Wiki
   - add introduction and links to DSC technology
+- SqlLogin
+  - `LoginMustChangePassword`, `LoginPasswordExpirationEnabled` and `LoginPasswordPolicyEnforced`
+    parameters no longer enforce default values [issue #1669](https://github.com/dsccommunity/SqlServerDsc/issues/1669).
 
 ### Fixed
 

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
@@ -163,15 +163,15 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $LoginMustChangePassword = $true,
+        $LoginMustChangePassword,
 
         [Parameter()]
         [System.Boolean]
-        $LoginPasswordExpirationEnabled = $true,
+        $LoginPasswordExpirationEnabled,
 
         [Parameter()]
         [System.Boolean]
-        $LoginPasswordPolicyEnforced = $true,
+        $LoginPasswordPolicyEnforced,
 
         [Parameter()]
         [System.Boolean]
@@ -195,15 +195,15 @@ function Set-TargetResource
                 if ( $login.LoginType -eq 'SqlLogin' )
                 {
                     # There is no way to update 'MustChangePassword' on existing login so must explicitly throw exception to avoid this functionality being assumed
-                    if ( $login.MustChangePassword -ne $LoginMustChangePassword )
+                    if ( $PSBoundParameters.ContainsKey('LoginMustChangePassword') -and $login.MustChangePassword -ne $LoginMustChangePassword )
                     {
                         $errorMessage = $script:localizedData.MustChangePasswordCannotBeChanged
                         New-InvalidOperationException -Message $errorMessage
                     }
 
                     # `PasswordPolicyEnforced and `PasswordExpirationEnabled` must be updated together (if one or both are not in the desired state)
-                    if ( $login.PasswordPolicyEnforced -ne $LoginPasswordPolicyEnforced -or
-                         $login.PasswordExpirationEnabled -ne $LoginPasswordExpirationEnabled )
+                    if ( ( $PSBoundParameters.ContainsKey('LoginPasswordPolicyEnforced') -and $login.PasswordPolicyEnforced -ne $LoginPasswordPolicyEnforced ) -or
+                         ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') -and $login.PasswordExpirationEnabled -ne $LoginPasswordExpirationEnabled ) )
                     {
                         Write-Verbose -Message (
                             $script:localizedData.SetPasswordPolicyEnforced -f $LoginPasswordPolicyEnforced, $Name, $ServerName, $InstanceName
@@ -212,8 +212,15 @@ function Set-TargetResource
                             $script:localizedData.SetPasswordExpirationEnabled -f $LoginPasswordExpirationEnabled, $Name, $ServerName, $InstanceName
                         )
 
-                        $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
-                        $login.PasswordExpirationEnabled = $LoginPasswordExpirationEnabled
+                        if ( $PSBoundParameters.ContainsKey('LoginPasswordPolicyEnforced') )
+                        {
+                            $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
+                        }
+
+                        if ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') )
+                        {
+                            $login.PasswordExpirationEnabled = $LoginPasswordExpirationEnabled
+                        }
 
                         Update-SQLServerLogin -Login $login
                     }
@@ -421,15 +428,15 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $LoginMustChangePassword = $true,
+        $LoginMustChangePassword,
 
         [Parameter()]
         [System.Boolean]
-        $LoginPasswordExpirationEnabled = $true,
+        $LoginPasswordExpirationEnabled,
 
         [Parameter()]
         [System.Boolean]
-        $LoginPasswordPolicyEnforced = $true,
+        $LoginPasswordPolicyEnforced,
 
         [Parameter()]
         [System.Boolean]
@@ -504,7 +511,7 @@ function Test-TargetResource
 
         if ( $LoginType -eq 'SqlLogin' )
         {
-            if ( $LoginPasswordExpirationEnabled -ne $loginInfo.LoginPasswordExpirationEnabled )
+            if ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') -and $LoginPasswordExpirationEnabled -ne $loginInfo.LoginPasswordExpirationEnabled )
             {
                 if ($LoginPasswordExpirationEnabled)
                 {
@@ -522,7 +529,7 @@ function Test-TargetResource
                 $testPassed = $false
             }
 
-            if ( $LoginPasswordPolicyEnforced -ne $loginInfo.LoginPasswordPolicyEnforced )
+            if ( $PSBoundParameters.ContainsKey('LoginPasswordPolicyEnforced') -and $LoginPasswordPolicyEnforced -ne $loginInfo.LoginPasswordPolicyEnforced )
             {
                 if ($LoginPasswordPolicyEnforced)
                 {

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
@@ -201,7 +201,8 @@ function Set-TargetResource
                         New-InvalidOperationException -Message $errorMessage
                     }
 
-                    # `PasswordPolicyEnforced and `PasswordExpirationEnabled` must be updated together (if one or both are not in the desired state)
+                    # Update SQL login data if either `PasswordPolicyEnforced or `PasswordExpirationEnabled` is specified and not in desired state.
+                    # Avoids executing `Update-SQLServerLogin` twice if both are not in desired state.
                     if ( ( $PSBoundParameters.ContainsKey('LoginPasswordPolicyEnforced') -and $login.PasswordPolicyEnforced -ne $LoginPasswordPolicyEnforced ) -or
                          ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') -and $login.PasswordExpirationEnabled -ne $LoginPasswordExpirationEnabled ) )
                     {

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
@@ -210,18 +210,12 @@ function Set-TargetResource
                             Write-Verbose -Message (
                                 $script:localizedData.SetPasswordPolicyEnforced -f $LoginPasswordPolicyEnforced, $Name, $ServerName, $InstanceName
                             )
-                            Write-Verbose -Message (
-                                $script:localizedData.SetPasswordExpirationEnabled -f $LoginPasswordExpirationEnabled, $Name, $ServerName, $InstanceName
-                            )
 
                             $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
                         }
 
                         if ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') )
                         {
-                            Write-Verbose -Message (
-                                $script:localizedData.SetPasswordPolicyEnforced -f $LoginPasswordPolicyEnforced, $Name, $ServerName, $InstanceName
-                            )
                             Write-Verbose -Message (
                                 $script:localizedData.SetPasswordExpirationEnabled -f $LoginPasswordExpirationEnabled, $Name, $ServerName, $InstanceName
                             )

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
@@ -205,20 +205,27 @@ function Set-TargetResource
                     if ( ( $PSBoundParameters.ContainsKey('LoginPasswordPolicyEnforced') -and $login.PasswordPolicyEnforced -ne $LoginPasswordPolicyEnforced ) -or
                          ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') -and $login.PasswordExpirationEnabled -ne $LoginPasswordExpirationEnabled ) )
                     {
-                        Write-Verbose -Message (
-                            $script:localizedData.SetPasswordPolicyEnforced -f $LoginPasswordPolicyEnforced, $Name, $ServerName, $InstanceName
-                        )
-                        Write-Verbose -Message (
-                            $script:localizedData.SetPasswordExpirationEnabled -f $LoginPasswordExpirationEnabled, $Name, $ServerName, $InstanceName
-                        )
-
                         if ( $PSBoundParameters.ContainsKey('LoginPasswordPolicyEnforced') )
                         {
+                            Write-Verbose -Message (
+                                $script:localizedData.SetPasswordPolicyEnforced -f $LoginPasswordPolicyEnforced, $Name, $ServerName, $InstanceName
+                            )
+                            Write-Verbose -Message (
+                                $script:localizedData.SetPasswordExpirationEnabled -f $LoginPasswordExpirationEnabled, $Name, $ServerName, $InstanceName
+                            )
+
                             $login.PasswordPolicyEnforced = $LoginPasswordPolicyEnforced
                         }
 
                         if ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') )
                         {
+                            Write-Verbose -Message (
+                                $script:localizedData.SetPasswordPolicyEnforced -f $LoginPasswordPolicyEnforced, $Name, $ServerName, $InstanceName
+                            )
+                            Write-Verbose -Message (
+                                $script:localizedData.SetPasswordExpirationEnabled -f $LoginPasswordExpirationEnabled, $Name, $ServerName, $InstanceName
+                            )
+
                             $login.PasswordExpirationEnabled = $LoginPasswordExpirationEnabled
                         }
 
@@ -838,4 +845,3 @@ function Set-SQLServerLoginPassword
         $ErrorActionPreference = $originalErrorActionPreference
     }
 }
-

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
@@ -107,13 +107,13 @@ function Get-TargetResource
         The credential containing the password for a SQL Login. Only applies if the login type is SqlLogin.
 
     .PARAMETER LoginMustChangePassword
-        Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Does not update pre-existing SQL Logins. Default is $true.
+        Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Does not update pre-existing SQL Logins.
 
     .PARAMETER LoginPasswordExpirationEnabled
-        Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins. Default is $true.
+        Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.
 
     .PARAMETER LoginPasswordPolicyEnforced
-        Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins. Default is $true.
+        Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.
 
     .PARAMETER Disabled
         Specifies if the login is disabled. Default is $false.
@@ -372,13 +372,13 @@ function Set-TargetResource
         The credential containing the password for a SQL Login. Only applies if the login type is SqlLogin.
 
     .PARAMETER LoginMustChangePassword
-        Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins. Default is $true.
+        Specifies if the login is required to have its password change on the next login. Only applies to SQL Logins.
 
     .PARAMETER LoginPasswordExpirationEnabled
-        Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins. Default is $true.
+        Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to SQL Logins.
 
     .PARAMETER LoginPasswordPolicyEnforced
-        Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins. Default is $true.
+        Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to SQL Logins.
 
     .PARAMETER Disabled
         Specifies if the login is disabled. Default is $false.

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.schema.mof
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.schema.mof
@@ -9,9 +9,9 @@ class DSC_SqlLogin : OMI_BaseResource
         Values{"WindowsUser","WindowsGroup","SqlLogin","Certificate","AsymmetricKey","ExternalUser","ExternalGroup"}] String LoginType;
     [Write, Description("The hostname of the _SQL Server_ to be configured. Default value is the current computer name.")] String ServerName;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Specifies the password as a `[PSCredential]` object. Only applies to _SQL Logins_.")] String LoginCredential;
-    [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to _SQL Logins_. Default value is `$true`. This cannot be updated on a pre-existing _SQL Login_ and any attempt to do this will throw an exception.")] Boolean LoginMustChangePassword;
-    [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to _SQL Logins_. Default value is `$true`.")] Boolean LoginPasswordExpirationEnabled;
-    [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to _SQL Logins_. Default value is `$true`.")] Boolean LoginPasswordPolicyEnforced;
+    [Write, Description("Specifies if the login is required to have its password change on the next login. Only applies to _SQL Logins_. This cannot be updated on a pre-existing _SQL Login_ and any attempt to do this will throw an exception.")] Boolean LoginMustChangePassword;
+    [Write, Description("Specifies if the login password is required to expire in accordance to the operating system security policy. Only applies to _SQL Logins_.")] Boolean LoginPasswordExpirationEnabled;
+    [Write, Description("Specifies if the login password is required to conform to the password policy specified in the system security policy. Only applies to _SQL Logins_.")] Boolean LoginPasswordPolicyEnforced;
     [Write, Description("Specifies if the login is disabled. Default value is `$false`.")] Boolean Disabled;
     [Write, Description("Specifies the default database name.")] String DefaultDatabase;
 };

--- a/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
@@ -265,8 +265,8 @@ try
                 $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
                 $resourceCurrentState.Disabled | Should -Be $false
                 $resourceCurrentState.LoginMustChangePassword | Should -Be $false
-                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $true
                 $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $true
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $true
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -365,8 +365,8 @@ try
                 $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
                 $resourceCurrentState.Disabled | Should -Be $false
                 $resourceCurrentState.LoginMustChangePassword | Should -Be $false # Left the same as this cannot be updated
-                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
                 $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $false
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
@@ -420,6 +420,110 @@ try
             }
         }
 
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforced"
+
+        Context ('When using configuration {0} (to update back to original password)' -f $configurationName) {
+            It 'Should re-compile and re-apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath                 = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData          = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
+                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -BeTrue
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -BeFalse
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config_LoginPasswordExpirationEnabled"
+
+        Context ('When using configuration {0} (to update back to original password)' -f $configurationName) {
+            It 'Should re-compile and re-apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath                 = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData          = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
+                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -BeTrue
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -BeTrue
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
 
         Wait-ForIdleLcm -Clear
 
@@ -482,161 +586,6 @@ try
 
         Wait-ForIdleLcm -Clear
 
-        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config_LoginPasswordExpirationEnabled"
-
-        Context ('When using configuration {0} (to update back to original password)' -f $configurationName) {
-            It 'Should re-compile and re-apply the MOF without throwing' {
-                {
-                    $configurationParameters = @{
-                        OutputPath                 = $TestDrive
-                        # The variable $ConfigurationData was dot-sourced above.
-                        ConfigurationData          = $ConfigurationData
-                    }
-
-                    & $configurationName @configurationParameters
-
-                    $startDscConfigurationParameters = @{
-                        Path         = $TestDrive
-                        ComputerName = 'localhost'
-                        Wait         = $true
-                        Verbose      = $true
-                        Force        = $true
-                        ErrorAction  = 'Stop'
-                    }
-
-                    Start-DscConfiguration @startDscConfigurationParameters
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                {
-                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
-                } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq $resourceId
-                }
-
-                $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
-                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
-                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -BeTrue
-                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -BeFalse
-            }
-
-            It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be 'True'
-            }
-        }
-
-        Wait-ForIdleLcm -Clear
-
-        # Reset LoginPasswordExpirationEnabled and LoginPasswordExpirationEnabled flags
-        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config"
-
-        Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
-                {
-                    $configurationParameters = @{
-                        OutputPath                 = $TestDrive
-                        # The variable $ConfigurationData was dot-sourced above.
-                        ConfigurationData          = $ConfigurationData
-                    }
-
-                    & $configurationName @configurationParameters
-
-                    $startDscConfigurationParameters = @{
-                        Path         = $TestDrive
-                        ComputerName = 'localhost'
-                        Wait         = $true
-                        Verbose      = $true
-                        Force        = $true
-                        ErrorAction  = 'Stop'
-                    }
-
-                    Start-DscConfiguration @startDscConfigurationParameters
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                {
-                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
-                } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq $resourceId
-                }
-
-                $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
-                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
-                $resourceCurrentState.Disabled | Should -Be $false
-                $resourceCurrentState.LoginMustChangePassword | Should -Be $false # Left the same as this cannot be updated
-                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
-                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $false
-            }
-        }
-
-        Wait-ForIdleLcm -Clear
-
-        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforced"
-
-        Context ('When using configuration {0} (to update back to original password)' -f $configurationName) {
-            It 'Should re-compile and re-apply the MOF without throwing' {
-                {
-                    $configurationParameters = @{
-                        OutputPath                 = $TestDrive
-                        # The variable $ConfigurationData was dot-sourced above.
-                        ConfigurationData          = $ConfigurationData
-                    }
-
-                    & $configurationName @configurationParameters
-
-                    $startDscConfigurationParameters = @{
-                        Path         = $TestDrive
-                        ComputerName = 'localhost'
-                        Wait         = $true
-                        Verbose      = $true
-                        Force        = $true
-                        ErrorAction  = 'Stop'
-                    }
-
-                    Start-DscConfiguration @startDscConfigurationParameters
-                } | Should -Not -Throw
-            }
-
-            It 'Should be able to call Get-DscConfiguration without throwing' {
-                {
-                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
-                } | Should -Not -Throw
-            }
-
-            It 'Should have set the resource and all the parameters should match' {
-                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq $resourceId
-                }
-
-                $resourceCurrentState.Ensure | Should -Be 'Present'
-                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
-                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
-                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -BeFalse
-                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -BeTrue
-            }
-
-            It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be 'True'
-            }
-        }
-
-        Wait-ForIdleLcm -Clear
-
         $configurationName = "$($script:dscResourceName)_AddLoginDscUser5_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
@@ -680,8 +629,8 @@ try
                 $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser5Type
                 $resourceCurrentState.Disabled | Should -Be $false
                 $resourceCurrentState.LoginMustChangePassword | Should -Be $false
-                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
                 $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $true
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {

--- a/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
@@ -629,7 +629,7 @@ try
                 $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser5Type
                 $resourceCurrentState.Disabled | Should -Be $false
                 $resourceCurrentState.LoginMustChangePassword | Should -Be $false
-                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $true
+                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $false
                 $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
             }
 

--- a/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
@@ -482,6 +482,116 @@ try
 
         Wait-ForIdleLcm -Clear
 
+        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config_LoginPasswordExpirationEnabled"
+
+        Context ('When using configuration {0} (to update back to original password)' -f $configurationName) {
+            It 'Should re-compile and re-apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath                 = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData          = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+
+            It 'Should allow SQL Server, login username and password to connect to SQL Instance (using SqlConnection.Open())' {
+                $serverName = $ConfigurationData.AllNodes.ServerName
+                $instanceName = $ConfigurationData.AllNodes.InstanceName
+                $databaseName = $ConfigurationData.AllNodes.DefaultDbName
+                $userName = $ConfigurationData.AllNodes.DscUser4Name
+                $password = $ConfigurationData.AllNodes.DscUser4Pass1 # Original password
+
+                $sqlConnectionString = 'Data Source={0}\{1};User ID={2};Password={3};Connect Timeout=5;Database={4};' -f $serverName, $instanceName, $userName, $password, $databaseName
+
+                {
+                    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString
+                    $sqlConnection.Open()
+                    $sqlConnection.Close()
+                } | Should -Not -Throw
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforced"
+
+        Context ('When using configuration {0} (to update back to original password)' -f $configurationName) {
+            It 'Should re-compile and re-apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath                 = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData          = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+
+            It 'Should allow SQL Server, login username and password to connect to SQL Instance (using SqlConnection.Open())' {
+                $serverName = $ConfigurationData.AllNodes.ServerName
+                $instanceName = $ConfigurationData.AllNodes.InstanceName
+                $databaseName = $ConfigurationData.AllNodes.DefaultDbName
+                $userName = $ConfigurationData.AllNodes.DscUser4Name
+                $password = $ConfigurationData.AllNodes.DscUser4Pass1 # Original password
+
+                $sqlConnectionString = 'Data Source={0}\{1};User ID={2};Password={3};Connect Timeout=5;Database={4};' -f $serverName, $instanceName, $userName, $password, $databaseName
+
+                {
+                    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString
+                    $sqlConnection.Open()
+                    $sqlConnection.Close()
+                } | Should -Not -Throw
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
         $configurationName = "$($script:dscResourceName)_AddLoginDscSqlUsers1_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {

--- a/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
@@ -637,6 +637,106 @@ try
 
         Wait-ForIdleLcm -Clear
 
+        $configurationName = "$($script:dscResourceName)_AddLoginDscUser5_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath                 = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData          = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser5Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser5Type
+                $resourceCurrentState.Disabled | Should -Be $false
+                $resourceCurrentState.LoginMustChangePassword | Should -Be $false
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
+                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $true
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+
+            It 'Should allow SQL Server, login username and password to connect to SQL Instance (using SqlConnection.Open())' {
+                $serverName = $ConfigurationData.AllNodes.ServerName
+                $instanceName = $ConfigurationData.AllNodes.InstanceName
+                $databaseName = $ConfigurationData.AllNodes.DefaultDbName
+                $userName = $ConfigurationData.AllNodes.DscUser5Name
+                $password = $ConfigurationData.AllNodes.DscUser5Pass
+
+                $sqlConnectionString = 'Data Source={0}\{1};User ID={2};Password={3};Connect Timeout=5;Database={4};' -f $serverName, $instanceName, $userName, $password, $databaseName
+
+                {
+                    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString
+                    $sqlConnection.Open()
+                    $sqlConnection.Close()
+                } | Should -Not -Throw
+            }
+
+            It 'Should allow SQL Server, login username and password to connect to correct, SQL instance, default database' {
+                $script:CurrentDatabaseName = $null
+
+                $serverName = $ConfigurationData.AllNodes.ServerName
+                $instanceName = $ConfigurationData.AllNodes.InstanceName
+                $userName = $ConfigurationData.AllNodes.DscUser5Name
+                $password = $ConfigurationData.AllNodes.DscUser5Pass
+
+                $sqlConnectionString = 'Data Source={0}\{1};User ID={2};Password={3};Connect Timeout=5;' -f $serverName, $instanceName, $userName, $password # Note: Not providing a database name
+
+                {
+                    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString
+                    $sqlCommand = New-Object System.Data.SqlClient.SqlCommand('SELECT DB_NAME() as CurrentDatabaseName', $sqlConnection)
+
+                    $sqlConnection.Open()
+                    $sqlDataAdapter = New-Object System.Data.SqlClient.SqlDataAdapter $sqlCommand
+                    $sqlDataSet = New-Object System.Data.DataSet
+                    $sqlDataAdapter.Fill($sqlDataSet) | Out-Null
+                    $sqlConnection.Close()
+
+                    $sqlDataSet.Tables[0].Rows[0].CurrentDatabaseName | Should -Be $ConfigurationData.AllNodes.DefaultDbName
+
+                    $script:CurrentDatabaseName = $sqlDataSet.Tables[0].Rows[0].CurrentDatabaseName
+                } | Should -Not -Throw
+
+                $script:CurrentDatabaseName | Should -Be $ConfigurationData.AllNodes.DefaultDbName
+
+                $script:CurrentDatabaseName = $null
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
         $configurationName = "$($script:dscResourceName)_AddLoginDscSqlUsers1_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {

--- a/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
@@ -514,30 +514,78 @@ try
                 } | Should -Not -Throw
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be 'True'
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -BeTrue
+                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -BeFalse
             }
 
-            It 'Should allow SQL Server, login username and password to connect to SQL Instance (using SqlConnection.Open())' {
-                $serverName = $ConfigurationData.AllNodes.ServerName
-                $instanceName = $ConfigurationData.AllNodes.InstanceName
-                $databaseName = $ConfigurationData.AllNodes.DefaultDbName
-                $userName = $ConfigurationData.AllNodes.DscUser4Name
-                $password = $ConfigurationData.AllNodes.DscUser4Pass1 # Original password
-
-                $sqlConnectionString = 'Data Source={0}\{1};User ID={2};Password={3};Connect Timeout=5;Database={4};' -f $serverName, $instanceName, $userName, $password, $databaseName
-
-                {
-                    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString
-                    $sqlConnection.Open()
-                    $sqlConnection.Close()
-                } | Should -Not -Throw
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
 
         Wait-ForIdleLcm -Clear
 
-        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforced"
+        # Reset LoginPasswordExpirationEnabled and LoginPasswordExpirationEnabled flags
+        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath                 = $TestDrive
+                        # The variable $ConfigurationData was dot-sourced above.
+                        ConfigurationData          = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
+                $resourceCurrentState.Disabled | Should -Be $false
+                $resourceCurrentState.LoginMustChangePassword | Should -Be $false # Left the same as this cannot be updated
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -Be $false
+                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -Be $false
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforced"
 
         Context ('When using configuration {0} (to update back to original password)' -f $configurationName) {
             It 'Should re-compile and re-apply the MOF without throwing' {
@@ -569,24 +617,21 @@ try
                 } | Should -Not -Throw
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be 'True'
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure | Should -Be 'Present'
+                $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.DscUser4Name
+                $resourceCurrentState.LoginType | Should -Be $ConfigurationData.AllNodes.DscUser4Type
+                $resourceCurrentState.LoginPasswordExpirationEnabled | Should -BeFalse
+                $resourceCurrentState.LoginPasswordPolicyEnforced | Should -BeTrue
             }
 
-            It 'Should allow SQL Server, login username and password to connect to SQL Instance (using SqlConnection.Open())' {
-                $serverName = $ConfigurationData.AllNodes.ServerName
-                $instanceName = $ConfigurationData.AllNodes.InstanceName
-                $databaseName = $ConfigurationData.AllNodes.DefaultDbName
-                $userName = $ConfigurationData.AllNodes.DscUser4Name
-                $password = $ConfigurationData.AllNodes.DscUser4Pass1 # Original password
-
-                $sqlConnectionString = 'Data Source={0}\{1};User ID={2};Password={3};Connect Timeout=5;Database={4};' -f $serverName, $instanceName, $userName, $password, $databaseName
-
-                {
-                    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString
-                    $sqlConnection.Open()
-                    $sqlConnection.Close()
-                } | Should -Not -Throw
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
 

--- a/tests/Integration/DSC_SqlLogin.config.ps1
+++ b/tests/Integration/DSC_SqlLogin.config.ps1
@@ -312,6 +312,58 @@ Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config
 
 <#
     .SYNOPSIS
+        Updates a SQL login, sets LoginPasswordExpirationEnabled to $true
+#>
+Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordExpirationEnabled
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlLogin 'Integration_Test'
+        {
+            Ensure                         = 'Present'
+            Name                           = $Node.DscUser4Name
+            LoginPasswordExpirationEnabled = $true
+
+            ServerName                     = $Node.ServerName
+            InstanceName                   = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Updates a SQL login, sets LoginPasswordPolicyEnforced to $true
+#>
+Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforced
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlLogin 'Integration_Test'
+        {
+            Ensure                         = 'Present'
+            Name                           = $Node.DscUser4Name
+            LoginPasswordPolicyEnforced    = $true
+
+            ServerName                     = $Node.ServerName
+            InstanceName                   = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
         Adds a Windows Group login.
 #>
 Configuration DSC_SqlLogin_AddLoginDscSqlUsers1_Config

--- a/tests/Integration/DSC_SqlLogin.config.ps1
+++ b/tests/Integration/DSC_SqlLogin.config.ps1
@@ -324,6 +324,7 @@ Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordExpirationEna
         {
             Ensure                         = 'Present'
             Name                           = $Node.DscUser4Name
+            LoginType                      = $Node.DscUser4Type
             LoginPasswordExpirationEnabled = $true
 
             ServerName                     = $Node.ServerName
@@ -350,6 +351,7 @@ Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforce
         {
             Ensure                         = 'Present'
             Name                           = $Node.DscUser4Name
+            LoginType                      = $Node.DscUser4Type
             LoginPasswordPolicyEnforced    = $true
 
             ServerName                     = $Node.ServerName

--- a/tests/Integration/DSC_SqlLogin.config.ps1
+++ b/tests/Integration/DSC_SqlLogin.config.ps1
@@ -41,6 +41,11 @@ else
                 DscUser4Type     = 'SqlLogin'
                 DscUser4Role     = 'sysadmin'
 
+                DscUser5Name     = 'DscUser5'
+                DscUser5Pass     = 'P@ssw0rd1'
+                DscUser5Type     = 'SqlLogin'
+                DscUser5Role     = 'sysadmin'
+
                 DscSqlUsers1Name = ('{0}\{1}' -f $env:COMPUTERNAME, 'DscSqlUsers1')
                 DscSqlUsers1Type = 'WindowsGroup'
 
@@ -360,6 +365,77 @@ Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforce
             PsDscRunAsCredential = New-Object `
                 -TypeName System.Management.Automation.PSCredential `
                 -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Adds a SQL login with default password parameters.
+#>
+Configuration DSC_SqlLogin_AddLoginDscUser5_Config
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlLogin 'Integration_Test'
+        {
+            Ensure                         = 'Present'
+            Name                           = $Node.DscUser5Name
+            LoginType                      = $Node.DscUser5Type
+
+            LoginCredential                = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.DscUser5Name, (ConvertTo-SecureString -String $Node.DscUser5Pass -AsPlainText -Force))
+
+            DefaultDatabase                = $Node.DefaultDbName
+
+            ServerName                     = $Node.ServerName
+            InstanceName                   = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
+        }
+
+        # Database user is also added so the connection into database (using the login) can be tested
+        SqlDatabaseUser 'Integration_Test_DatabaseUser'
+        {
+            ServerName                     = $Node.ServerName
+            InstanceName                   = $Node.InstanceName
+
+            DatabaseName                   = $Node.DefaultDbName
+            Name                           = $Node.DscUser5Name
+            UserType                       = 'Login'
+            LoginName                      = $Node.DscUser5Name
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
+
+            DependsOn = @(
+                '[SqlLogin]Integration_Test'
+            )
+        }
+
+        SqlRole 'Integration_Test_SqlRole'
+        {
+            Ensure               = 'Present'
+            ServerRoleName       = $Node.DscUser5Role
+            ServerName           = $Node.ServerName
+            InstanceName         = $Node.InstanceName
+            MembersToInclude     = @(
+                $Node.DscUser5Name
+            )
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
+
+            DependsOn = @(
+                '[SqlDatabaseUser]Integration_Test_DatabaseUser'
+            )
         }
     }
 }

--- a/tests/Integration/DSC_SqlLogin.config.ps1
+++ b/tests/Integration/DSC_SqlLogin.config.ps1
@@ -317,33 +317,6 @@ Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config
 
 <#
     .SYNOPSIS
-        Updates a SQL login, sets LoginPasswordExpirationEnabled to $true
-#>
-Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordExpirationEnabled
-{
-    Import-DscResource -ModuleName 'SqlServerDsc'
-
-    node $AllNodes.NodeName
-    {
-        SqlLogin 'Integration_Test'
-        {
-            Ensure                         = 'Present'
-            Name                           = $Node.DscUser4Name
-            LoginType                      = $Node.DscUser4Type
-            LoginPasswordExpirationEnabled = $true
-
-            ServerName                     = $Node.ServerName
-            InstanceName                   = $Node.InstanceName
-
-            PsDscRunAsCredential = New-Object `
-                -TypeName System.Management.Automation.PSCredential `
-                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
-        }
-    }
-}
-
-<#
-    .SYNOPSIS
         Updates a SQL login, sets LoginPasswordPolicyEnforced to $true
 #>
 Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforced
@@ -358,6 +331,33 @@ Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordPolicyEnforce
             Name                           = $Node.DscUser4Name
             LoginType                      = $Node.DscUser4Type
             LoginPasswordPolicyEnforced    = $true
+
+            ServerName                     = $Node.ServerName
+            InstanceName                   = $Node.InstanceName
+
+            PsDscRunAsCredential = New-Object `
+                -TypeName System.Management.Automation.PSCredential `
+                -ArgumentList @($Node.Admin_UserName, (ConvertTo-SecureString -String $Node.Admin_Password -AsPlainText -Force))
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Updates a SQL login, sets LoginPasswordExpirationEnabled to $true
+#>
+Configuration DSC_SqlLogin_UpdateLoginDscUser4_Config_LoginPasswordExpirationEnabled
+{
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node $AllNodes.NodeName
+    {
+        SqlLogin 'Integration_Test'
+        {
+            Ensure                         = 'Present'
+            Name                           = $Node.DscUser4Name
+            LoginType                      = $Node.DscUser4Type
+            LoginPasswordExpirationEnabled = $true
 
             ServerName                     = $Node.ServerName
             InstanceName                   = $Node.InstanceName


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlLogin
  - `LoginMustChangePassword`, `LoginPasswordExpirationEnabled` and `LoginPasswordPolicyEnforced`
    parameters no longer enforce default values (issue #1669).


#### This Pull Request (PR) fixes the following issues

- Fixes #1669 


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1696)
<!-- Reviewable:end -->
