### PR TITLE
SqlServerDsc: Re-enable Pester's new code coverage method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     is loaded into the session. This will make it possible for classes and
     commands to use and return SQL types. If no module is found it will
     output a warning to install any of the dependent modules.
+  - Add empty constructor to classes to be able to use Pester's new code
+    coverage method. See more information can be found in [pester/Pester#2306](https://github.com/pester/Pester/issues/2306).
 - `Install-SqlServerDsc`
   - No longer throws an exception when parameter `AgtSvcAccount` is not specified.
 - SqlAgReplica

--- a/build.yaml
+++ b/build.yaml
@@ -98,9 +98,7 @@ Pester:
       CoveragePercentTarget: 85
       OutputPath: JaCoCo_coverage.xml
       OutputEncoding: ascii
-      # There is a bug in Pester when running unit tests for classes when 'UseBreakpoints' is turned off.
-      # See error in gist: https://gist.github.com/johlju/c16dfd9587c7e066e8825fc54b33a703
-      UseBreakpoints: true
+      UseBreakpoints: false
     TestResult:
       OutputFormat: NUnitXML
       OutputEncoding: ascii

--- a/source/Classes/002.DatabasePermission.ps1
+++ b/source/Classes/002.DatabasePermission.ps1
@@ -114,6 +114,10 @@ class DatabasePermission : IComparable, System.IEquatable[Object]
     [System.String[]]
     $Permission
 
+    DatabasePermission ()
+    {
+    }
+
     [System.Boolean] Equals([System.Object] $object)
     {
         $isEqual = $false

--- a/source/Classes/002.ServerPermission.ps1
+++ b/source/Classes/002.ServerPermission.ps1
@@ -81,6 +81,11 @@ class ServerPermission : IComparable, System.IEquatable[Object]
     [System.String[]]
     $Permission
 
+
+    ServerPermission ()
+    {
+    }
+
     <#
         TODO: It was not possible to move this to a parent class. But since these are
               generic functions for DatabasePermission and ServerPermission we

--- a/source/Classes/004.StartupParameters.ps1
+++ b/source/Classes/004.StartupParameters.ps1
@@ -34,6 +34,10 @@ class StartupParameters
     [System.UInt32[]]
     $InternalTraceFlag
 
+    StartupParameters ()
+    {
+    }
+
     static [StartupParameters] Parse([System.String] $InstanceStartupParameters)
     {
         Write-Debug -Message (


### PR DESCRIPTION


#### Pull Request (PR) description
- SqlServerDsc
  - Add empty constructor to classes to be able to use Pester's new code
    coverage method. See more information can be found in [pester/Pester#2306](https://github.com/pester/Pester/issues/2306).

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1857)
<!-- Reviewable:end -->
