### PR TITLE
SqlServerDsc: `Connect-Sql` now handles `ErrorAction` correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       only be used together with the module _SqlServer_ v22.x (minimum
       v22.0.49-preview). The parameter will be ignored if an older major
       versions of the module _SqlServer_ is used.
+  - `Connect-SQL`
+    - Was updated to handle both `-ErrorAction 'Stop'` and `-ErrorAction 'SilentlyContinue'`
+      when passed to the command ([issue #1837](https://github.com/dsccommunity/SqlServerDsc/issues/1837)).
 
 ### Fixed
 

--- a/source/Classes/011.SqlResourceBase.ps1
+++ b/source/Classes/011.SqlResourceBase.ps1
@@ -67,6 +67,7 @@ class SqlResourceBase : ResourceBase
             $connectSqlDscDatabaseEngineParameters = @{
                 ServerName   = $this.ServerName
                 InstanceName = $this.InstanceName
+                ErrorAction  = 'Stop'
             }
 
             if ($this.Credential)

--- a/source/DSCResources/DSC_SqlAG/DSC_SqlAG.psm1
+++ b/source/DSCResources/DSC_SqlAG/DSC_SqlAG.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
     )
 
     # Connect to the instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Define current version for check compatibility
     $sqlMajorVersion = $serverObject.Version.Major
@@ -244,7 +244,7 @@ function Set-TargetResource
     )
 
     # Connect to the instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Determine if HADR is enabled on the instance. If not, throw an error
     if ( -not $serverObject.IsHadrEnabled )

--- a/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
+++ b/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
@@ -72,7 +72,7 @@ function Get-TargetResource
     }
 
     # Connect to the instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Is this node actively hosting the SQL instance?
     $currentConfiguration.IsActiveNode = Test-ActiveNode -ServerObject $serverObject
@@ -213,7 +213,7 @@ function Set-TargetResource
     Import-SQLPSModule
 
     # Connect to the defined instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -StatementTimeout $StatementTimeout
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -StatementTimeout $StatementTimeout -ErrorAction 'Stop'
 
     # Get the Availability Group
     $availabilityGroup = $serverObject.AvailabilityGroups[$AvailabilityGroupName]
