### PR TITLE
`Connect-SQL`: Returns clear error message when status is not Online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Connect-SQL`
     - Was updated to handle both `-ErrorAction 'Stop'` and `-ErrorAction 'SilentlyContinue'`
       when passed to the command ([issue #1837](https://github.com/dsccommunity/SqlServerDsc/issues/1837)).
+    - Now returns a more clear error message when the status of a database
+      instance is not `Online`.
 
 ### Fixed
 

--- a/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/en-US/SqlServerDsc.Common.strings.psd1
@@ -56,4 +56,5 @@ ConvertFrom-StringData @'
     LoadedAssembly = Loaded the assembly '{0}'. (SQLCOMMON0068)
     FailedToLoadAssembly = Failed to load the assembly '{0}'. (SQLCOMMON0069)
     FailedToObtainServerInstance = Failed to obtain a SQL Server instance with name '{0}' on server '{1}'. Ensure the SQL Server instance exists on the server and that the 'SQLServer' module references a version of the 'Microsoft.SqlServer.Management.Smo.Wmi' library that supports the version of the SQL Server instance. (SQLCOMMON0070)
+    DatabaseEngineInstanceNotOnline = The SQL instance '{0}' was expected to have the status 'Online', but had status '{1}'. (SQLCOMMON0071)
 '@

--- a/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
+++ b/source/Modules/SqlServerDsc.Common/sv-SE/SqlServerDsc.Common.strings.psd1
@@ -62,4 +62,5 @@ ConvertFrom-StringData @'
     LoadedAssembly = Loaded the assembly '{0}'. (SQLCOMMON0068)
     FailedToLoadAssembly = Failed to load the assembly '{0}'. (SQLCOMMON0069)
     FailedToObtainServerInstance = Failed to obtain a SQL Server instance with name '{0}' on server '{1}'. Ensure the SQL Server instance exists on the server and that the 'SQLServer' module references a version of the 'Microsoft.SqlServer.Management.Smo.Wmi' library that supports the version of the SQL Server instance. (SQLCOMMON0070)
+    DatabaseEngineInstanceNotOnline = The SQL instance '{0}' was expected to have the status 'Online', but had status '{1}'. (SQLCOMMON0071)
 '@


### PR DESCRIPTION
#### Pull Request (PR) description

- SqlServerDsc.Common
  - `Connect-SQL`
    - Now returns a more clear error message when the status of a database
      instance is not `Online`.

#### This Pull Request (PR) fixes the following issues
None.

I saw that a pipeline build failed with `ScriptHalted` instead of a real message.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1841)
<!-- Reviewable:end -->
