### PR TITLE
SqlAGListener: Add parameter `ProcessOnlyOnActiveNode` to make it cluster aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       no SQL module is found. The script-terminating error is caught and made into
       a statement-terminating error.
   - Bump GitHub Action Checkout to v4.
+- SqlAGListener
+  - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
+    the resource will only determine if a change is needed if the target node
+    is the active host of the SQL Server instance ([issue #871](https://github.com/dsccommunity/SqlServerDsc/issues/871)).
 
 ### Remove
 

--- a/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
+++ b/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
@@ -496,7 +496,7 @@ function Test-TargetResource
         If this is supposed to process only the active node, and this is not the
         active node, don't bother evaluating the test.
     #>
-    if ( $ProcessOnlyOnActiveNode -and -not $getTargetResourceResult.IsActiveNode )
+    if ( $ProcessOnlyOnActiveNode -and -not $IsActiveNode )
     {
         # Use localization if the resource has been converted
         New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME, $SQLInstanceName )

--- a/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
+++ b/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
@@ -24,7 +24,6 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 #>
 function Get-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Connect-Sql is called when Get-SQLAlwaysOnAvailabilityGroupListener is called')]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -51,13 +50,13 @@ function Get-TargetResource
         $script:localizedData.GetAvailabilityGroupListener -f $Name, $AvailabilityGroup, $InstanceName
     )
 
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
-
-    # Is this node actively hosting the SQL instance?
-    $isActiveNode = Test-ActiveNode -ServerObject $serverObject
-
     try
     {
+        $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+
+        # Is this node actively hosting the SQL instance?
+        $isActiveNode = Test-ActiveNode -ServerObject $serverObject
+
         $availabilityGroupListener = Get-SQLAlwaysOnAvailabilityGroupListener -Name $Name -AvailabilityGroup $AvailabilityGroup -ServerName $ServerName -InstanceName $InstanceName
 
         if ($null -ne $availabilityGroupListener)

--- a/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
+++ b/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
@@ -51,6 +51,11 @@ function Get-TargetResource
         $script:localizedData.GetAvailabilityGroupListener -f $Name, $AvailabilityGroup, $InstanceName
     )
 
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+
+    # Is this node actively hosting the SQL instance?
+    $isActiveNode = Test-ActiveNode -ServerObject $serverObject
+
     try
     {
         $availabilityGroupListener = Get-SQLAlwaysOnAvailabilityGroupListener -Name $Name -AvailabilityGroup $AvailabilityGroup -ServerName $ServerName -InstanceName $InstanceName
@@ -107,6 +112,7 @@ function Get-TargetResource
         IpAddress         = [System.String[]] $ipAddress
         Port              = [System.UInt16] $port
         DHCP              = [System.Boolean] $dhcp
+        IsActiveNode      = [System.Boolean] $isActiveNode
     }
 }
 
@@ -137,6 +143,10 @@ function Get-TargetResource
 
     .PARAMETER DHCP
         If DHCP should be used for the availability group listener instead of static IP address.