@@ -264,7 +264,7 @@ function Set-TargetResource
 
                 foreach ( $availabilityGroupReplica in $secondaryReplicas )
                 {
-                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL -ServerName $availabilityGroupReplica.Name
+                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL -ServerName $availabilityGroupReplica.Name -ErrorAction 'Stop'
                     $impersonatePermissionsStatus.Add(
                         $availabilityGroupReplica.Name,
                         ( Test-ImpersonatePermissions -ServerObject $currentAvailabilityGroupReplicaServerObject -Securable $databaseObject.Owner )
@@ -328,7 +328,7 @@ function Set-TargetResource
                 foreach ( $availabilityGroupReplica in $secondaryReplicas )
                 {
                     $connectSqlParameters = Split-FullSqlInstanceName -FullSqlInstanceName $availabilityGroupReplica.Name
-                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters
+                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters -ErrorAction 'Stop'
                     $availabilityReplicaFilestreamLevel.Add($availabilityGroupReplica.Name, $currentAvailabilityGroupReplicaServerObject.FilestreamLevel)
                 }
 
@@ -349,7 +349,7 @@ function Set-TargetResource
                 foreach ( $availabilityGroupReplica in $secondaryReplicas )
                 {
                     $connectSqlParameters = Split-FullSqlInstanceName -FullSqlInstanceName $availabilityGroupReplica.Name
-                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters
+                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters -ErrorAction 'Stop'
                     $availabilityReplicaContainmentEnabled.Add($availabilityGroupReplica.Name, $currentAvailabilityGroupReplicaServerObject.Configuration.ContainmentEnabled.ConfigValue)
                 }
 
@@ -373,7 +373,7 @@ function Set-TargetResource
             foreach ( $availabilityGroupReplica in $secondaryReplicas )
             {
                 $connectSqlParameters = Split-FullSqlInstanceName -FullSqlInstanceName $availabilityGroupReplica.Name
-                $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters
+                $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters -ErrorAction 'Stop'
 
                 $missingDirectories = @()
                 foreach ( $databaseFileDirectory in $databaseFileDirectories )
@@ -411,7 +411,7 @@ function Set-TargetResource
                 foreach ( $availabilityGroupReplica in $secondaryReplicas )
                 {
                     $connectSqlParameters = Split-FullSqlInstanceName -FullSqlInstanceName $availabilityGroupReplica.Name
-                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters
+                    $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters -ErrorAction 'Stop'
 
                     [System.Array] $installedCertificateThumbprints = $currentAvailabilityGroupReplicaServerObject.Databases['master'].Certificates |
                         ForEach-Object -Process { [System.BitConverter]::ToString($_.Thumbprint) }
@@ -594,7 +594,7 @@ function Set-TargetResource
                     {
                         # Connect to the replica
                         $connectSqlParameters = Split-FullSqlInstanceName -FullSqlInstanceName $availabilityGroupReplica.Name
-                        $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters
+                        $currentAvailabilityGroupReplicaServerObject = Connect-SQL @connectSqlParameters -ErrorAction 'Stop'
                         $currentReplicaAvailabilityGroupObject = $currentAvailabilityGroupReplicaServerObject.AvailabilityGroups[$AvailabilityGroupName]
 
                         if ( $availabilityGroupReplica.SeedingMode -eq 'MANUAL')
@@ -801,7 +801,7 @@ function Test-TargetResource
     }
 
     # Connect to the defined instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Get the Availability Group if it exists
     if ( -not [System.String]::IsNullOrEmpty($currentConfiguration.AvailabilityGroupName) )

--- a/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
+++ b/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
@@ -195,7 +195,7 @@ function Set-TargetResource
                 $script:localizedData.CreateAvailabilityGroupListener -f $Name, $AvailabilityGroup, $InstanceName
             )
 
-            $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+            $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
             $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
             if ($availabilityGroupObject)
@@ -255,7 +255,7 @@ function Set-TargetResource
                 $script:localizedData.DropAvailabilityGroupListener -f $Name, $AvailabilityGroup, $InstanceName
             )
 
-            $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+            $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
             $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
             if ($availabilityGroupObject)
@@ -312,7 +312,7 @@ function Set-TargetResource
                 New-InvalidOperationException -Message $errorMessage
             }
 
-            $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+            $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
             $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
             if ($availabilityGroupObject)
@@ -559,7 +559,7 @@ function Get-SQLAlwaysOnAvailabilityGroupListener
         $script:localizedData.DebugConnectingAvailabilityGroup -f $Name, [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     $availabilityGroupObject = $sqlServerObject.AvailabilityGroups[$AvailabilityGroup]
     if ($availabilityGroupObject)

--- a/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
+++ b/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
@@ -50,7 +50,7 @@ function Get-TargetResource
     )
 
     # Connect to the instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Is this node actively hosting the SQL instance?
     $isActiveNode = Test-ActiveNode -ServerObject $serverObject
@@ -241,7 +241,7 @@ function Set-TargetResource
     Import-SQLPSModule
 
     # Connect to the instance
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Determine if HADR is enabled on the instance. If not, throw an error
     if ( -not $serverObject.IsHadrEnabled )
@@ -403,7 +403,7 @@ function Set-TargetResource
             else
             {
                 # Connect to the instance that is supposed to house the primary replica
-                $primaryReplicaServerObject = Connect-SQL -ServerName $PrimaryReplicaServerName -InstanceName $PrimaryReplicaInstanceName
+                $primaryReplicaServerObject = Connect-SQL -ServerName $PrimaryReplicaServerName -InstanceName $PrimaryReplicaInstanceName -ErrorAction 'Stop'
 
                 # Verify the Availability Group exists on the supplied primary replica
                 $primaryReplicaAvailabilityGroup = $primaryReplicaServerObject.AvailabilityGroups[$AvailabilityGroupName]

--- a/source/DSCResources/DSC_SqlAgentAlert/DSC_SqlAgentAlert.psm1
+++ b/source/DSCResources/DSC_SqlAgentAlert/DSC_SqlAgentAlert.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
         MessageId    = $null
     }
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {
@@ -148,7 +148,7 @@ function Set-TargetResource
         $MessageId
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlAgentFailsafe/DSC_SqlAgentFailsafe.psm1
+++ b/source/DSCResources/DSC_SqlAgentFailsafe/DSC_SqlAgentFailsafe.psm1
@@ -50,7 +50,7 @@ function Get-TargetResource
         NotificationMethod = $null
     }
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {
@@ -140,7 +140,7 @@ function Set-TargetResource
         $NotificationMethod
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlAgentOperator/DSC_SqlAgentOperator.psm1
+++ b/source/DSCResources/DSC_SqlAgentOperator/DSC_SqlAgentOperator.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
         EmailAddress = $null
     }
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {
@@ -142,7 +142,7 @@ function Set-TargetResource
         $EmailAddress
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
+++ b/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
@@ -56,7 +56,7 @@ function Get-TargetResource
         $RestartTimeout = 120
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     $isAlwaysOnEnabled = [System.Boolean] $sqlServerObject.IsHadrEnabled
     if ($isAlwaysOnEnabled -eq $true)

--- a/source/DSCResources/DSC_SqlConfiguration/DSC_SqlConfiguration.psm1
+++ b/source/DSCResources/DSC_SqlConfiguration/DSC_SqlConfiguration.psm1
@@ -65,7 +65,7 @@ function Get-TargetResource
         $RestartTimeout = 120
     )
 
-    $sql = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sql = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Get the current value of the configuration option.
     $option = $sql.Configuration.Properties |
@@ -148,7 +148,7 @@ function Set-TargetResource
         $RestartTimeout = 120
     )
 
