### PR TITLE
SqlSetup: SourcePath should be a mandatory parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     that was not available.
   - The loop that evaluates what features are installed did an unnecessary
     step for each iteration. A line of code was moved outside of the loop.
+  - The `SourcePath` parameter is now mandatory for all `*-TargetResource`
+    ([issue #1755](https://github.com/dsccommunity/SqlServerDsc/issues/1755)).
 
 ## [15.2.0] - 2021-09-01
 

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -58,7 +58,7 @@ function Get-TargetResource
         [System.String]
         $Action = 'Install',
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $SourcePath,
 
@@ -663,7 +663,7 @@ function Set-TargetResource
         [System.String]
         $Action = 'Install',
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $SourcePath,
 
@@ -1875,7 +1875,7 @@ function Test-TargetResource
         [System.String]
         $Action = 'Install',
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $SourcePath,
 

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
@@ -2,7 +2,7 @@
 class DSC_SqlSetup : OMI_BaseResource
 {
     [Write, Description("The action to be performed. Default value is `'Install'`. **NOTE: AddNode is not currently functional.**"), ValueMap{"Install","Upgrade","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}, Values{"Install","Upgrade","InstallFailoverCluster","AddNode","PrepareFailoverCluster","CompleteFailoverCluster"}] String Action;
-    [Write, Description("The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.")] String SourcePath;
+    [Required, Description("The path to the root of the source files for installation. I.e and UNC path to a shared resource. Environment variables can be used in the path.")] String SourcePath;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Credentials used to access the path set in the parameter **SourcePath**. See section [Considerations](#considerations) regarding the parameter **SourceCredential**.")] String SourceCredential;
     [Write, Description("Suppresses reboot.")] Boolean SuppressReboot;
     [Write, Description("Forces reboot.")] Boolean ForceReboot;


### PR DESCRIPTION
#### Pull Request (PR) description
SourcePath should be a mandatory parameter on the *-TargetResource
functions, as an exception is thrown if the parameter is not passed.

#### This Pull Request (PR) fixes the following issues
- Fixes #1755 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1756)
<!-- Reviewable:end -->
