### PR TITLE
`Import-SqlDscPreferredModule`: Allow unit tests to run cross-plattform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Uninstall-SqlDscServer`
   - Was changed to support the SQL Server 2022 GA feature `AzureExtension`
     (that replaced the feature name `ARC`) ([issue #1798](https://github.com/dsccommunity/SqlServerDsc/issues/1798)).
+- `Import-SqlDscPreferredModule`
+  - No longer tries to get the environment variables from the machine state
+    when run on Linux or macOS. This will allow the unit tests to run
+    cross-plattform.
 - SqlReplication
   - The resource now supports SQL Server 2022. The resource will require
     the module _SqlServer_ v22.0.49-preview or newer when used against an

--- a/source/Public/Import-SqlDscPreferredModule.ps1
+++ b/source/Public/Import-SqlDscPreferredModule.ps1
@@ -91,13 +91,17 @@ function Import-SqlDscPreferredModule
     {
         Write-Verbose -Message ($script:localizedData.PreferredModule_ModuleNotFound)
 
-        <#
-            After installing SQL Server the current PowerShell session doesn't know
-            about the new path that was added for the SQLPS module. This reloads
-            PowerShell session environment variable PSModulePath to make sure it
-            contains all paths.
-        #>
-        Set-PSModulePath -Path ([System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine'))
+        # Only run on Windows that has Machine state.
+        if (-not ($IsLinux -or $IsMacOS))
+        {
+            <#
+                After installing SQL Server the current PowerShell session doesn't know
+                about the new path that was added for the SQLPS module. This reloads
+                PowerShell session environment variable PSModulePath to make sure it
+                contains all paths.
+            #>
+            Set-PSModulePath -Path ([System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine'))
+        }
 
         # Get the newest SQLPS module if more than one exist.
         $availableModule = Get-Module -FullyQualifiedName 'SQLPS' -ListAvailable |


### PR DESCRIPTION

#### Pull Request (PR) description
- `Import-SqlDscPreferredModule`
  - No longer tries to get the environment variables from the machine state
    when run on Linux or macOS. This will allow the unit tests to run
    cross-plattform.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1852)
<!-- Reviewable:end -->