+
+    .PARAMETER ProcessOnlyOnActiveNode
+        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.
+        Not used in Set-TargetResource.
 #>
 function Set-TargetResource
 {
@@ -175,7 +185,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $DHCP
+        $DHCP,
+
+        [Parameter()]
+        [System.Boolean]
+        $ProcessOnlyOnActiveNode
     )
 
     $parameters = @{
@@ -413,6 +427,9 @@ function Set-TargetResource
 
     .PARAMETER DHCP
         If DHCP should be used for the availability group listener instead of static IP address.
+
+    .PARAMETER ProcessOnlyOnActiveNode
+        Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.
 #>
 function Test-TargetResource
 {
@@ -453,7 +470,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $DHCP
+        $DHCP,
+
+        [Parameter()]
+        [System.Boolean]
+        $ProcessOnlyOnActiveNode
     )
 
     $parameters = @{
@@ -470,6 +491,18 @@ function Test-TargetResource
     $availabilityGroupListenerState = Get-TargetResource @parameters
 
     [System.Boolean] $result = $false
+
+    <#
+        If this is supposed to process only the active node, and this is not the
+        active node, don't bother evaluating the test.
+    #>
+    if ( $ProcessOnlyOnActiveNode -and -not $getTargetResourceResult.IsActiveNode )
+    {
+        # Use localization if the resource has been converted
+        New-VerboseMessage -Message ( 'The node "{0}" is not actively hosting the instance "{1}". Exiting the test.' -f $env:COMPUTERNAME, $SQLInstanceName )
+        $result = $true
+        return $result
+    }
 
     if ($availabilityGroupListenerState.Ensure -eq $Ensure)
     {

--- a/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.schema.mof
+++ b/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.schema.mof
@@ -10,5 +10,6 @@ class DSC_SqlAGListener : OMI_BaseResource
     [Write, Description("The IP address used for the availability group listener, in the format `'192.168.10.45/255.255.252.0'`. If using DHCP, set to the first IP-address of the DHCP subnet, in the format `'192.168.8.1/255.255.252.0'`. Must be valid in the cluster-allowed IP range.")] String IpAddress[];
     [Write, Description("The port used for the availability group listener.")] UInt16 Port;
     [Write, Description("If DHCP should be used for the availability group listener instead of static IP address.")] Boolean DHCP;
+    [Write, Description("Specifies that the resource will only determine if a change is needed if the target node is the active host of the SQL Server instance.")] Boolean ProcessOnlyOnActiveNode;
+    [Read, Description("Determines if the current node is actively hosting the SQL Server instance.")] Boolean IsActiveNode;
 };
-

--- a/source/Examples/Resources/SqlAGListener/1-AddAvailabilityGroupListenerWithSameNameAsVCO.ps1
+++ b/source/Examples/Resources/SqlAGListener/1-AddAvailabilityGroupListenerWithSameNameAsVCO.ps1
@@ -2,6 +2,11 @@
     .DESCRIPTION
         This example will add an Availability Group listener with the same name
         as the cluster role VCO.
+
+        In the event this is applied to a Failover Cluster Instance (FCI), the
+        ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
+        to evaluate if any changes are needed if the node is actively hosting the
+        SQL Server instance.
 #>
 Configuration Example
 {
@@ -18,15 +23,16 @@ Configuration Example
     {
         SqlAGListener 'AvailabilityGroupListenerWithSameNameAsVCO'
         {
-            Ensure               = 'Present'
-            ServerName           = 'SQLNODE01.company.local'
-            InstanceName         = 'MSSQLSERVER'
-            AvailabilityGroup    = 'AG-01'
-            Name                 = 'AG-01'
-            IpAddress            = '192.168.0.73/255.255.255.0'
-            Port                 = 5301
+            Ensure                  = 'Present'
+            ServerName              = 'SQLNODE01.company.local'
+            InstanceName            = 'MSSQLSERVER'
+            AvailabilityGroup       = 'AG-01'
+            Name                    = 'AG-01'
+            IpAddress               = '192.168.0.73/255.255.255.0'
+            Port                    = 5301
+            ProcessOnlyOnActiveNode = $true
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential    = $SqlAdministratorCredential
         }
     }
 }

--- a/source/Examples/Resources/SqlAGListener/2-AddAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
+++ b/source/Examples/Resources/SqlAGListener/2-AddAvailabilityGroupListenerWithDifferentNameAsVCO.ps1
@@ -2,6 +2,11 @@
     .DESCRIPTION
         This example will add an Availability Group listener with a different
         than the cluster role VCO.
+
+        In the event this is applied to a Failover Cluster Instance (FCI), the
+        ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
+        to evaluate if any changes are needed if the node is actively hosting the
+        SQL Server instance.
 #>
 Configuration Example
 {
@@ -18,15 +23,16 @@ Configuration Example
     {
         SqlAGListener 'AvailabilityGroupListenerWithDifferentNameAsVCO'
         {
-            Ensure               = 'Present'
-            ServerName           = 'SQLNODE01.company.local'
-            InstanceName         = 'MSSQLSERVER'
-            AvailabilityGroup    = 'AvailabilityGroup-01'
-            Name                 = 'AG-01'
-            IpAddress            = '192.168.0.74/255.255.255.0'
-            Port                 = 5302
+            Ensure                  = 'Present'
+            ServerName              = 'SQLNODE01.company.local'
+            InstanceName            = 'MSSQLSERVER'
+            AvailabilityGroup       = 'AvailabilityGroup-01'
+            Name                    = 'AG-01'
+            IpAddress               = '192.168.0.74/255.255.255.0'
+            Port                    = 5302
+            ProcessOnlyOnActiveNode = $true
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential    = $SqlAdministratorCredential
         }
     }
 }

--- a/source/Examples/Resources/SqlAGListener/5-AddAvailabilityGroupListenerUsingDHCPWithDefaultServerSubnet.ps1
+++ b/source/Examples/Resources/SqlAGListener/5-AddAvailabilityGroupListenerUsingDHCPWithDefaultServerSubnet.ps1
@@ -2,6 +2,11 @@
     .DESCRIPTION
         This example will add an Availability Group listener using DHCP on the
         default server subnet.
+
+        In the event this is applied to a Failover Cluster Instance (FCI), the
+        ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
+        to evaluate if any changes are needed if the node is actively hosting the
+        SQL Server instance.
 #>
 Configuration Example
 {
@@ -18,19 +23,20 @@ Configuration Example
     {
         SqlAGListener 'AvailabilityGroupListenerWithSameNameAsVCO'
         {
-            Ensure               = 'Present'
-            ServerName           = 'SQLNODE01.company.local'
-            InstanceName         = 'MSSQLSERVER'
-            AvailabilityGroup    = 'AG-01'
-            Name                 = 'AG-01'
+            Ensure                  = 'Present'
+            ServerName              = 'SQLNODE01.company.local'
+            InstanceName            = 'MSSQLSERVER'
+            AvailabilityGroup       = 'AG-01'
+            Name                    = 'AG-01'
             <#
                 If not specifying parameter DHCP, then the default will be
                 DHCP with the default server subnet.
             #>
-            DHCP                 = $true
-            Port                 = 5301
+            DHCP                    = $true
+            Port                    = 5301
+            ProcessOnlyOnActiveNode = $true
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential    = $SqlAdministratorCredential
         }
     }
 }

--- a/source/Examples/Resources/SqlAGListener/6-AddAvailabilityGroupListenerUsingDHCPWithSpecificSubnet.ps1
+++ b/source/Examples/Resources/SqlAGListener/6-AddAvailabilityGroupListenerUsingDHCPWithSpecificSubnet.ps1
@@ -1,6 +1,11 @@
 <#
     .DESCRIPTION
         This example will add an Availability Group listener using DHCP with a specific subnet.
+
+        In the event this is applied to a Failover Cluster Instance (FCI), the
+        ProcessOnlyOnActiveNode property will tell the Test-TargetResource function
+        to evaluate if any changes are needed if the node is actively hosting the
+        SQL Server instance.
 #>
 Configuration Example
 {
@@ -17,16 +22,17 @@ Configuration Example
     {
         SqlAGListener 'AvailabilityGroupListenerWithSameNameAsVCO'
         {
-            Ensure               = 'Present'
-            ServerName           = 'SQLNODE01.company.local'
-            InstanceName         = 'MSSQLSERVER'
-            AvailabilityGroup    = 'AG-01'
-            Name                 = 'AG-01'
-            DHCP                 = $true
-            IpAddress            = '192.168.0.1/255.255.252.0'
-            Port                 = 5301
+            Ensure                  = 'Present'
+            ServerName              = 'SQLNODE01.company.local'
+            InstanceName            = 'MSSQLSERVER'
+            AvailabilityGroup       = 'AG-01'
+            Name                    = 'AG-01'
+            DHCP                    = $true
+            IpAddress               = '192.168.0.1/255.255.252.0'
+            Port                    = 5301
+            ProcessOnlyOnActiveNode = $true
 
-            PsDscRunAsCredential = $SqlAdministratorCredential
+            PsDscRunAsCredential    = $SqlAdministratorCredential
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- Changes to SqlAGListener
  - Made the resource cluster aware. When ProcessOnlyOnActiveNode is specified,
    the resource will only determine if a change is needed if the target node
    is the active host of the SQL Server instance ([issue #871](https://github.com/dsccommunity/SqlServerDsc/issues/871)).

#### This Pull Request (PR) fixes the following issues

- Fixes #871

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [x] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1783)
<!-- Reviewable:end -->
