### PR TITLE
SqlDatabaseUser: Execute Set-TargetResource when database IsUpdateable is $true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes to SqlAGDatabase
   - Added StatementTimeout optional parameter with default value of 600 seconds (10 mins) to SqlAGDatabase to fix Issue#1743
     Users will be able to specify the backup and restore timeout with it.
+- Changes to SqlDatabaseUser
+  - `Test-TargetResource` returns true if the `IsUpdateable` property of the database is `$false` to resolve Issue#1748.
 
 ### Removed
 

--- a/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
@@ -530,7 +530,7 @@ function Test-TargetResource
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
-    if ( $getTargetResourceResult.DatabaseIsUpdateable -eq $false )
+    if ( $false -eq $getTargetResourceResult.DatabaseIsUpdateable )
     {
         $testTargetResourceReturnValue = $true
     }

--- a/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
@@ -54,17 +54,18 @@ function Get-TargetResource
     )
 
     $returnValue = @{
-        Ensure             = 'Absent'
-        Name               = $Name
-        ServerName         = $ServerName
-        InstanceName       = $InstanceName
-        DatabaseName       = $DatabaseName
-        LoginName          = $null
-        AsymmetricKeyName  = $null
-        CertificateName    = $null
-        UserType           = $null
-        AuthenticationType = $null
-        LoginType          = $null
+        Ensure               = 'Absent'
+        Name                 = $Name
+        ServerName           = $ServerName
+        InstanceName         = $InstanceName
+        DatabaseName         = $DatabaseName
+        DatabaseIsUpdateable = $null
+        LoginName            = $null
+        AsymmetricKeyName    = $null
+        CertificateName      = $null
+        UserType             = $null
+        AuthenticationType   = $null
+        LoginType            = $null
     }
 
     # Check if database exists.
@@ -72,6 +73,7 @@ function Get-TargetResource
 
     if ($sqlDatabaseObject)
     {
+        $returnValue['DatabaseIsUpdateable'] = $sqlDatabaseObject.IsUpdateable
         $sqlUserObject = $sqlDatabaseObject.Users[$Name]
 
         if ($sqlUserObject)
@@ -528,7 +530,11 @@ function Test-TargetResource
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
-    if ($getTargetResourceResult.Ensure -eq $Ensure)
+    if ( $getTargetResourceResult.DatabaseIsUpdateable -eq $false )
+    {
+        $testTargetResourceReturnValue = $true
+    }
+    elseif ($getTargetResourceResult.Ensure -eq $Ensure)
     {
         if ($Ensure -eq 'Present')
         {
@@ -870,4 +876,3 @@ function Assert-DatabaseAsymmetricKey
         New-ObjectNotFoundException -Message $errorMessage
     }
 }
-

--- a/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.schema.mof
@@ -13,4 +13,5 @@ class DSC_SqlDatabaseUser : OMI_BaseResource
     [Write, Description("Specifies if it is allowed to re-create the database user if either the user type, the asymmetric key, or the certificate changes. Default value is `$false` not allowing database users to be re-created.")] Boolean Force;
     [Read, Description("Returns the authentication type of the login connected to the database user. This will return either `'Windows'`, `'Instance'`, or `'None'`. The value `'Windows'` means the login is using _Windows Authentication_, `'Instance'` means that the login is using _SQL Authentication_, and `'None'` means that the database user have no login connected to it.")] String AuthenticationType;
     [Read, Description("Returns the login type of the login connected to the database user. If no login is connected to the database user this returns `$null`.")] String LoginType;
+    [Read, Description("Returns if the database is updatable. If the database is updatable, this will return `$true`. Otherwise it will return `$false`.")] Boolean DatabaseIsUpdateable;
 };

--- a/source/DSCResources/DSC_SqlDatabaseUser/README.md
+++ b/source/DSCResources/DSC_SqlDatabaseUser/README.md
@@ -3,7 +3,8 @@
 The `SqlDatabaseUser` DSC resource is used to create database users.
 A database user can be created with or without a login, and a database
 user can be mapped to a certificate or asymmetric key. The resource also
