### PR TITLE
SqlServerDsc: Integration tests for SQL Server 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New GitHub issue templates for proposing new public commands, proposing
     an enhancement to an existing command, or having a problem with an existing
     command.
+  - Integration tests are now also run on SQL Server 2022.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     an enhancement to an existing command, or having a problem with an existing
     command.
   - Integration tests are now also run on SQL Server 2022.
+- SqlDatabase
+  - Added compatibility levels for SQL Server 2022 (major version 16).
+- SqlSetup
+  - Paths for SQL Server 2022 are correctly returned by Get.
 
 ### Changed
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,6 +156,12 @@ stages:
             SQL2019_WIN2022:
               JOB_VMIMAGE: 'windows-2022'
               TEST_CONFIGURATION: 'Integration_SQL2019'
+            SQL2022_WIN2019:
+              JOB_VMIMAGE: 'windows-2019'
+              TEST_CONFIGURATION: 'Integration_SQL2022'
+            SQL2022_WIN2022:
+              JOB_VMIMAGE: 'windows-2022'
+              TEST_CONFIGURATION: 'Integration_SQL2022'
         pool:
           vmImage: $(JOB_VMIMAGE)
         timeoutInMinutes: 0

--- a/source/DSCResources/DSC_SqlDatabase/DSC_SqlDatabase.psm1
+++ b/source/DSCResources/DSC_SqlDatabase/DSC_SqlDatabase.psm1
@@ -15,6 +15,7 @@ $script:supportedCompatibilityLevels = @{
     13 = @('Version100', 'Version110', 'Version120', 'Version130')
     14 = @('Version100', 'Version110', 'Version120', 'Version130', 'Version140')
     15 = @('Version100', 'Version110', 'Version120', 'Version130', 'Version140', 'Version150')
+    16 = @('Version100', 'Version110', 'Version120', 'Version130', 'Version140', 'Version150', 'Version160')
 }
 
 <#

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -987,7 +987,7 @@ function Set-TargetResource
 
     foreach ($feature in $featuresArray)
     {
-        if (($sqlVersion -in ('13', '14', '15')) -and ($feature -in ('ADV_SSMS', 'SSMS')))
+        if (($sqlVersion -in ('13', '14', '15', '16')) -and ($feature -in ('ADV_SSMS', 'SSMS')))
         {
             $errorMessage = $script:localizedData.FeatureNotSupported -f $feature
             New-InvalidOperationException -Message $errorMessage
@@ -1009,7 +1009,7 @@ function Set-TargetResource
     # If SQL shared components already installed, clear InstallShared*Dir variables
     switch ($sqlVersion)
     {
-        { $_ -in ('10', '11', '12', '13', '14', '15') }
+        { $_ -in ('10', '11', '12', '13', '14', '15', '16') }
         {
             if ((Get-Variable -Name 'InstallSharedDir' -ErrorAction SilentlyContinue) -and (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\FEE2E540D20152D4597229B6CFBC0A69' -ErrorAction SilentlyContinue))
             {
@@ -3211,7 +3211,7 @@ function Get-SqlSharedPaths
 
     switch ($SqlServerMajorVersion)
     {
-        { $_ -in ('10', '11', '12', '13', '14', '15') }
+        { $_ -in ('10', '11', '12', '13', '14', '15', '16') }
         {
             $registryKeySharedDir = 'FEE2E540D20152D4597229B6CFBC0A69'
             $registryKeySharedWOWDir = 'A79497A344129F64CA7D69C56F5DD8B4'

--- a/tests/Integration/DSC_SqlAgentAlert.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlAgentAlert.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "<dscResourceFriendlyName>_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "<dscResourceFriendlyName>_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlAgentFailsafe.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlAgentFailsafe.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlAgentOperator.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlAgentOperator.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlAlwaysOnService.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlAlwaysOnService.Integration.Tests.ps1
@@ -54,7 +54,7 @@ AfterAll {
 
 <#
     TODO: This has temporarily been disabled as the test is not passing.
-          Tags should be changed to @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019')
+          Tags should be changed to @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022')
 #>
 Describe "$($script:dscResourceName)_Integration" -Tag 'Skip'  {
     BeforeAll {

--- a/tests/Integration/DSC_SqlAudit.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlAudit.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
@@ -28,33 +28,12 @@ BeforeAll {
         -ResourceType 'Mof' `
         -TestType 'Integration'
 
-    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
-
-    if (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2022')
-    {
-        $script:sqlVersion = '160'
-    }
-    elseif (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2019')
-    {
-        $script:sqlVersion = '150'
-    }
-    elseif (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2017')
-    {
-        $script:sqlVersion = '140'
-    }
-    else
-    {
-        $script:sqlVersion = '130'
-    }
-
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 }
 
 AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
-
-    Get-Module -Name 'CommonTestHelper' -All | Remove-Module -Force
 }
 
 Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
@@ -28,6 +28,8 @@ BeforeAll {
         -ResourceType 'Mof' `
         -TestType 'Integration'
 
+    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\CommonTestHelper.psm1')
+
     if (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2022')
     {
         $script:sqlVersion = '160'
@@ -51,6 +53,8 @@ BeforeAll {
 
 AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+
+    Get-Module -Name 'CommonTestHelper' -All | Remove-Module -Force
 }
 
 Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabase.Integration.Tests.ps1
@@ -28,6 +28,23 @@ BeforeAll {
         -ResourceType 'Mof' `
         -TestType 'Integration'
 
+    if (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2022')
+    {
+        $script:sqlVersion = '160'
+    }
+    elseif (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2019')
+    {
+        $script:sqlVersion = '150'
+    }
+    elseif (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2017')
+    {
+        $script:sqlVersion = '140'
+    }
+    else
+    {
+        $script:sqlVersion = '130'
+    }
+
     $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 }

--- a/tests/Integration/DSC_SqlDatabase.config.ps1
+++ b/tests/Integration/DSC_SqlDatabase.config.ps1
@@ -13,6 +13,41 @@ if (Test-Path -Path $configFile)
 }
 else
 {
+    <#
+        The variable $script:sqlVersion is set in the integration script file,
+        which is available once this script is dot-sourced.
+    #>
+    switch ($script:sqlVersion)
+    {
+        '160'
+        {
+            $versionSpecificData = @{
+                CompatibilityLevel = 'Version150'
+            }
+        }
+
+        '150'
+        {
+            $versionSpecificData = @{
+                CompatibilityLevel = 'Version120'
+            }
+        }
+
+        '140'
+        {
+            $versionSpecificData = @{
+                CompatibilityLevel = 'Version120'
+            }
+        }
+
+        '130'
+        {
+            $versionSpecificData = @{
+                CompatibilityLevel = 'Version120'
+            }
+        }
+    }
+
     $ConfigurationData = @{
         AllNodes = @(
             @{
@@ -32,7 +67,7 @@ else
                 DatabaseName5      = 'Database5'
 
                 Collation          = 'SQL_Latin1_General_Pref_CP850_CI_AS'
-                CompatibilityLevel = 'Version120'
+                CompatibilityLevel = $versionSpecificData.CompatibilityLevel
                 RecoveryModel      = 'Simple'
                 OwnerName          = 'sa'
             }

--- a/tests/Integration/DSC_SqlDatabase.config.ps1
+++ b/tests/Integration/DSC_SqlDatabase.config.ps1
@@ -13,41 +13,6 @@ if (Test-Path -Path $configFile)
 }
 else
 {
-    <#
-        The variable $script:sqlVersion is set in the integration script file,
-        which is available once this script is dot-sourced.
-    #>
-    switch ($script:sqlVersion)
-    {
-        '160'
-        {
-            $versionSpecificData = @{
-                CompatibilityLevel = 'Version150'
-            }
-        }
-
-        '150'
-        {
-            $versionSpecificData = @{
-                CompatibilityLevel = 'Version120'
-            }
-        }
-
-        '140'
-        {
-            $versionSpecificData = @{
-                CompatibilityLevel = 'Version120'
-            }
-        }
-
-        '130'
-        {
-            $versionSpecificData = @{
-                CompatibilityLevel = 'Version120'
-            }
-        }
-    }
-
     $ConfigurationData = @{
         AllNodes = @(
             @{
@@ -67,7 +32,7 @@ else
                 DatabaseName5      = 'Database5'
 
                 Collation          = 'SQL_Latin1_General_Pref_CP850_CI_AS'
-                CompatibilityLevel = $versionSpecificData.CompatibilityLevel
+                CompatibilityLevel = 'Version120'
                 RecoveryModel      = 'Simple'
                 OwnerName          = 'sa'
             }

--- a/tests/Integration/DSC_SqlDatabaseDefaultLocation.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseDefaultLocation.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlDatabaseMail.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseMail.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseObjectPermission.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabasePermission.Integration.Tests.ps1
@@ -40,7 +40,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlDatabaseUser.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlDatabaseUser.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlEndpoint.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlEndpoint.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlLogin.Integration.Tests.ps1
@@ -40,7 +40,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlPermission.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlPermission.Integration.Tests.ps1
@@ -40,7 +40,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlProtocol.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlProtocol.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019' <#, 'Integration_SQL2022' #>) {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlProtocol.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlProtocol.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlProtocolTcpIp.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlProtocolTcpIp.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019' <#, 'Integration_SQL2022' #>) {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlProtocolTcpIp.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlProtocolTcpIp.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlReplication.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlReplication.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019' <#, 'Integration_SQL2022' #>) {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlReplication.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlReplication.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlRole.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlRole.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlScript.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlScript.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlScriptQuery.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlScriptQuery.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlSecureConnection.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSecureConnection.Integration.Tests.ps1
@@ -50,7 +50,7 @@ AfterAll {
     Get-Module -Name 'CommonTestHelper' -All | Remove-Module -Force
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlServiceAccount.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlServiceAccount.Integration.Tests.ps1
@@ -45,7 +45,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019' <#, 'Integration_SQL2022' #>) {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlServiceAccount.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlServiceAccount.Integration.Tests.ps1
@@ -45,7 +45,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
@@ -160,7 +160,7 @@ AfterAll {
     Get-Module -Name 'CommonTestHelper' -All | Remove-Module -Force
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }

--- a/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
@@ -642,7 +642,21 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             $resourceCurrentState.FailoverClusterGroupName   | Should -BeNullOrEmpty
             $resourceCurrentState.FailoverClusterIPAddress   | Should -BeNullOrEmpty
             $resourceCurrentState.FailoverClusterNetworkName | Should -BeNullOrEmpty
-            $resourceCurrentState.Features                   | Should -Be $ConfigurationData.AllNodes.AnalysisServicesMultiFeatures
+
+            if ($script:sqlVersion -in (160))
+            {
+                <#
+                    The features CONN, BC, SDK is no longer supported after SQL Server 2019.
+                    Thus they are not installed with the Database Engine instance DSCSQLTEST
+                    in prior test, so this test do not find them already installed.
+                #>
+                $resourceCurrentState.Features | Should -Be 'AS'
+            }
+            else
+            {
+                $resourceCurrentState.Features | Should -Be 'AS,CONN,BC,SDK'
+            }
+
             $resourceCurrentState.ForceReboot                | Should -BeNullOrEmpty
             $resourceCurrentState.FTSvcAccount               | Should -BeNullOrEmpty
             $resourceCurrentState.FTSvcAccountUsername       | Should -BeNullOrEmpty
@@ -794,7 +808,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             $resourceCurrentState.FailoverClusterGroupName   | Should -BeNullOrEmpty
             $resourceCurrentState.FailoverClusterIPAddress   | Should -BeNullOrEmpty
             $resourceCurrentState.FailoverClusterNetworkName | Should -BeNullOrEmpty
-            $resourceCurrentState.Features                   | Should -Be $ConfigurationData.AllNodes.AnalysisServicesTabularFeatures
+            $resourceCurrentState.Features                   | Should -Be 'AS,CONN,BC,SDK'
             $resourceCurrentState.ForceReboot                | Should -BeNullOrEmpty
             $resourceCurrentState.FTSvcAccount               | Should -BeNullOrEmpty
             $resourceCurrentState.FTSvcAccountUsername       | Should -BeNullOrEmpty

--- a/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
@@ -808,7 +808,21 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             $resourceCurrentState.FailoverClusterGroupName   | Should -BeNullOrEmpty
             $resourceCurrentState.FailoverClusterIPAddress   | Should -BeNullOrEmpty
             $resourceCurrentState.FailoverClusterNetworkName | Should -BeNullOrEmpty
-            $resourceCurrentState.Features                   | Should -Be 'AS,CONN,BC,SDK'
+
+            if ($script:sqlVersion -in (160))
+            {
+                <#
+                    The features CONN, BC, SDK is no longer supported after SQL Server 2019.
+                    Thus they are not installed with the Database Engine instance DSCSQLTEST
+                    in prior test, so this test do not find them already installed.
+                #>
+                $resourceCurrentState.Features | Should -Be 'AS'
+            }
+            else
+            {
+                $resourceCurrentState.Features | Should -Be 'AS,CONN,BC,SDK'
+            }
+
             $resourceCurrentState.ForceReboot                | Should -BeNullOrEmpty
             $resourceCurrentState.FTSvcAccount               | Should -BeNullOrEmpty
             $resourceCurrentState.FTSvcAccountUsername       | Should -BeNullOrEmpty

--- a/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSetup.Integration.Tests.ps1
@@ -71,8 +71,15 @@ BeforeAll {
         This is used in both the configuration file and in this script file
         to run the correct tests depending of what version of SQL Server is
         being tested in the current job.
+
+        The actual download URL can easiest be found in the browser download history.
     #>
-    if (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2019')
+    if (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2022')
+    {
+        $script:sqlVersion = '160'
+        $script:mockSourceDownloadExeUrl = 'https://download.microsoft.com/download/c/c/9/cc9c6797-383c-4b24-8920-dc057c1de9d3/SQL2022-SSEI-Dev.exe'
+    }
+    elseif (Test-ContinuousIntegrationTaskCategory -Category 'Integration_SQL2019')
     {
         $script:sqlVersion = '150'
         $script:mockSourceDownloadExeUrl = 'https://download.microsoft.com/download/d/a/2/da259851-b941-459d-989c-54a18a5d44dd/SQL2019-SSEI-Dev.exe'
@@ -119,7 +126,6 @@ BeforeAll {
             # Rename the ISO to maintain consistency of names within integration tests
             Rename-Item -Path $ConfigurationData.AllNodes.DownloadIsoPath `
                 -NewName $(Split-Path -Path $ConfigurationData.AllNodes.ImagePath -Leaf) | Out-Null
-
         }
         else
         {

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -33,6 +33,9 @@ else
                 # Additional variables required as ISO is downloaded via additional EXE
                 DownloadExeName = 'SQL2022_Download.exe'
                 DownloadIsoName = 'SQLServer2022-x64-ENU-Dev.iso'
+
+                # Features CONN, BC, SDK, SNAC_SDK, DREPLAY_CLT, DREPLAY_CTLR are no longer supported in 2022.
+                SupportedFeatures = 'SQLENGINE,REPLICATION'
             }
         }
 
@@ -46,6 +49,8 @@ else
                 # Additional variables required as ISO is downloaded via additional EXE
                 DownloadExeName = 'SQL2019_Download.exe'
                 DownloadIsoName = 'SQLServer2019-x64-ENU-Dev.iso'
+
+                SupportedFeatures = 'SQLENGINE,REPLICATION,CONN,BC,SDK'
             }
         }
 
@@ -55,6 +60,8 @@ else
                 SqlServerInstanceIdPrefix = 'MSSQL14'
                 AnalysisServiceInstanceIdPrefix = 'MSAS14'
                 IsoImageName = 'SQL2017.iso'
+
+                SupportedFeatures = 'SQLENGINE,REPLICATION,CONN,BC,SDK'
             }
         }
 
@@ -64,6 +71,8 @@ else
                 SqlServerInstanceIdPrefix = 'MSSQL13'
                 AnalysisServiceInstanceIdPrefix = 'MSAS13'
                 IsoImageName = 'SQL2016.iso'
+
+                SupportedFeatures = 'SQLENGINE,REPLICATION,CONN,BC,SDK'
             }
         }
     }
@@ -82,7 +91,7 @@ else
 
                 # Database Engine properties.
                 DatabaseEngineNamedInstanceName         = 'DSCSQLTEST'
-                DatabaseEngineNamedInstanceFeatures     = 'SQLENGINE,REPLICATION,CONN,BC,SDK'
+                DatabaseEngineNamedInstanceFeatures     = $versionSpecificData.SupportedFeatures
 
                 <#
                     Analysis Services Multi-dimensional properties.

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -95,35 +95,23 @@ else
 
                 <#
                     Analysis Services Multi-dimensional properties.
-                    The features CONN,BC,SDK is installed with the DSCSQLTEST so those
-                    features will found for DSCTABULAR instance as well.
-                    The features is added here so the same property can be used to
-                    evaluate the result in the test.
                 #>
                 AnalysisServicesMultiInstanceName     = 'DSCMULTI'
-                AnalysisServicesMultiFeatures         = 'AS,CONN,BC,SDK'
+                AnalysisServicesMultiFeatures         = 'AS'
                 AnalysisServicesMultiServerMode       = 'MULTIDIMENSIONAL'
 
                 <#
                     Analysis Services Tabular properties.
-                    The features CONN,BC,SDK is installed with the DSCSQLTEST so those
-                    features will found for DSCTABULAR instance as well.
-                    The features is added here so the same property can be used to
-                    evaluate the result in the test.
                 #>
                 AnalysisServicesTabularInstanceName     = 'DSCTABULAR'
-                AnalysisServicesTabularFeatures         = 'AS,CONN,BC,SDK'
+                AnalysisServicesTabularFeatures         = 'AS'
                 AnalysisServicesTabularServerMode       = 'TABULAR'
 
                 <#
                     Database Engine default instance properties.
-                    The features CONN,BC,SDK is installed with the DSCSQLTEST so those
-                    features will found for DSCTABULAR instance as well.
-                    The features is added here so the same property can be used to
-                    evaluate the result in the test.
                 #>
                 DatabaseEngineDefaultInstanceName       = 'MSSQLSERVER'
-                DatabaseEngineDefaultInstanceFeatures   = 'SQLENGINE,REPLICATION,CONN,BC,SDK'
+                DatabaseEngineDefaultInstanceFeatures   = $versionSpecificData.SupportedFeatures
 
                 # General SqlSetup properties
                 Collation                               = 'Finnish_Swedish_CI_AS'

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -23,6 +23,19 @@ else
     #>
     switch ($script:sqlVersion)
     {
+        '160'
+        {
+            $versionSpecificData = @{
+                SqlServerInstanceIdPrefix = 'MSSQL16'
+                AnalysisServiceInstanceIdPrefix = 'MSAS16'
+                IsoImageName = 'SQL2022.iso'
+
+                # Additional variables required as ISO is downloaded via additional EXE
+                DownloadExeName = 'SQL2022_Download.exe'
+                DownloadIsoName = 'SQLServer2022-x64-ENU-Dev.iso'
+            }
+        }
+
         '150'
         {
             $versionSpecificData = @{

--- a/tests/Integration/DSC_SqlWindowsFirewall.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlWindowsFirewall.Integration.Tests.ps1
@@ -36,7 +36,7 @@ AfterAll {
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }
 
-Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019') {
+Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
     }


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc
  - Integration tests are now also run on SQL Server 2022.
- SqlDatabase
  - Added compatibility levels for SQL Server 2022 (major version 16).
- SqlSetup
  - Paths for SQL Server 2022 are correctly returned by Get.

#### This Pull Request (PR) fixes the following issues
None. But added a few new issues.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sqlserverdsc/1803)
<!-- Reviewable:end -->
