### PR TITLE
`Get-SqlDscAudit`: `Name` no longer mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Get-TargetResource` was updated to always return an array for parameter
     `TraceFlags`, `TraceFlagsToInclude`, and `TraceFlagsToInclude`. _The last_
     _two properties will always return an empty array._
+- `Get-SqlDscAudit`
+  - The parameter `Name` is no longer mandatory. When left out all the current
+    audits are returned.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed the regular expression `features?` from the GitVersion configuration.
     Before, if a fix commit mentioned the word feature but means a SQL Server
     feature GitVersion would bump minor instead of patch number.
+- `Get-SqlDscAudit`
+  - The parameter `Name` is no longer mandatory. When left out all the current
+    audits are returned ([issue #1812](https://github.com/dsccommunity/SqlServerDsc/issues/1812)).
 
 ### Fixed
 
@@ -255,9 +258,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Get-TargetResource` was updated to always return an array for parameter
     `TraceFlags`, `TraceFlagsToInclude`, and `TraceFlagsToInclude`. _The last_
     _two properties will always return an empty array._
-- `Get-SqlDscAudit`
-  - The parameter `Name` is no longer mandatory. When left out all the current
-    audits are returned ([issue #1812](https://github.com/dsccommunity/SqlServerDsc/issues/1812)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,7 +257,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     _two properties will always return an empty array._
 - `Get-SqlDscAudit`
   - The parameter `Name` is no longer mandatory. When left out all the current
-    audits are returned.
+    audits are returned ([issue #1812](https://github.com/dsccommunity/SqlServerDsc/issues/1812)).
 
 ### Fixed
 

--- a/source/Classes/020.SqlAudit.ps1
+++ b/source/Classes/020.SqlAudit.ps1
@@ -260,9 +260,11 @@ class SqlAudit : SqlResourceBase
 
         $serverObject = $this.GetServerObject()
 
-        $auditObject = $serverObject |
-            Get-SqlDscAudit -Name $properties.Name -ErrorAction 'SilentlyContinue' |
-            Select-Object -First 1
+        $auditObjectArray = $serverObject |
+            Get-SqlDscAudit -Name $properties.Name -ErrorAction 'SilentlyContinue'
+
+        # Pick the only object in the array.
+        $auditObject = $auditObjectArray | Select-Object -First 1
 
         if ($auditObject)
         {
@@ -350,9 +352,11 @@ class SqlAudit : SqlResourceBase
             #>
             if ($this.Ensure -eq [Ensure]::Present)
             {
-                $auditObject = $serverObject |
-                    Get-SqlDscAudit -Name $this.Name -ErrorAction 'Stop' |
-                    Select-Object -First 1
+                $auditObjectArray = $serverObject |
+                    Get-SqlDscAudit -Name $this.Name -ErrorAction 'Stop'
+
+                # Pick the only object in the array.
+                $auditObject = $auditObjectArray | Select-Object -First 1
 
                 if ($auditObject)
                 {

--- a/source/Classes/020.SqlAudit.ps1
+++ b/source/Classes/020.SqlAudit.ps1
@@ -261,7 +261,8 @@ class SqlAudit : SqlResourceBase
         $serverObject = $this.GetServerObject()
 
         $auditObject = $serverObject |
-            Get-SqlDscAudit -Name $properties.Name -ErrorAction 'SilentlyContinue'
+            Get-SqlDscAudit -Name $properties.Name -ErrorAction 'SilentlyContinue' |
+            Select-Object -First 1
 
         if ($auditObject)
         {
@@ -350,7 +351,8 @@ class SqlAudit : SqlResourceBase
             if ($this.Ensure -eq [Ensure]::Present)
             {
                 $auditObject = $serverObject |
-                    Get-SqlDscAudit -Name $this.Name -ErrorAction 'Stop'
+                    Get-SqlDscAudit -Name $this.Name -ErrorAction 'Stop' |
+                    Select-Object -First 1
 
                 if ($auditObject)
                 {

--- a/source/Public/Disable-SqlDscAudit.ps1
+++ b/source/Public/Disable-SqlDscAudit.ps1
@@ -85,8 +85,7 @@ function Disable-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $auditObjectArray = $serverObject |
-                Get-SqlDscAudit @getSqlDscAuditParameters
+            $auditObjectArray = Get-SqlDscAudit @getSqlDscAuditParameters
 
             # Pick the only object in the array.
             $AuditObject = $auditObjectArray | Select-Object -First 1

--- a/source/Public/Disable-SqlDscAudit.ps1
+++ b/source/Public/Disable-SqlDscAudit.ps1
@@ -85,8 +85,11 @@ function Disable-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
-                Select-Object -First 1
+            $auditObjectArray = $serverObject |
+                Get-SqlDscAudit -Name @getSqlDscAuditParameters
+
+            # Pick the only object in the array.
+            $AuditObject = $auditObjectArray | Select-Object -First 1
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Disable_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Disable-SqlDscAudit.ps1
+++ b/source/Public/Disable-SqlDscAudit.ps1
@@ -86,7 +86,7 @@ function Disable-SqlDscAudit
 
             # If this command does not find the audit it will throw an exception.
             $auditObjectArray = $serverObject |
-                Get-SqlDscAudit -Name @getSqlDscAuditParameters
+                Get-SqlDscAudit @getSqlDscAuditParameters
 
             # Pick the only object in the array.
             $AuditObject = $auditObjectArray | Select-Object -First 1

--- a/source/Public/Disable-SqlDscAudit.ps1
+++ b/source/Public/Disable-SqlDscAudit.ps1
@@ -85,7 +85,8 @@ function Disable-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters
+            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
+                Select-Object -First 1
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Disable_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Enable-SqlDscAudit.ps1
+++ b/source/Public/Enable-SqlDscAudit.ps1
@@ -85,8 +85,11 @@ function Enable-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
-                Select-Object -First 1
+            $auditObjectArray = $serverObject |
+                Get-SqlDscAudit -Name @getSqlDscAuditParameters
+
+            # Pick the only object in the array.
+            $AuditObject = $auditObjectArray | Select-Object -First 1
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Enable_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Enable-SqlDscAudit.ps1
+++ b/source/Public/Enable-SqlDscAudit.ps1
@@ -85,8 +85,7 @@ function Enable-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $auditObjectArray = $serverObject |
-                Get-SqlDscAudit @getSqlDscAuditParameters
+            $auditObjectArray = Get-SqlDscAudit @getSqlDscAuditParameters
 
             # Pick the only object in the array.
             $AuditObject = $auditObjectArray | Select-Object -First 1

--- a/source/Public/Enable-SqlDscAudit.ps1
+++ b/source/Public/Enable-SqlDscAudit.ps1
@@ -85,7 +85,8 @@ function Enable-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters
+            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
+                Select-Object -First 1
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Enable_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Enable-SqlDscAudit.ps1
+++ b/source/Public/Enable-SqlDscAudit.ps1
@@ -86,7 +86,7 @@ function Enable-SqlDscAudit
 
             # If this command does not find the audit it will throw an exception.
             $auditObjectArray = $serverObject |
-                Get-SqlDscAudit -Name @getSqlDscAuditParameters
+                Get-SqlDscAudit @getSqlDscAuditParameters
 
             # Pick the only object in the array.
             $AuditObject = $auditObjectArray | Select-Object -First 1

--- a/source/Public/New-SqlDscAudit.ps1
+++ b/source/Public/New-SqlDscAudit.ps1
@@ -214,7 +214,8 @@ function New-SqlDscAudit
             ErrorAction = 'SilentlyContinue'
         }
 
-        $auditObject = Get-SqlDscAudit @getSqlDscAuditParameters
+        $auditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
+            Select-Object -First 1
 
         if ($auditObject)
         {

--- a/source/Public/New-SqlDscAudit.ps1
+++ b/source/Public/New-SqlDscAudit.ps1
@@ -214,10 +214,9 @@ function New-SqlDscAudit
             ErrorAction = 'SilentlyContinue'
         }
 
-        $auditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
-            Select-Object -First 1
+        $auditObject = Get-SqlDscAudit @getSqlDscAuditParameters
 
-        if ($auditObject)
+        if ($auditObject.Count -gt 0)
         {
             $auditAlreadyPresentMessage = $script:localizedData.Audit_AlreadyPresent -f $Name
 

--- a/source/Public/Remove-SqlDscAudit.ps1
+++ b/source/Public/Remove-SqlDscAudit.ps1
@@ -85,8 +85,10 @@ function Remove-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
-                    Select-Object -First 1
+            $auditObjectArray = Get-SqlDscAudit @getSqlDscAuditParameters
+
+            # Pick the only object in the array.
+            $AuditObject = $auditObjectArray | Select-Object -First 1
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Remove_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Remove-SqlDscAudit.ps1
+++ b/source/Public/Remove-SqlDscAudit.ps1
@@ -85,10 +85,8 @@ function Remove-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = [Microsoft.SqlServer.Management.Smo.Audit] (
-                Get-SqlDscAudit @getSqlDscAuditParameters |
+            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
                     Select-Object -First 1
-            )
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Remove_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Remove-SqlDscAudit.ps1
+++ b/source/Public/Remove-SqlDscAudit.ps1
@@ -85,7 +85,8 @@ function Remove-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters
+            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
+                Select-Object -First 1
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Remove_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Remove-SqlDscAudit.ps1
+++ b/source/Public/Remove-SqlDscAudit.ps1
@@ -85,8 +85,10 @@ function Remove-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
-                Select-Object -First 1
+            $AuditObject = [Microsoft.SqlServer.Management.Smo.Audit] (
+                Get-SqlDscAudit @getSqlDscAuditParameters |
+                    Select-Object -First 1
+            )
         }
 
         $verboseDescriptionMessage = $script:localizedData.Audit_Remove_ShouldProcessVerboseDescription -f $AuditObject.Name, $AuditObject.Parent.InstanceName

--- a/source/Public/Set-SqlDscAudit.ps1
+++ b/source/Public/Set-SqlDscAudit.ps1
@@ -259,7 +259,8 @@ function Set-SqlDscAudit
                 ErrorAction = 'Stop'
             }
 
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters
+            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
+                Select-Object -First 1
         }
 
         if ($Refresh.IsPresent)

--- a/source/Public/Set-SqlDscAudit.ps1
+++ b/source/Public/Set-SqlDscAudit.ps1
@@ -259,8 +259,12 @@ function Set-SqlDscAudit
                 ErrorAction = 'Stop'
             }
 
-            $AuditObject = Get-SqlDscAudit @getSqlDscAuditParameters |
-                Select-Object -First 1
+            # If this command does not find the audit it will throw an exception.
+            $auditObjectArray = $serverObject |
+                Get-SqlDscAudit -Name @getSqlDscAuditParameters
+
+            # Pick the only object in the array.
+            $AuditObject = $auditObjectArray | Select-Object -First 1
         }
 
         if ($Refresh.IsPresent)

--- a/source/Public/Set-SqlDscAudit.ps1
+++ b/source/Public/Set-SqlDscAudit.ps1
@@ -261,7 +261,7 @@ function Set-SqlDscAudit
 
             # If this command does not find the audit it will throw an exception.
             $auditObjectArray = $serverObject |
-                Get-SqlDscAudit -Name @getSqlDscAuditParameters
+                Get-SqlDscAudit @getSqlDscAuditParameters
 
             # Pick the only object in the array.
             $AuditObject = $auditObjectArray | Select-Object -First 1

--- a/source/Public/Set-SqlDscAudit.ps1
+++ b/source/Public/Set-SqlDscAudit.ps1
@@ -260,8 +260,7 @@ function Set-SqlDscAudit
             }
 
             # If this command does not find the audit it will throw an exception.
-            $auditObjectArray = $serverObject |
-                Get-SqlDscAudit @getSqlDscAuditParameters
+            $auditObjectArray = Get-SqlDscAudit @getSqlDscAuditParameters
 
             # Pick the only object in the array.
             $AuditObject = $auditObjectArray | Select-Object -First 1

--- a/tests/Unit/Public/Get-SqlDscAudit.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscAudit.Tests.ps1
@@ -53,7 +53,7 @@ Describe 'Get-SqlDscAudit' -Tag 'Public' {
     It 'Should have the correct parameters in parameter set <MockParameterSetName>' -ForEach @(
         @{
             MockParameterSetName = '__AllParameterSets'
-            MockExpectedParameters = '[-ServerObject] <Server> [-Name] <string> [-Refresh] [<CommonParameters>]'
+            MockExpectedParameters = '[-ServerObject] <Server> [[-Name] <string>] [-Refresh] [<CommonParameters>]'
         }
     ) {
         $result = (Get-Command -Name 'Get-SqlDscAudit').ParameterSets |


### PR DESCRIPTION

#### Pull Request (PR) description
- `Get-SqlDscAudit`
  - The parameter `Name` is no longer mandatory. When left out all the current
    audits are returned.

#### This Pull Request (PR) fixes the following issues

- Fixes #1812

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1850)
<!-- Reviewable:end -->