-allows re-mapping of the SQL login.
+allows re-mapping of the SQL login. If the targeted database is not updatable,
+the resource returns true.
 
 > **Note:** This resource does not yet support [Contained Databases](https://docs.microsoft.com/en-us/sql/relational-databases/databases/contained-databases).
 

--- a/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
@@ -48,6 +48,7 @@ try
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockDatabaseName = 'TestDB'
+        $mockDatabaseIsUpdateable = $true
         $mockLoginName = 'CONTOSO\Login1'
         $mockAsymmetricKeyName = 'AsymmetricKey1'
         $mockCertificateName = 'Certificate1'
@@ -75,7 +76,7 @@ try
                                 @{
                                     $mockDatabaseName = New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $mockDatabaseIsUpdateable -PassThru |
                                     Add-Member -MemberType ScriptProperty -Name 'Users' -Value {
                                         return @(
                                             @{
@@ -131,6 +132,11 @@ try
                         $getTargetResourceResult.LoginType | Should -BeNullOrEmpty
                         $getTargetResourceResult.UserType | Should -BeNullOrEmpty
                     }
+
+                    It 'Should return $true for the property DatabaseIsUpdateable' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+                        $getTargetResourceResult.DatabaseIsUpdateable | Should -Be $true
+                    }
                 }
 
                 Context 'When the configuration is present' {
@@ -159,6 +165,11 @@ try
                         $getTargetResourceResult.AuthenticationType | Should -Be $mockAuthenticationType
                         $getTargetResourceResult.LoginType | Should -Be 'WindowsUser'
                         $getTargetResourceResult.UserType | Should -Be $mockUserType
+                    }
+
+                    It 'Should return $true for the property DatabaseIsUpdateable' {
+                        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+                        $getTargetResourceResult.DatabaseIsUpdateable | Should -Be $true
                     }
                 }
             }
@@ -195,17 +206,18 @@ try
                     BeforeAll {
                         Mock -CommandName Get-TargetResource -MockWith {
                             return @{
-                                Ensure             = 'Absent'
-                                Name               = $mockName
-                                ServerName         = $mockServerName
-                                InstanceName       = $mockInstanceName
-                                DatabaseName       = $mockDatabaseName
-                                LoginName          = $null
-                                AsymmetricKeyName  = $null
-                                CertificateName    = $null
-                                UserType           = $null
-                                AuthenticationType = $null
-                                LoginType          = $null
+                                Ensure               = 'Absent'
+                                Name                 = $mockName
+                                ServerName           = $mockServerName
+                                InstanceName         = $mockInstanceName
+                                DatabaseName         = $mockDatabaseName
+                                DatabaseIsUpdateable = $mockDatabaseIsUpdateable
+                                LoginName            = $null
+                                AsymmetricKeyName    = $null
+                                CertificateName      = $null
+                                UserType             = $null
+                                AuthenticationType   = $null
+                                LoginType            = $null
                             }
                         }
 
@@ -225,17 +237,18 @@ try
                     BeforeAll {
                         Mock -CommandName Get-TargetResource -MockWith {
                             return @{
-                                Ensure             = 'Present'
-                                Name               = $mockName
-                                ServerName         = $mockServerName
-                                InstanceName       = $mockInstanceName
-                                DatabaseName       = $mockDatabaseName
-                                LoginName          = $mockLoginName
-                                AsymmetricKeyName  = $null
-                                CertificateName    = $null
-                                UserType           = $mockUserType
-                                AuthenticationType = $mockAuthenticationType
-                                LoginType          = $mockLoginType
+                                Ensure               = 'Present'
+                                Name                 = $mockName
+                                ServerName           = $mockServerName
+                                InstanceName         = $mockInstanceName
+                                DatabaseName         = $mockDatabaseName
+                                DatabaseIsUpdateable = $mockDatabaseIsUpdateable
+                                LoginName            = $mockLoginName
+                                AsymmetricKeyName    = $null
+                                CertificateName      = $null
+                                UserType             = $mockUserType
+                                AuthenticationType   = $mockAuthenticationType
+                                LoginType            = $mockLoginType
                             }
                         }
 
@@ -373,6 +386,71 @@ try
 
                             Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
                         }
+                    }
+                }
+            }
+
+            Context 'When the database is not updatable' {
+                Context 'When the configuration is absent' {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Ensure               = 'Absent'
+                                Name                 = $mockName
+                                ServerName           = $mockServerName
+                                InstanceName         = $mockInstanceName
+                                DatabaseName         = $mockDatabaseName
+                                DatabaseIsUpdateable = $false
+                                LoginName            = $null
+                                AsymmetricKeyName    = $null
+                                CertificateName      = $null
+                                UserType             = $null
+                                AuthenticationType   = $null
+                                LoginType            = $null
+                            }
+                        }
+
+                        $testTargetResourceParameters = $mockDefaultParameters.Clone()
+                        $testTargetResourceParameters['Ensure'] = 'Absent'
+                    }
+
+                    It 'Should return the state as $true' {
+                        $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                        $testTargetResourceResult | Should -Be $true
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
+                    }
+                }
+
+                Context 'When the configuration is present' {
+                    BeforeAll {
+                        Mock -CommandName Get-TargetResource -MockWith {
+                            return @{
+                                Ensure               = 'Present'
+                                Name                 = $mockName
+                                ServerName           = $mockServerName
+                                InstanceName         = $mockInstanceName
+                                DatabaseName         = $mockDatabaseName
+                                DatabaseIsUpdateable = $false
+                                LoginName            = $mockLoginName
+                                AsymmetricKeyName    = $null
+                                CertificateName      = $null
+                                UserType             = $mockUserType
+                                AuthenticationType   = $mockAuthenticationType
+                                LoginType            = $mockLoginType
+                            }
+                        }
+
+                        $testTargetResourceParameters = $mockDefaultParameters.Clone()
+                        $testTargetResourceParameters['UserType'] = $mockUserType
+                        $testTargetResourceParameters['LoginName'] = $mockLoginName
+                    }
+
+                    It 'Should return the state as $true' {
+                        $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
+                        $testTargetResourceResult | Should -Be $true
+
+                        Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
                     }
                 }
             }
