### PR TITLE
SqlAgDatabase: Fixes Issue #1743

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Changes to SqlAGDatabase
+  - Added StatementTimeout parameter with value 0 (no timeout) to Connect-SQL invocation in Set-TargetResource function to fix Issue#1743
+    This prevents timeout during backup operation on secondary.
+
 ### Removed
 
 - The deprecated DSC resource SqlDatabaseOwner have been removed _(and replaced_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Changes to SqlAGDatabase
-  - Added StatementTimeout parameter with value 0 (no timeout) to Connect-SQL invocation in Set-TargetResource function to fix Issue#1743
-    This prevents timeout during backup operation on secondary.
+  - Added StatementTimeout optional parameter with default value of 600 seconds (10 mins) to SqlAGDatabase to fix Issue#1743
+    Users will be able to specify the backup and restore timeout with it.
 
 ### Removed
 

--- a/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
+++ b/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
@@ -204,7 +204,7 @@ function Set-TargetResource
     Import-SQLPSModule
 
     # Connect to the defined instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -StatementTimeout 0
 
     # Get the Availability Group
     $availabilityGroup = $serverObject.AvailabilityGroups[$AvailabilityGroupName]
@@ -576,7 +576,6 @@ function Set-TargetResource
                         $restoreLogQueryStringBuilder.AppendLine() | Out-Null
                         $restoreLogQueryStringBuilder.Append('REVERT') | Out-Null
                     }
-
                     $restoreLogQueryString = $restoreLogQueryStringBuilder.ToString()
                 }
 

--- a/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
+++ b/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
@@ -153,6 +153,9 @@ function Get-TargetResource
     .PARAMETER ProcessOnlyOnActiveNode
         Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
         Not used in Set-TargetResource.
+
+    .PARAMETER StatementTimeout
+        Set the query StatementTimeout in seconds. Default 600 seconds (10mins).
 #>
 function Set-TargetResource
 {
@@ -198,13 +201,18 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $ProcessOnlyOnActiveNode
+        $ProcessOnlyOnActiveNode,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Int32]
+        $StatementTimeout = 600
     )
 
     Import-SQLPSModule
 
     # Connect to the defined instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -StatementTimeout 0
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -StatementTimeout $StatementTimeout
 
     # Get the Availability Group
     $availabilityGroup = $serverObject.AvailabilityGroups[$AvailabilityGroupName]
@@ -591,8 +599,8 @@ function Set-TargetResource
                         if ( $availabilityGroupReplica.SeedingMode -eq 'MANUAL')
                         {
                             # Restore the database
-                            Invoke-Query -ServerName $currentAvailabilityGroupReplicaServerObject.NetName -InstanceName $currentAvailabilityGroupReplicaServerObject.ServiceName -Database master -Query $restoreDatabaseQueryString -StatementTimeout 0
-                            Invoke-Query -ServerName $currentAvailabilityGroupReplicaServerObject.NetName -InstanceName $currentAvailabilityGroupReplicaServerObject.ServiceName -Database master -Query $restoreLogQueryString -StatementTimeout 0
+                            Invoke-Query -ServerName $currentAvailabilityGroupReplicaServerObject.NetName -InstanceName $currentAvailabilityGroupReplicaServerObject.ServiceName -Database master -Query $restoreDatabaseQueryString -StatementTimeout $StatementTimeout
+                            Invoke-Query -ServerName $currentAvailabilityGroupReplicaServerObject.NetName -InstanceName $currentAvailabilityGroupReplicaServerObject.ServiceName -Database master -Query $restoreLogQueryString -StatementTimeout $StatementTimeout
                         }
 
                         # Add the database to the Availability Group
@@ -713,6 +721,9 @@ function Set-TargetResource
 
     .PARAMETER ProcessOnlyOnActiveNode
         Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
+
+    .PARAMETER StatementTimeout
+        Set the query StatementTimeout in seconds. Default 600 seconds (10mins).
 #>
 function Test-TargetResource
 {
@@ -759,7 +770,12 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $ProcessOnlyOnActiveNode
+        $ProcessOnlyOnActiveNode,
+
+        [Parameter()]
+        [ValidateNotNull()]
+        [System.Int32]
+        $StatementTimeout = 600
     )
 
     $configurationInDesiredState = $true

--- a/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.schema.mof
+++ b/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.schema.mof
@@ -11,5 +11,6 @@ class DSC_SqlAGDatabase : OMI_BaseResource
     [Write, Description("If set to `$true`, this ensures the database owner of the database on the primary replica is the owner of the database on all secondary replicas. This requires the database owner is available as a login on all replicas and that the **PsDscRunAsCredential** has _impersonate any login_, _control server_, _impersonate login_, or _control login_ permissions. If set to `$false`, the owner of the database will be the username specified in **PsDscRunAsCredential**. The default is `$false`.")] Boolean MatchDatabaseOwner;
     [Write, Description("If set to `$true`, this adds the restore option `WITH REPLACE`. If set to `$false`, existing databases and files will block the restore and throw error. The default is `$false`.")] Boolean ReplaceExisting;
     [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the _SQL Server_ instance.")] Boolean ProcessOnlyOnActiveNode;
+    [Write, Description("Set the query timeout in seconds for the backup and restore operations. The default is 600 seconds (10mins).")] SInt32 StatementTimeout;
     [Read, Description("Returns if the current node is actively hosting the _SQL Server_ instance.")] Boolean IsActiveNode;
 };

--- a/source/DSCResources/DSC_SqlAGDatabase/en-US/about_SqlAGDatabase.help.txt
+++ b/source/DSCResources/DSC_SqlAGDatabase/en-US/about_SqlAGDatabase.help.txt
@@ -48,4 +48,7 @@ PARAMETER MatchDatabaseOwner
     The default is '$false'.
 
 .PARAMETER ProcessOnlyOnActiveNode
-        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
+    Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server Instance.
+
+.PARAMETER StatementTimeout
+    Set the query StatementTimeout in seconds. Default 600 seconds (10mins).

--- a/source/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
+++ b/source/Examples/Resources/SqlAGDatabase/1-AddDatabaseToAvailabilityGroup.ps1
@@ -1,7 +1,7 @@
 <#
     .DESCRIPTION
         This example shows how to ensure that the databases 'DB*' and 'AdventureWorks'
-        are members in the Availability Group 'TestAG'.
+        are members of the Availability Group 'TestAG'.
 
         In the event this is applied to a Failover Cluster Instance (FCI), the
         ProcessOnlyOnActiveNode property will tell the Test-TargetResource function

--- a/source/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
+++ b/source/Examples/Resources/SqlAGDatabase/3-MatchDefinedDatabaseInAvailabilityGroup.ps1
@@ -1,7 +1,7 @@
 <#
     .DESCRIPTION
         This example shows how to ensure that the databases 'DB*' and 'AdventureWorks'
-        'are the only members of the Availability Group 'TestAG'.
+        are the only members of the Availability Group 'TestAG'.
 #>
 
 Configuration Example


### PR DESCRIPTION
#### Pull Request (PR) description

- Changes to SqlAGDatabase
  - Added StatementTimeout parameter with value 0 (no timeout) to Connect-SQL invocation in Set-TargetResource function to fix Issue#1743
    This prevents timeout during backup operation on secondary.

#### This Pull Request (PR) fixes the following issues

- Fixes #1743

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [x] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1744)
<!-- Reviewable:end -->