-    $sql = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sql = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Get the current value of the configuration option.
     $option = $sql.Configuration.Properties |

--- a/source/DSCResources/DSC_SqlDatabase/DSC_SqlDatabase.psm1
+++ b/source/DSCResources/DSC_SqlDatabase/DSC_SqlDatabase.psm1
@@ -78,7 +78,7 @@ function Get-TargetResource
         OwnerName          = $null
     }
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {
@@ -187,7 +187,7 @@ function Set-TargetResource
         $OwnerName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlDatabaseDefaultLocation/DSC_SqlDatabaseDefaultLocation.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseDefaultLocation/DSC_SqlDatabaseDefaultLocation.psm1
@@ -56,7 +56,7 @@ function Get-TargetResource
     Write-Verbose -Message ($script:localizedData.GetCurrentPath -f $Type, $InstanceName)
 
     # Connect to the instance
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Is this node actively hosting the SQL instance?
     $isActiveNode = Test-ActiveNode -ServerObject $sqlServerObject
@@ -166,7 +166,7 @@ function Set-TargetResource
     else
     {
         Write-Verbose -Message ($script:localizedData.SettingDefaultPath -f $Type)
-        $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+        $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
         # Check which default location is being updated
         switch ($Type)

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
@@ -83,7 +83,7 @@ function Get-TargetResource
             -f $ServerName, $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {
@@ -293,7 +293,7 @@ function Set-TargetResource
             -f $ServerName, $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -792,7 +792,7 @@ function Get-DatabaseObject
 
     $sqlObject = $null
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlDatabaseRole/DSC_SqlDatabaseRole.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseRole/DSC_SqlDatabaseRole.psm1
@@ -80,7 +80,7 @@ function Get-TargetResource
     $roleStatus = 'Absent'
     $membersInDesiredState = $false
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     if ($sqlServerObject)
     {
         $membersInDesiredState = $true
@@ -252,7 +252,7 @@ function Set-TargetResource
         $script:localizedData.SetDatabaseRoleProperties -f $Name
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     if ($sqlServerObject)
     {
         $sqlDatabaseObject = $sqlServerObject.Databases[$DatabaseName]

--- a/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
@@ -47,7 +47,7 @@ function Get-TargetResource
         $DatabaseName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     Write-Verbose -Message (
         $script:localizedData.RetrievingDatabaseUser -f $Name, $DatabaseName
@@ -756,7 +756,7 @@ function Assert-SqlLogin
         $LoginName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if (-not $sqlServerObject.Logins[$LoginName])
     {
@@ -812,7 +812,7 @@ function Assert-DatabaseCertificate
         $RemainingArguments
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if (-not $sqlServerObject.Databases[$DatabaseName].Certificates[$CertificateName])
     {
@@ -868,7 +868,7 @@ function Assert-DatabaseAsymmetricKey
         $RemainingArguments
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if (-not $sqlServerObject.Databases[$DatabaseName].AsymmetricKeys[$AsymmetricKeyName])
     {

--- a/source/DSCResources/DSC_SqlEndpoint/DSC_SqlEndpoint.psm1
+++ b/source/DSCResources/DSC_SqlEndpoint/DSC_SqlEndpoint.psm1
@@ -75,7 +75,7 @@ function Get-TargetResource
         MessageForwardingSize      = $null
     }
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {
@@ -224,7 +224,7 @@ function Set-TargetResource
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlEndpointPermission/DSC_SqlEndpointPermission.psm1
+++ b/source/DSCResources/DSC_SqlEndpointPermission/DSC_SqlEndpointPermission.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
 
     try
     {
-        $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+        $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
         $endpointObject = $sqlServerObject.Endpoints[$Name]
         if ( $null -ne $endpointObject )
@@ -169,7 +169,7 @@ function Set-TargetResource
             $script:localizedData.SetEndpointPermission -f $Name, $InstanceName
         )
 
-        $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+        $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
         $endpointObject = $sqlServerObject.Endpoints[$Name]
         if ($null -ne $endpointObject)

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
@@ -44,7 +44,7 @@ function Get-TargetResource
         $script:localizedData.GetLogin -f $Name, $ServerName, $InstanceName
     )
 
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     if ($serverObject)
     {
         $login = $serverObject.Logins[$Name]
@@ -182,7 +182,7 @@ function Set-TargetResource
         $DefaultDatabase
     )
 
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     switch ( $Ensure )
     {
@@ -567,7 +567,7 @@ function Test-TargetResource
 
                 try
                 {
-                    Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -SetupCredential $userCredential -LoginType 'SqlLogin' | Out-Null
+                    Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -SetupCredential $userCredential -LoginType 'SqlLogin' | Out-Null -ErrorAction 'Stop'
                 }
                 catch
                 {

--- a/source/DSCResources/DSC_SqlMaxDop/DSC_SqlMaxDop.psm1
+++ b/source/DSCResources/DSC_SqlMaxDop/DSC_SqlMaxDop.psm1
@@ -40,7 +40,7 @@ function Get-TargetResource
     $currentMaxDop = $null
     $isActiveNode = $null
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     if ($sqlServerObject)
     {
         # Is this node actively hosting the SQL instance?
@@ -128,7 +128,7 @@ function Set-TargetResource
         $ProcessOnlyOnActiveNode
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     if ($sqlServerObject)
     {
         Write-Verbose -Message (

--- a/source/DSCResources/DSC_SqlMemory/DSC_SqlMemory.psm1
+++ b/source/DSCResources/DSC_SqlMemory/DSC_SqlMemory.psm1
@@ -38,7 +38,7 @@ function Get-TargetResource
         $script:localizedData.GetMemoryValues -f $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     if ($sqlServerObject)
     {
         $minMemory = $sqlServerObject.Configuration.MinServerMemory.ConfigValue
@@ -154,7 +154,7 @@ function Set-TargetResource
         $script:localizedData.SetNewValues -f $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     if ($sqlServerObject)
     {
         switch ($Ensure)

--- a/source/DSCResources/DSC_SqlRole/DSC_SqlRole.psm1
+++ b/source/DSCResources/DSC_SqlRole/DSC_SqlRole.psm1
@@ -50,7 +50,7 @@ function Get-TargetResource
         $ServerRoleName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
     $ensure = 'Absent'
     $membersInRole = $null
 
@@ -166,7 +166,7 @@ function Set-TargetResource
 
     Assert-BoundParameter @assertBoundParameterParameters
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     if ($sqlServerObject)
     {

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -2539,7 +2539,7 @@ function Get-SqlEngineProperties
     #$agentServiceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter ("Name = '{0}'" -f $serviceNames.AgentService)
     $sqlAgentService = Get-ServiceProperties -ServiceName $serviceNames.AgentService
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     $sqlCollation = $sqlServerObject.Collation
     $isClustered = $sqlServerObject.IsClustered
@@ -2742,7 +2742,7 @@ function Get-TempDbProperties
         $InstanceName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     $databaseTempDb = $sqlServerObject.Databases['tempdb']
 
@@ -2934,7 +2934,7 @@ function Get-SqlRoleMembers
         $RoleName
     )
 
-    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     $membersOfSysAdminRole = @($sqlServerObject.Roles[$RoleName].EnumMemberNames())
 

--- a/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
+++ b/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
@@ -76,7 +76,7 @@ function Get-TargetResource
         )
 
         # Connect to the instance
-        $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+        $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
         if ($serverObject)
         {

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -458,7 +458,7 @@ function Start-SqlSetupProcess
         Connects to the instance 'MyInstance' on the local server.
 
     .EXAMPLE
-        Connect-SQL ServerName 'sql.company.local' -InstanceName 'MyInstance'
+        Connect-SQL ServerName 'sql.company.local' -InstanceName 'MyInstance' -ErrorAction 'Stop'
 
         Connects to the instance 'MyInstance' on the server 'sql.company.local'.
 #>
@@ -569,7 +569,15 @@ function Connect-SQL
     catch
     {
         $errorMessage = $script:localizedData.FailedToConnectToDatabaseEngineInstance -f $databaseEngineInstance
-        New-InvalidOperationException -Message $errorMessage -ErrorRecord $_
+
+        $writeErrorParameters = @{
+            Message = $errorMessage
+            Category = 'InvalidOperation'
+            ErrorId = 'CS0001' # cspell: disable-line
+            TargetObject = $databaseEngineInstance
+        }
+
+        Write-Error @writeErrorParameters
     }
     finally
     {
@@ -1029,7 +1037,7 @@ function Restart-SqlService
     if (-not $SkipClusterCheck.IsPresent)
     {
         ## Connect to the instance
-        $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+        $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
         if ($serverObject.IsClustered)
         {
@@ -1470,7 +1478,7 @@ function Invoke-Query
             $connectSQLParameters.SetupCredential = $DatabaseCredential
         }
 
-        $serverObject = Connect-SQL @connectSQLParameters
+        $serverObject = Connect-SQL @connectSQLParameters -ErrorAction 'Stop'
     }
 
     $redactedQuery = $Query
@@ -1718,7 +1726,7 @@ function Test-AvailabilityReplicaSeedingModeAutomatic
     # Assume automatic seeding is disabled by default
     $availabilityReplicaSeedingModeAutomatic = $false
 
-    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName
+    $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
     # Only check the seeding mode if this is SQL 2016 or newer
     if ( $serverObject.Version -ge 13 )
@@ -1777,7 +1785,7 @@ function Get-PrimaryReplicaServerObject
     # Determine if we're connected to the primary replica
     if ( ( $AvailabilityGroup.PrimaryReplicaServerName -ne $serverObject.DomainInstanceName ) -and ( -not [System.String]::IsNullOrEmpty($AvailabilityGroup.PrimaryReplicaServerName) ) )
     {
-        $primaryReplicaServerObject = Connect-SQL -ServerName $AvailabilityGroup.PrimaryReplicaServerName
+        $primaryReplicaServerObject = Connect-SQL -ServerName $AvailabilityGroup.PrimaryReplicaServerName -ErrorAction 'Stop'
     }
 
     return $primaryReplicaServerObject

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -2932,7 +2932,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
             $mockExpectedDatabaseEngineServer = 'TestServer'
             $mockExpectedDatabaseEngineInstance = 'MSSQLSERVER'
 
-            $databaseEngineServerObject = Connect-SQL -ServerName $mockExpectedDatabaseEngineServer
+            $databaseEngineServerObject = Connect-SQL -ServerName $mockExpectedDatabaseEngineServer -ErrorAction 'Stop'
             $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly $mockExpectedDatabaseEngineServer
 
             Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It `
@@ -2946,7 +2946,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
             $mockExpectedDatabaseEngineInstance = 'MSSQLSERVER'
             $mockExpectedDatabaseEngineLoginSecure = $false
 
-            $databaseEngineServerObject = Connect-SQL -ServerName $mockExpectedDatabaseEngineServer -SetupCredential $mockSqlCredential -LoginType 'SqlLogin'
+            $databaseEngineServerObject = Connect-SQL -ServerName $mockExpectedDatabaseEngineServer -SetupCredential $mockSqlCredential -LoginType 'SqlLogin' -ErrorAction 'Stop'
             $databaseEngineServerObject.ConnectionContext.LoginSecure | Should -Be $false
             $databaseEngineServerObject.ConnectionContext.Login | Should -Be $mockSqlCredentialUserName
             $databaseEngineServerObject.ConnectionContext.SecurePassword | Should -Be $mockSqlCredentialSecurePassword
@@ -2960,9 +2960,9 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
     Context 'When connecting to the named instance using integrated Windows Authentication' {
         It 'Should return the correct service instance' {
             $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
-            $mockExpectedDatabaseEngineInstance = $mockInstanceName
+            $mockExpectedDatabaseEngineInstance = 'SqlInstance'
 
-            $databaseEngineServerObject = Connect-SQL -InstanceName $mockExpectedDatabaseEngineInstance
+            $databaseEngineServerObject = Connect-SQL -InstanceName $mockExpectedDatabaseEngineInstance -ErrorAction 'Stop'
             $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly "$mockExpectedDatabaseEngineServer\$mockExpectedDatabaseEngineInstance"
 
             Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It `
@@ -2973,10 +2973,10 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
     Context 'When connecting to the named instance using SQL Server Authentication' {
         It 'Should return the correct service instance' {
             $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
-            $mockExpectedDatabaseEngineInstance = $mockInstanceName
+            $mockExpectedDatabaseEngineInstance = 'SqlInstance'
             $mockExpectedDatabaseEngineLoginSecure = $false
 
-            $databaseEngineServerObject = Connect-SQL -InstanceName $mockExpectedDatabaseEngineInstance -SetupCredential $mockSqlCredential -LoginType 'SqlLogin'
+            $databaseEngineServerObject = Connect-SQL -InstanceName $mockExpectedDatabaseEngineInstance -SetupCredential $mockSqlCredential -LoginType 'SqlLogin' -ErrorAction 'Stop'
             $databaseEngineServerObject.ConnectionContext.LoginSecure | Should -Be $false
             $databaseEngineServerObject.ConnectionContext.Login | Should -Be $mockSqlCredentialUserName
             $databaseEngineServerObject.ConnectionContext.SecurePassword | Should -Be $mockSqlCredentialSecurePassword
@@ -2990,9 +2990,9 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
     Context 'When connecting to the named instance using integrated Windows Authentication and different server name' {
         It 'Should return the correct service instance' {
             $mockExpectedDatabaseEngineServer = 'SERVER'
-            $mockExpectedDatabaseEngineInstance = $mockInstanceName
+            $mockExpectedDatabaseEngineInstance = 'SqlInstance'
 
-            $databaseEngineServerObject = Connect-SQL -ServerName $mockExpectedDatabaseEngineServer -InstanceName $mockExpectedDatabaseEngineInstance
+            $databaseEngineServerObject = Connect-SQL -ServerName $mockExpectedDatabaseEngineServer -InstanceName $mockExpectedDatabaseEngineInstance -ErrorAction 'Stop'
             $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly "$mockExpectedDatabaseEngineServer\$mockExpectedDatabaseEngineInstance"
 
             Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It `
@@ -3003,7 +3003,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
     Context 'When connecting to the named instance using Windows Authentication impersonation' {
         BeforeAll {
             $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
-            $mockExpectedDatabaseEngineInstance = $mockInstanceName
+            $mockExpectedDatabaseEngineInstance = 'SqlInstance'
         }
 
         Context 'When using the default login type' {
@@ -3016,7 +3016,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
             }
 
             It 'Should return the correct service instance' {
-                $databaseEngineServerObject = Connect-SQL @testParameters
+                $databaseEngineServerObject = Connect-SQL @testParameters -ErrorAction 'Stop'
                 $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly "$mockExpectedDatabaseEngineServer\$mockExpectedDatabaseEngineInstance"
                 $databaseEngineServerObject.ConnectionContext.ConnectAsUser | Should -Be $true
                 $databaseEngineServerObject.ConnectionContext.ConnectAsUserPassword | Should -BeExactly $mockWinCredential.GetNetworkCredential().Password
@@ -3041,7 +3041,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
                 }
 
                 It 'Should return the correct service instance' {
-                    $databaseEngineServerObject = Connect-SQL @testParameters
+                    $databaseEngineServerObject = Connect-SQL @testParameters -ErrorAction 'Stop'
                     $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly "$mockExpectedDatabaseEngineServer\$mockExpectedDatabaseEngineInstance"
                     $databaseEngineServerObject.ConnectionContext.ConnectAsUser | Should -Be $true
                     $databaseEngineServerObject.ConnectionContext.ConnectAsUserPassword | Should -BeExactly $mockWinCredential.GetNetworkCredential().Password
@@ -3065,7 +3065,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
                 }
 
                 It 'Should return the correct service instance' {
-                    $databaseEngineServerObject = Connect-SQL @testParameters
+                    $databaseEngineServerObject = Connect-SQL @testParameters -ErrorAction 'Stop'
                     $databaseEngineServerObject.ConnectionContext.ServerInstance | Should -BeExactly "$mockExpectedDatabaseEngineServer\$mockExpectedDatabaseEngineInstance"
                     $databaseEngineServerObject.ConnectionContext.ConnectAsUser | Should -Be $true
                     $databaseEngineServerObject.ConnectionContext.ConnectAsUserPassword | Should -BeExactly $mockWinFqdnCredential.GetNetworkCredential().Password
@@ -3081,26 +3081,42 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
     }
 
     Context 'When connecting to the default instance using the correct service instance but does not return a correct Database Engine object' {
-        It 'Should throw the correct error' {
-            $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
-            $mockExpectedDatabaseEngineInstance = $mockInstanceName
+        Context 'When using ErrorAction set to Stop' {
+            It 'Should throw the correct error' {
+                $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
+                $mockExpectedDatabaseEngineInstance = 'MissingInstance'
 
-            Mock -CommandName New-Object `
-                -MockWith $mockNewObject_MicrosoftDatabaseEngine `
-                -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
+                Mock -CommandName New-Object `
+                    -MockWith $mockNewObject_MicrosoftDatabaseEngine `
+                    -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
 
-            $mockLocalizedString = InModuleScope -ScriptBlock {
-                $script:localizedData.FailedToConnectToDatabaseEngineInstance
+                $mockLocalizedString = InModuleScope -ScriptBlock {
+                    $script:localizedData.FailedToConnectToDatabaseEngineInstance
+                }
+
+                $mockErrorMessage = $mockLocalizedString -f $mockExpectedDatabaseEngineServer
+
+                { Connect-SQL -ErrorAction 'Stop' } | Should -Throw -ExpectedMessage ($mockErrorMessage + '*')
+
+                Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
             }
+        }
 
-            $mockErrorRecord = Get-InvalidOperationRecord -Message (
-                $mockLocalizedString -f $mockExpectedDatabaseEngineServer
-            )
+        Context 'When using ErrorAction set to SilentlyContinue' {
+            It 'Should not throw an exception' {
+                $mockExpectedDatabaseEngineServer = $env:COMPUTERNAME
+                $mockExpectedDatabaseEngineInstance = 'MissingInstance'
 
-            { Connect-SQL } | Should -Throw -ExpectedMessage ($mockErrorRecord.Exception.Message + '*')
+                Mock -CommandName New-Object `
+                    -MockWith $mockNewObject_MicrosoftDatabaseEngine `
+                    -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
 
-            Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It `
-                -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
+                { Connect-SQL -ErrorAction 'SilentlyContinue' } | Should -Not -Throw
+
+                Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It `
+                    -ParameterFilter $mockNewObject_MicrosoftDatabaseEngine_ParameterFilter
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc.Common
  - `Connect-SQL`
    - Was updated to handle both `-ErrorAction 'Stop'` and `-ErrorAction 'SilentlyContinue'`
      when passed to the command ([issue #1837]).

#### This Pull Request (PR) fixes the following issues
- Fixes #1837

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
