### PR TITLE
SqlDatabaseRole: Execute Set-TargetResource when database IsUpdateable is $true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Users will be able to specify the backup and restore timeout with it.
 - Changes to SqlDatabaseUser
   - `Test-TargetResource` returns true if the `IsUpdateable` property of the database is `$false` to resolve Issue#1748.
+- Changes to SqlDatabaseRole
+  - `Test-TargetResource` returns true if the `IsUpdateable` property of the database is `$false` to resolve Issue#1750.
 
 ### Removed
 

--- a/source/DSCResources/DSC_SqlDatabaseRole/DSC_SqlDatabaseRole.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseRole/DSC_SqlDatabaseRole.schema.mof
@@ -10,4 +10,5 @@ class DSC_SqlDatabaseRole : OMI_BaseResource
     [Write, Description("The members the database role should exclude. This parameter will only remove members from a database role. Will only be used when parameter **Ensure** is set to `'Present'`. Can not be used at the same time as parameter **Members**.")] String MembersToExclude[];
     [Write, Description("If `'Present'` then the role will be added to the database and the role membership will be set. If `'Absent'` then the role will be removed from the database. Default value is `'Present'`."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Read, Description("Returns whether the database role members are in the desired state.")] Boolean MembersInDesiredState;
+    [Read, Description("Returns if the database is updatable. If the database is updatable, this will return `$true`. Otherwise it will return `$false`.")] Boolean DatabaseIsUpdateable;
 };

--- a/source/DSCResources/DSC_SqlDatabaseRole/README.md
+++ b/source/DSCResources/DSC_SqlDatabaseRole/README.md
@@ -3,7 +3,8 @@
 The `SqlDatabaseRole` DSC resource is used to create a database role when
 Ensure is set to 'Present' or remove a database role when Ensure is set to
 'Absent'. The resource also manages members in both built-in and user
-created database roles.
+created database roles. If the targeted database is not updatable, the resource
+returns true.
 
 ## Requirements
 

--- a/tests/Unit/DSC_SqlDatabaseRole.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseRole.Tests.ps1
@@ -48,6 +48,7 @@ try
         $mockServerName = 'localhost'
         $mockInstanceName = 'MSSQLSERVER'
         $mockSqlDatabaseName = 'AdventureWorks'
+        $mockDatabaseIsUpdateable = $true
 
         $mockSqlServerLogin1 = 'John'
         $mockSqlServerLogin1Type = 'WindowsUser'
@@ -91,6 +92,7 @@ try
                             $mockSqlDatabaseName = @((
                                     New-Object -TypeName Object |
                                     Add-Member -MemberType NoteProperty -Name Name -Value $mockSqlDatabaseName -PassThru |
+                                    Add-Member -MemberType NoteProperty -Name 'IsUpdateable' -Value $mockDatabaseIsUpdateable -PassThru |
                                     Add-Member -MemberType ScriptProperty -Name Users -Value {
                                         return @{
                                             $mockSqlServerLogin1 = @((
@@ -274,6 +276,7 @@ try
 
         Describe 'DSC_SqlDatabaseRole\Get-TargetResource' -Tag 'Get' {
             BeforeEach {
+                $mockDatabaseIsUpdateable = $true
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
 
@@ -292,6 +295,47 @@ try
 
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+            }
+
+            Context 'When role does not exist and the database is not updatable' {
+                $testParameters = $mockDefaultParameters
+                $testParameters += @{
+                    DatabaseName = $mockSqlDatabaseName
+                    Name         = 'UnknownRoleName'
+                }
+
+                BeforeEach {
+                    $mockDatabaseIsUpdateable = $false
+                }
+
+                It 'Should return the state as Absent' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Ensure | Should -Be 'Absent'
+
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return the members as null' {
+                    $result = Get-TargetResource @testParameters
+                    $result.Members | Should -BeNullOrEmpty
+
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return the same values as passed as parameters' {
+                    $result = Get-TargetResource @testParameters
+                    $result.ServerName | Should -Be $testParameters.ServerName
+                    $result.InstanceName | Should -Be $testParameters.InstanceName
+                    $result.DatabaseName | Should -Be $testParameters.DatabaseName
+                    $result.Name | Should -Be $testParameters.Name
+
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $false
                 }
             }
 
@@ -325,6 +369,11 @@ try
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                 }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
+                }
             }
 
             Context 'When only key parameters have values and the role exists' {
@@ -343,6 +392,11 @@ try
 
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
+                }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
                 }
             }
 
@@ -411,6 +465,11 @@ try
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                 }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
+                }
             }
 
             Context 'When parameter Members is assigned a value, the role exists, and the role members are not in the desired state' {
@@ -440,6 +499,11 @@ try
                     ($result.Members -is [System.String[]]) | Should -Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
                 }
             }
 