@@ -1088,7 +1166,7 @@ try
                             @{
                                 $mockDatabaseName = New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
-                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $mockDatabaseIsUpdateable -PassThru |
                                 Add-Member -MemberType ScriptProperty -Name 'Certificates' -Value {
                                     return @(
                                         @{
@@ -1139,7 +1217,7 @@ try
                             @{
                                 $mockDatabaseName = New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
-                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $mockDatabaseIsUpdateable -PassThru |
                                 Add-Member -MemberType ScriptProperty -Name 'AsymmetricKeys' -Value {
                                     return @(
                                         @{

--- a/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
@@ -75,7 +75,7 @@ try
                                 @{
                                     $mockDatabaseName = New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
-                                    Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true |
+                                    Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true -PassThru |
                                     Add-Member -MemberType ScriptProperty -Name 'Users' -Value {
                                         return @(
                                             @{

--- a/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
@@ -1088,7 +1088,7 @@ try
                             @{
                                 $mockDatabaseName = New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
-                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true |
+                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true -PassThru |
                                 Add-Member -MemberType ScriptProperty -Name 'Certificates' -Value {
                                     return @(
                                         @{
@@ -1139,7 +1139,7 @@ try
                             @{
                                 $mockDatabaseName = New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
-                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true |
+                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true -PassThru |
                                 Add-Member -MemberType ScriptProperty -Name 'AsymmetricKeys' -Value {
                                     return @(
                                         @{

--- a/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
@@ -75,6 +75,7 @@ try
                                 @{
                                     $mockDatabaseName = New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true |
                                     Add-Member -MemberType ScriptProperty -Name 'Users' -Value {
                                         return @(
                                             @{
@@ -1087,6 +1088,7 @@ try
                             @{
                                 $mockDatabaseName = New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true |
                                 Add-Member -MemberType ScriptProperty -Name 'Certificates' -Value {
                                     return @(
                                         @{
@@ -1137,6 +1139,7 @@ try
                             @{
                                 $mockDatabaseName = New-Object -TypeName Object |
                                 Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockDatabaseName -PassThru |
+                                Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $true |
                                 Add-Member -MemberType ScriptProperty -Name 'AsymmetricKeys' -Value {
                                     return @(
                                         @{


### PR DESCRIPTION
#### Pull Request (PR) description
Retrieved the `IsUpdateable` property from the database object. If `IsUpdateable` is `$false`, then `Test-TargetResource` returns `$true`

#### This Pull Request (PR) fixes the following issues
- Fixes #1748

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1749)
<!-- Reviewable:end -->
