### PR TITLE
BREAKING CHANGE: SQLAlwaysOnService: Get-TargetResource should return Ensure=Absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlDatabaseRole
   - `Test-TargetResource` returns true if the `IsUpdateable` property of the
     database is `$false` to resolve issue #1750.
+- SqlAlwaysOnService
+  - BREAKING CHANGE: The parameter `IsHadrEnabled` is no longer returned by
+    `Get-TargetResource`. The `Ensure` parameter now returns `Present` if
+    Always On HADR is enabled and `Absent` if it is disabled.
 
 ### Fixed
 

--- a/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
+++ b/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
@@ -62,10 +62,12 @@ function Get-TargetResource
     if ($isAlwaysOnEnabled -eq $true)
     {
         $statusString = 'enabled'
+        $EnsureStatus = 'Present'
     }
     elseif ($isAlwaysOnEnabled -eq $false)
     {
         $statusString = 'disabled'
+        $EnsureStatus = 'Absent'
     }
 
     Write-Verbose -Message (
@@ -74,10 +76,9 @@ function Get-TargetResource
 
     return @{
         InstanceName   = $InstanceName
-        Ensure         = $Ensure
+        Ensure         = $EnsureStatus
         ServerName     = $ServerName
         RestartTimeout = $RestartTimeout
-        IsHadrEnabled  = $isAlwaysOnEnabled
     }
 }
 
@@ -244,7 +245,7 @@ function Test-TargetResource
 
     $isInDesiredState = $true
 
-    if ($state.IsHadrEnabled)
+    if ($state.Ensure -eq 'Present')
     {
         if ($Ensure -eq 'Present')
         {

--- a/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.schema.mof
+++ b/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.schema.mof
@@ -5,5 +5,4 @@ class DSC_SqlAlwaysOnService : OMI_BaseResource
     [Required, Description("An enumerated value that describes if the _SQL Server_ should have _Always On High Availability and Disaster Recovery_ (HADR) property enabled (`'Present'`) or disabled (`'Absent'`)."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("The hostname of the _SQL Server_ to be configured. Default value is the current computer name.")] String ServerName;
     [Write, Description("The length of time, in seconds, to wait for the service to restart. Default value is `120` seconds.")] UInt32 RestartTimeout;
-    [Read, Description("Returns the status of _AlwaysOn High Availability and Disaster Recovery_ (HADR).")] Boolean IsHadrEnabled;
 };

--- a/tests/Integration/DSC_SqlAlwaysOnService.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlAlwaysOnService.Integration.Tests.ps1
@@ -142,7 +142,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag 'Skip'  {
                 -and $_.ResourceId -eq $resourceId
             }
 
-            $resourceCurrentState.IsHadrEnabled | Should -Be $true
+            $resourceCurrentState.Ensure | Should -Be 'Present'
         }
 
         It 'Should return $true when Test-DscConfiguration is run' {
@@ -196,7 +196,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag 'Skip'  {
                 -and $_.ResourceId -eq $resourceId
             }
 
-            $resourceCurrentState.IsHadrEnabled | Should -Be $false
+            $resourceCurrentState.Ensure | Should -Be 'Absent'
         }
 
         It 'Should return $true when Test-DscConfiguration is run' {

--- a/tests/Unit/DSC_SqlAlwaysOnService.Tests.ps1
+++ b/tests/Unit/DSC_SqlAlwaysOnService.Tests.ps1
@@ -115,7 +115,7 @@ Describe 'SqlAlwaysOnService\Get-TargetResource' {
 
                         $result = Get-TargetResource @mockGetTargetResourceParameters
 
-                        $result.IsHadrEnabled | Should -BeFalse
+                        $result.Ensure | Should -Be 'Absent'
                     }
 
                     Should -Invoke -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -166,7 +166,7 @@ Describe 'SqlAlwaysOnService\Get-TargetResource' {
 
                         $result = Get-TargetResource @mockGetTargetResourceParameters
 
-                        $result.IsHadrEnabled | Should -BeTrue
+                        $result.Ensure | Should -Be 'Present'
                     }
 
                     Should -Invoke -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -230,7 +230,7 @@ Describe 'SqlAlwaysOnService\Get-TargetResource' {
                         # Get the current state
                         $result = Get-TargetResource @mockGetTargetResourceParameters
 
-                        $result.IsHadrEnabled | Should -BeFalse
+                        $result.Ensure | Should -Be 'Absent'
                     }
 
                     Should -Invoke -CommandName Connect-SQL -Scope It -Times 1 -Exactly
@@ -275,7 +275,6 @@ Describe 'SqlAlwaysOnService\Test-TargetResource' {
                             Ensure         = 'Absent'
                             ServerName     = 'Server01'
                             RestartTimeout = 120
-                            IsHadrEnabled  = $false
                         }
                     }
                 }
@@ -304,7 +303,6 @@ Describe 'SqlAlwaysOnService\Test-TargetResource' {
                             Ensure         = 'Present'
                             ServerName     = 'Server01'
                             RestartTimeout = 120
-                            IsHadrEnabled  = $true
                         }
                     }
                 }
@@ -346,7 +344,6 @@ Describe 'SqlAlwaysOnService\Test-TargetResource' {
                             Ensure         = 'Present'
                             ServerName     = 'Server01'
                             RestartTimeout = 120
-                            IsHadrEnabled  = $true
                         }
                     }
                 }
@@ -375,7 +372,6 @@ Describe 'SqlAlwaysOnService\Test-TargetResource' {
                             Ensure         = 'Absent'
                             ServerName     = 'Server01'
                             RestartTimeout = 120
-                            IsHadrEnabled  = $false
                         }
                     }
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
Remove IsHadrEnabled and return the state in Ensure.
Update Test-TargetResource to look at Ensure instead of IsHadrEnabled.
Update Tests to match.

#### This Pull Request (PR) fixes the following issues
- Fixes #1759

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1760)
<!-- Reviewable:end -->