@@ -509,6 +573,11 @@ try
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                 }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
+                }
             }
 
             Context 'When parameter MembersToInclude is assigned a value, the role exists, and the role members are not in the desired state' {
@@ -539,6 +608,11 @@ try
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                 }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
+                }
             }
 
             Context 'When both parameters MembersToExclude and Members are assigned a value' {
@@ -559,7 +633,6 @@ try
                 It 'Should call the mock function Connect-SQL' {
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope Context
                 }
-
             }
 
             Context 'When parameter MembersToExclude is assigned a value, the role exists, and the role members are in the desired state' {
@@ -594,6 +667,11 @@ try
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                 }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
+                }
             }
 
             Context 'When parameter MembersToExclude is assigned a value, the role exists, and the role members are not in the desired state' {
@@ -623,6 +701,11 @@ try
                     ($result.Members -is [System.String[]]) | Should -Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                }
+
+                It 'Should return $true for the property DatabaseIsUpdateable' {
+                    $result = Get-TargetResource @testParameters
+                    $result.DatabaseIsUpdateable | Should -Be $true
                 }
             }
 
@@ -886,6 +969,7 @@ try
 
         Describe "DSC_SqlDatabaseRole\Test-TargetResource" -Tag 'Test' {
             BeforeEach {
+                $mockDatabaseIsUpdateable = $true
                 Mock -CommandName Connect-SQL -MockWith $mockConnectSQL -Verifiable
             }
 
@@ -905,8 +989,28 @@ try
                 }
             }
 
+            Context 'When the system is not in the desired state and Ensure is set to Absent and the database is not updateable' {
+                BeforeEach {
+                    $mockDatabaseIsUpdateable = $false
+                }
+
+                It 'Should return True when the desired database role exists' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        DatabaseName = $mockSqlDatabaseName
+                        Name         = $mockSqlDatabaseRole1
+                        Ensure       = 'Absent'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
+
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
             Context 'When the system is not in the desired state and Ensure is set to Present' {
-                It 'Should return True when the desired database role does not exist' {
+                It 'Should return False when the desired database role does not exist' {
                     $testParameters = $mockDefaultParameters
                     $testParameters += @{
                         DatabaseName = $mockSqlDatabaseName
@@ -916,6 +1020,26 @@ try
 
                     $result = Test-TargetResource @testParameters
                     $result | Should -Be $false
+
+                    Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
+                }
+            }
+
+            Context 'When the system is not in the desired state and Ensure is set to Present and the database is not updateable' {
+                BeforeEach {
+                    $mockDatabaseIsUpdateable = $false
+                }
+
+                It 'Should return True when the desired database role does not exist' {
+                    $testParameters = $mockDefaultParameters
+                    $testParameters += @{
+                        DatabaseName = $mockSqlDatabaseName
+                        Name         = $mockSqlDatabaseRole3
+                        Ensure       = 'Present'
+                    }
+
+                    $result = Test-TargetResource @testParameters
+                    $result | Should -Be $true
 
                     Assert-MockCalled -CommandName Connect-SQL -Exactly -Times 1 -Scope It
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
Retrieved the `IsUpdateable` property from the database object. If `IsUpdateable` is `$false`, then `Test-TargetResource` returns `$true`.

#### This Pull Request (PR) fixes the following issues
- Fixes #1750

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1751)
<!-- Reviewable:end -->
