### PR TITLE
SqlServerDsc: Replace `Import-SQLPSModule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SqlServerDsc
   - Update `appveyor.yml` to use `dotnet tool install` to install _GitVersion_.
+  - The private function `Import-SQLPSModule` was replaced throughout with
+    the public command `Import-SqlDscPreferredModule` ([issue #1848](https://github.com/dsccommunity/SqlServerDsc/issues/1848)).
 
 ## [16.1.0] - 2023-02-28
 

--- a/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
+++ b/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
@@ -210,7 +210,7 @@ function Set-TargetResource
         $StatementTimeout = 600
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     # Connect to the defined instance
     $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -StatementTimeout $StatementTimeout -ErrorAction 'Stop'

--- a/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
+++ b/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
@@ -238,7 +238,7 @@ function Set-TargetResource
         $ProcessOnlyOnActiveNode
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     # Connect to the instance
     $serverObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'

--- a/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
+++ b/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
@@ -137,7 +137,7 @@ function Set-TargetResource
         $serverInstance = "$ServerName\$InstanceName"
     }
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     switch ($Ensure)
     {

--- a/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
+++ b/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
@@ -89,7 +89,7 @@ function Get-TargetResource
         $script:localizedData.GetCurrentState -f $protocolNameProperties.DisplayName, $InstanceName, $computerName
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     <#
         Must connect to the local machine name because $ServerName can point
@@ -186,7 +186,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called when calling Compare-TargetResourceState')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called when calling Compare-TargetResourceState')]
     [CmdletBinding()]
     param
     (
@@ -415,7 +415,7 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called when calling Compare-TargetResourceState')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called when calling Compare-TargetResourceState')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
@@ -97,7 +97,7 @@ function Get-TargetResource
         $script:localizedData.GetCurrentState -f $IpAddressGroup, $InstanceName, $computerName
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     <#
         Must connect to the local machine name because $ServerName can point
@@ -229,7 +229,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called when calling Compare-TargetResourceState')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called when calling Compare-TargetResourceState')]
     [CmdletBinding()]
     param
     (
@@ -493,7 +493,7 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called when calling Compare-TargetResourceState')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called when calling Compare-TargetResourceState')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param

--- a/source/DSCResources/DSC_SqlRS/DSC_SqlRS.psm1
+++ b/source/DSCResources/DSC_SqlRS/DSC_SqlRS.psm1
@@ -467,11 +467,11 @@ function Set-TargetResource
             $reportingServicesDatabaseRightsScript = Invoke-RsCimMethod @invokeRsCimMethodParameters
 
             <#
-                Import-SQLPSModule cmdlet will import SQLPS (SQL 2012/14) or SqlServer module (SQL 2016),
+                Import-SqlDscPreferredModule cmdlet will import SQLPS (SQL 2012/14) or SqlServer module (SQL 2016),
                 and if importing SQLPS, change directory back to the original one, since SQLPS changes the
                 current directory to SQLSERVER:\ on import.
             #>
-            Import-SQLPSModule
+            Import-SqlDscPreferredModule
 
             $invokeSqlCmdParameters = @{
                 ServerInstance = $reportingServicesConnection

--- a/source/DSCResources/DSC_SqlReplication/DSC_SqlReplication.psm1
+++ b/source/DSCResources/DSC_SqlReplication/DSC_SqlReplication.psm1
@@ -93,7 +93,7 @@ function Get-TargetResource
         $script:localizedData.GetCurrentState -f $InstanceName
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     $sqlMajorVersion = Get-SqlInstanceMajorVersion -InstanceName $InstanceName
     $localSqlName = Get-SqlLocalServerName -InstanceName $InstanceName
@@ -227,7 +227,7 @@ function Set-TargetResource
         $UninstallWithForce = $true
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     if (($DistributorMode -eq 'Remote') -and (-not $RemoteDistributor))
     {

--- a/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
+++ b/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
@@ -62,7 +62,7 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 #>
 function Get-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called in Invoke-SqlScript')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called in Invoke-SqlScript')]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -211,7 +211,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called in Invoke-SqlScript')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called in Invoke-SqlScript')]
     [CmdletBinding()]
     param
     (
@@ -341,7 +341,7 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called in Invoke-SqlScript')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called in Invoke-SqlScript')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param

--- a/source/DSCResources/DSC_SqlScriptQuery/DSC_SqlScriptQuery.psm1
+++ b/source/DSCResources/DSC_SqlScriptQuery/DSC_SqlScriptQuery.psm1
@@ -62,7 +62,7 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 #>
 function Get-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called in Invoke-SqlScript')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called in Invoke-SqlScript')]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -211,7 +211,7 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called in Invoke-SqlScript')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called in Invoke-SqlScript')]
     [CmdletBinding()]
     param
     (
@@ -341,7 +341,7 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called in Invoke-SqlScript')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called in Invoke-SqlScript')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param

--- a/source/DSCResources/DSC_SqlServiceAccount/DSC_SqlServiceAccount.psm1
+++ b/source/DSCResources/DSC_SqlServiceAccount/DSC_SqlServiceAccount.psm1
@@ -35,7 +35,7 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 #>
 function Get-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is called when Get-ServiceObject is called')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is called when Get-ServiceObject is called')]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -127,7 +127,7 @@ function Get-TargetResource
 #>
 function Test-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is implicitly called when calling Get-TargetResource')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is implicitly called when calling Get-TargetResource')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -209,7 +209,7 @@ function Test-TargetResource
 #>
 function Set-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is called when Get-ServiceObject is called')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is called when Get-ServiceObject is called')]
     [CmdletBinding()]
     param
     (
@@ -326,7 +326,7 @@ function Get-ServiceObject
     }
 
     # Load the SMO libraries
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     $verboseMessage = $script:localizedData.ConnectingToWmi -f $ServerName
     Write-Verbose -Message $verboseMessage

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -1615,7 +1615,7 @@ function Set-TargetResource
                 matches the latest assemblies in GAC, mitigating for example
                 issue #1151.
             #>
-            Import-SQLPSModule -Force
+            Import-SqlDscPreferredModule -Force
         }
 
         if (-not (Test-TargetResource @PSBoundParameters))

--- a/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
+++ b/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
@@ -34,7 +34,7 @@ function Get-TargetResource
     )
 
     # Import SqlServer module.
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     Write-Verbose -Message (
         $script:localizedData.GetConfiguration -f $InstanceName
@@ -188,7 +188,7 @@ function Set-TargetResource
     )
 
     # Import SqlServer module.
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     Write-Verbose -Message (
         $script:localizedData.SetConfiguration -f $InstanceName
@@ -363,7 +363,7 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SQLPSModule is called when Get-TargetResource is called')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Import-SqlDscPreferredModule is called when Get-TargetResource is called')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
@@ -32,7 +32,6 @@
         'Connect-SQL'
         'Connect-SQLAnalysis'
         'Get-SqlInstanceMajorVersion'
-        'Import-SqlDscPreferredModule'
         'Restart-SqlService'
         'Restart-ReportingServicesService'
         'Invoke-Query'

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
@@ -32,7 +32,7 @@
         'Connect-SQL'
         'Connect-SQLAnalysis'
         'Get-SqlInstanceMajorVersion'
-        'Import-SQLPSModule'
+        'Import-SqlDscPreferredModule'
         'Restart-SqlService'
         'Restart-ReportingServicesService'
         'Invoke-Query'

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -496,7 +496,7 @@ function Connect-SQL
         $StatementTimeout = 600
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     if ($InstanceName -eq 'MSSQLSERVER')
     {
@@ -697,7 +697,7 @@ function Connect-SQLAnalysis
     {
         if ((Test-FeatureFlag -FeatureFlag $FeatureFlag -TestFlag 'AnalysisServicesConnection'))
         {
-            Import-SQLPSModule
+            Import-SqlDscPreferredModule
 
             $analysisServicesObject = New-Object -TypeName 'Microsoft.AnalysisServices.Server'
 
@@ -2083,7 +2083,7 @@ function Invoke-SqlScript
         $Encrypt
     )
 
-    Import-SQLPSModule
+    Import-SqlDscPreferredModule
 
     if ($PSCmdlet.ParameterSetName -eq 'File')
     {

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -862,29 +862,6 @@ function Get-SqlInstanceMajorVersion
 
 <#
     .SYNOPSIS
-        Imports the module SQLPS in a standardized way.
-
-    .PARAMETER Force
-        Forces the removal of the previous SQL module, to load the same or newer
-        version fresh. This is meant to make sure the newest version is used, with
-        the latest assemblies.
-
-#>
-function Import-SQLPSModule
-{
-    [CmdletBinding()]
-    param
-    (
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $Force
-    )
-
-    Import-SqlDscPreferredModule @PSBoundParameters
-}
-
-<#
-    .SYNOPSIS
         Restarts a SQL Server instance and associated services
 
     .PARAMETER ServerName

--- a/tests/QA/AnalyzerRules/SqlServerDsc.AnalyzerRules.psm1
+++ b/tests/QA/AnalyzerRules/SqlServerDsc.AnalyzerRules.psm1
@@ -1,9 +1,9 @@
 <#
     .SYNOPSIS
-        Validates that each *-TargetResource calls Import-SQLPSModule.
+        Validates that each *-TargetResource calls Import-SqlDscPreferredModule.
 
     .DESCRIPTION
-        Every *-TargetResource function should include a call to Import-SQLPSModule
+        Every *-TargetResource function should include a call to Import-SqlDscPreferredModule
         so that SMO assemblies are loaded into the PowerShell session.
 
     .EXAMPLE
@@ -53,18 +53,18 @@ function Measure-CommandsNeededToLoadSMO
             $astFilter = {
                 $args[0] -is [System.Management.Automation.Language.CommandAst] `
                 -and (
-                    $args[0].CommandElements.Value -eq 'Import-SQLPSModule' `
+                    $args[0].CommandElements.Value -eq 'Import-SqlDscPreferredModule' `
                     -or $args[0].CommandElements.Value -eq 'Connect-SQL'
                 )
             }
 
-            # Find all command calls of Import-SQLPSModule in the function.
+            # Find all command calls of Import-SqlDscPreferredModule in the function.
             $commandAsts = $FunctionAst.FindAll($astFilter, $true)
 
             # If no calls was found then an error record should be returned.
             if (-not $commandAsts)
             {
-                $diagnosticRecord['Message'] = 'The function is not calling Import-SQLPSModule or Connect-SQL. If it is meant not to, then suppress the rule ''SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO'' with a justification. See https://github.com/PowerShell/PSScriptAnalyzer#suppressing-rules for more information.'
+                $diagnosticRecord['Message'] = 'The function is not calling Import-SqlDscPreferredModule or Connect-SQL. If it is meant not to, then suppress the rule ''SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO'' with a justification. See https://github.com/PowerShell/PSScriptAnalyzer#suppressing-rules for more information.'
                 $diagnosticRecord -as $diagnosticRecordType
             }
         }

--- a/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
+++ b/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
@@ -375,7 +375,7 @@ REVERT'
 
 
                 Mock -CommandName Connect-SQL -MockWith { return $mockServerObject } -Verifiable
-                Mock -CommandName Import-SQLPSModule -Verifiable
+                Mock -CommandName Import-SqlDscPreferredModule -Verifiable
             }
 
             BeforeEach {
@@ -400,7 +400,7 @@ REVERT'
                     $result.DatabaseName | Should -BeNullOrEmpty
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 0 -Exactly
                 }
 
                 It 'Should not return any databases if there are no databases in the availability group' {
@@ -414,7 +414,7 @@ REVERT'
                     $result.DatabaseName | Should -BeNullOrEmpty
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 0 -Exactly
                 }
 
                 It 'Should return databases when there are databases in the availability group' {
@@ -435,7 +435,7 @@ REVERT'
                     }
 
                     Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
-                    Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 0 -Exactly
+                    Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 0 -Exactly
                 }
             }
         }
@@ -772,7 +772,7 @@ REVERT'
 
                     Mock -CommandName Get-PrimaryReplicaServerObject -MockWith { return $mockServerObject } -Verifiable -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                     Mock -CommandName Get-PrimaryReplicaServerObject -MockWith { return $mockServer2Object } -Verifiable -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                    Mock -CommandName Import-SQLPSModule -Verifiable
+                    Mock -CommandName Import-SqlDscPreferredModule -Verifiable
                     Mock -CommandName Invoke-Query -Verifiable -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                     Mock -CommandName Invoke-Query -Verifiable -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
                     Mock -CommandName Join-Path -MockWith { [IO.Path]::Combine($databaseMembershipClass.BackupPath,"$($database.Name)_Full_$(Get-Date -Format 'yyyyMMddhhmmss').bak") } -Verifiable -ParameterFilter { $ChildPath -like '*_Full_*.bak' }
@@ -822,7 +822,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -849,7 +849,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -876,7 +876,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -903,7 +903,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -931,7 +931,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -958,7 +958,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1009,7 +1009,7 @@ REVERT'
                             Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                            Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                            Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1039,7 +1039,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1075,7 +1075,7 @@ REVERT'
                             Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                            Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                            Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1106,7 +1106,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1137,7 +1137,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1168,7 +1168,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1199,7 +1199,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1230,7 +1230,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1257,7 +1257,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1284,7 +1284,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1311,7 +1311,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1338,7 +1338,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1370,7 +1370,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1431,7 +1431,7 @@ REVERT'
                     $mockServerObject_Set.ServiceName = 'MSSQLSERVER'
                     $mockServerObject_Set.AvailabilityGroups[$mockAvailabilityGroupObject_Set.Name].LocalReplicaRole = 'Primary'
 
-                    Mock -CommandName Import-SQLPSModule
+                    Mock -CommandName Import-SqlDscPreferredModule
 
                     Mock -CommandName Connect-SQL -MockWith {
                         return $mockServerObject_Set
@@ -1472,7 +1472,7 @@ REVERT'
                     It 'Should remove the specified database from the availability group(s)' {
                         { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
 
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Remove-SqlAvailabilityDatabase -ParameterFilter {
@@ -1493,7 +1493,7 @@ REVERT'
 
                         { Set-TargetResource @mockSetTargetResourceParameters } | Should -Throw $errorMessage
 
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Remove-SqlAvailabilityDatabase -Scope It -Times 1 -Exactly
@@ -1832,7 +1832,7 @@ REVERT'
 
                     Mock -CommandName Get-PrimaryReplicaServerObject -MockWith { return $mockServerObject } -Verifiable -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                     Mock -CommandName Get-PrimaryReplicaServerObject -MockWith { return $mockServer2Object } -Verifiable -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                    Mock -CommandName Import-SQLPSModule -Verifiable
+                    Mock -CommandName Import-SqlDscPreferredModule -Verifiable
                     Mock -CommandName Invoke-Query -Verifiable -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                     Mock -CommandName Invoke-Query -Verifiable -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
                     Mock -CommandName Join-Path -MockWith { [IO.Path]::Combine($databaseMembershipClass.BackupPath,"$($database.Name)_Full_$(Get-Date -Format 'yyyyMMddhhmmss').bak") } -Verifiable -ParameterFilter { $ChildPath -like '*_Full_*.bak' }
@@ -1882,7 +1882,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1909,7 +1909,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1936,7 +1936,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 0 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1963,7 +1963,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -1991,7 +1991,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2018,7 +2018,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 1 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2069,7 +2069,7 @@ REVERT'
                             Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                            Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                            Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2099,7 +2099,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2135,7 +2135,7 @@ REVERT'
                             Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                             Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                            Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                            Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                             Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2166,7 +2166,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2197,7 +2197,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2228,7 +2228,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2259,7 +2259,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2291,7 +2291,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2322,7 +2322,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 2 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2349,7 +2349,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs
@@ -2381,7 +2381,7 @@ REVERT'
                         Assert-MockCalled -CommandName Connect-SQL -Scope It -Times 3 -Exactly -ParameterFilter { $ServerName -eq 'Server2' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server1' }
                         Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 0 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
-                        Assert-MockCalled -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                        Assert-MockCalled -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 2 -Exactly -ParameterFilter { $Query -like 'EXEC master.dbo.xp_fileexist *' }
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabase
                         Assert-MockCalled -CommandName Invoke-Query -Scope It -Times 0 -Exactly -ParameterFilter $mockInvokeQueryParameterRestoreDatabaseWithExecuteAs

--- a/tests/Unit/DSC_SqlAGReplica.Tests.ps1
+++ b/tests/Unit/DSC_SqlAGReplica.Tests.ps1
@@ -445,7 +445,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             return $mockServerObject
         }
 
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
 
         Mock -CommandName Connect-SQL -MockWith $mockConnectSqlServer1 -ParameterFilter {
             $ServerName -eq 'Server1'
@@ -520,7 +520,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Exactly -Times 1 -Scope It
@@ -576,7 +576,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Exactly -Times 1 -Scope It
@@ -621,7 +621,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                 $ServerName -eq 'ServerNotEnabled'
             } -Times 1 -Exactly
 
-            Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
         }
     }
 
@@ -660,7 +660,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                 $ServerName -eq 'ServerWithoutEndpoint'
             } -Times 1 -Exactly
 
-            Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
         }
     }
 
@@ -717,7 +717,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                 $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
             }
 
-            Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Join-SqlAvailabilityGroup -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName New-SqlAvailabilityReplica -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -773,7 +773,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -830,7 +830,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -898,7 +898,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -966,7 +966,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -1028,7 +1028,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
@@ -1092,7 +1092,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName Test-ClusterPermissions -Exactly -Times 1 -Scope It
@@ -1187,7 +1187,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
                     $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server3'
                 }
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Join-SqlAvailabilityGroup -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName New-SqlAvailabilityReplica -Scope It -Times 0 -Exactly
                 Should -Invoke -CommandName Remove-SqlAvailabilityReplica -Scope It -Times 0 -Exactly

--- a/tests/Unit/DSC_SqlAlwaysOnService.Tests.ps1
+++ b/tests/Unit/DSC_SqlAlwaysOnService.Tests.ps1
@@ -417,7 +417,7 @@ Describe 'SqlAlwaysOnService\Set-TargetResource' {
 
     Context 'When the system is not in the desired state' {
         BeforeAll {
-            Mock -CommandName Import-SQLPSModule
+            Mock -CommandName Import-SqlDscPreferredModule
             Mock -CommandName Restart-SqlService
         }
 
@@ -449,7 +449,7 @@ Describe 'SqlAlwaysOnService\Set-TargetResource' {
                         { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
                     }
 
-                    Should -Invoke -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                    Should -Invoke -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                     Should -Invoke -CommandName Disable-SqlAlwaysOn -Scope It -Times 1 -Exactly
                     Should -Invoke -CommandName Restart-SqlService -Scope It -Times 1 -Exactly
                 }
@@ -473,7 +473,7 @@ Describe 'SqlAlwaysOnService\Set-TargetResource' {
                         { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw
                     }
 
-                    Should -Invoke -CommandName Import-SQLPSModule -Scope It -Times 1 -Exactly
+                    Should -Invoke -CommandName Import-SqlDscPreferredModule -Scope It -Times 1 -Exactly
                     Should -Invoke -CommandName Enable-SqlAlwaysOn -Scope It -Times 1 -Exactly
                     Should -Invoke -CommandName Restart-SqlService -Scope It -Times 1 -Exactly
                 }

--- a/tests/Unit/DSC_SqlProtocol.Tests.ps1
+++ b/tests/Unit/DSC_SqlProtocol.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'SqlProtocol\Get-TargetResource' -Tag 'Get' {
             scoping them to the module's scope since they are imported by
             the module that is being tested.
         #>
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
 
         <#
             This sets a variable inside the module scope. The name of the

--- a/tests/Unit/DSC_SqlProtocolTcpIp.Tests.ps1
+++ b/tests/Unit/DSC_SqlProtocolTcpIp.Tests.ps1
@@ -66,7 +66,7 @@ AfterAll {
 
 Describe 'SqlProtocolTcpIp\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
 
         InModuleScope -ScriptBlock {
             $script:mockInstanceName = 'DSCTEST'

--- a/tests/Unit/DSC_SqlRS.Tests.ps1
+++ b/tests/Unit/DSC_SqlRS.Tests.ps1
@@ -507,7 +507,7 @@ Describe 'SqlRS\Set-TargetResource' -Tag 'Set' {
         #>
         Mock -CommandName Invoke-CimMethod -MockWith $mockInvokeCimMethod
 
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
         Mock -CommandName Invoke-SqlCmd
         Mock -CommandName Restart-ReportingServicesService
         Mock -CommandName Invoke-RsCimMethod

--- a/tests/Unit/DSC_SqlReplication.Tests.ps1
+++ b/tests/Unit/DSC_SqlReplication.Tests.ps1
@@ -138,7 +138,7 @@ Describe 'The system is not in the desired state given Local distribution mode' 
         Mock -CommandName Install-RemoteDistributor
         Mock -CommandName Register-DistributorPublisher
         Mock -CommandName Uninstall-Distributor
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'The system is not in the desired state' {
@@ -324,7 +324,7 @@ Describe 'The system is not in the desired state given Remote distribution mode'
         Mock -CommandName Install-RemoteDistributor
         Mock -CommandName Register-DistributorPublisher
         Mock -CommandName Uninstall-Distributor
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'The system is not in the desired state' {
@@ -528,7 +528,7 @@ Describe 'The system is in sync given Local distribution mode' {
         Mock -CommandName Install-RemoteDistributor
         Mock -CommandName Register-DistributorPublisher
         Mock -CommandName Uninstall-Distributor
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'Get method' {
@@ -709,7 +709,7 @@ Describe 'The system is in sync given Remote distribution mode' {
         Mock -CommandName Install-RemoteDistributor
         Mock -CommandName Register-DistributorPublisher
         Mock -CommandName Uninstall-Distributor
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'Get method' {
@@ -889,7 +889,7 @@ Describe 'The system is not in desired state given Local distribution, but shoul
         Mock -CommandName Install-RemoteDistributor
         Mock -CommandName Register-DistributorPublisher
         Mock -CommandName Uninstall-Distributor
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'Get method' {
@@ -1070,7 +1070,7 @@ Describe 'The system is not in desired state given Remote distribution, but shou
         Mock -CommandName Install-RemoteDistributor
         Mock -CommandName Register-DistributorPublisher
         Mock -CommandName Uninstall-Distributor
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'Get method' {
@@ -1251,7 +1251,7 @@ Describe 'The system is in sync when Absent' {
         Mock -CommandName Install-RemoteDistributor
         Mock -CommandName Register-DistributorPublisher
         Mock -CommandName Uninstall-Distributor
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'Get method' {

--- a/tests/Unit/DSC_SqlServiceAccount.Tests.ps1
+++ b/tests/Unit/DSC_SqlServiceAccount.Tests.ps1
@@ -1149,7 +1149,7 @@ Describe 'SqlServerServiceAccount\Get-SqlServiceName' -Tag 'Helper' {
 
 Describe 'SqlServerServiceAccount\Get-ServiceObject' -Tag 'Helper' {
     BeforeAll {
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
 
         InModuleScope -ScriptBlock {
             $script:mockDefaultGetServiceObjectParameters = @{
@@ -1195,7 +1195,7 @@ Describe 'SqlServerServiceAccount\Get-ServiceObject' -Tag 'Helper' {
             }
 
             # Ensure mocks are properly used
-            Should -Invoke -CommandName Import-SQLPSModule -Scope It -Exactly -Times 1
+            Should -Invoke -CommandName Import-SqlDscPreferredModule -Scope It -Exactly -Times 1
             Should -Invoke -CommandName New-Object -Scope It -Exactly -Times 1
         }
     }
@@ -1241,7 +1241,7 @@ Describe 'SqlServerServiceAccount\Get-ServiceObject' -Tag 'Helper' {
             }
 
             # Ensure mocks are properly used
-            Should -Invoke -CommandName Import-SQLPSModule -Scope It -Exactly -Times 1
+            Should -Invoke -CommandName Import-SqlDscPreferredModule -Scope It -Exactly -Times 1
             Should -Invoke -CommandName New-Object -Scope It -Exactly -Times 1
         }
     }

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -2146,7 +2146,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
 
         # General mocks
         Mock -CommandName Get-PSDrive
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
         Mock -CommandName Get-FilePathMajorVersion -MockWith $mockGetSqlMajorVersion
 
         # Mocking SharedDirectory and SharedWowDirectory (when not previously installed)
@@ -2264,7 +2264,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
                     Should -Invoke -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                    Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 }
             }
 
@@ -2535,7 +2535,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
                     Should -Invoke -CommandName Get-PSDrive -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Test-TargetResource -Exactly -Times 1 -Scope It
-                    Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 0 -Scope It
+                    Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 0 -Scope It
                 }
             }
         }
@@ -2812,7 +2812,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
                 }
 
                 Should -Invoke -CommandName Write-Warning -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 0 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 0 -Scope It
             }
         }
     }

--- a/tests/Unit/DSC_SqlTraceFlag.Tests.ps1
+++ b/tests/Unit/DSC_SqlTraceFlag.Tests.ps1
@@ -154,7 +154,7 @@ Describe 'DSC_SqlTraceFlag\Get-TargetResource' -Tag 'Get' {
             $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer'
         }
 
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
 
         InModuleScope -ScriptBlock {
             # Default parameters that are used for the It-blocks.
@@ -821,7 +821,7 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf
             $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer'
         }
 
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
         Mock -CommandName Restart-SqlService
 
         InModuleScope -ScriptBlock {

--- a/tests/Unit/SqlServerDsc.AnalyzerRules.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.AnalyzerRules.Tests.ps1
@@ -87,7 +87,7 @@ Describe 'Measure-CommandsNeededToLoadSMO' {
         #>
         Import-Module -Name 'PSScriptAnalyzer'
 
-        $expectedErrorRecordMessage = 'The function is not calling Import-SQLPSModule or Connect-SQL. If it is meant not to, then suppress the rule ''SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO'' with a justification. See https://github.com/PowerShell/PSScriptAnalyzer#suppressing-rules for more information.'
+        $expectedErrorRecordMessage = 'The function is not calling Import-SqlDscPreferredModule or Connect-SQL. If it is meant not to, then suppress the rule ''SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO'' with a justification. See https://github.com/PowerShell/PSScriptAnalyzer#suppressing-rules for more information.'
     }
 
     Context 'When calling the function directly' {
@@ -96,7 +96,7 @@ Describe 'Measure-CommandsNeededToLoadSMO' {
             $ruleName = 'Measure-CommandsNeededToLoadSMO'
         }
 
-        Context 'When a function do not have a call to neither Import-SQLPSModule or Connect-SQL' {
+        Context 'When a function do not have a call to neither Import-SqlDscPreferredModule or Connect-SQL' {
             It 'Should write the correct error record for function <FunctionName>' -ForEach $testCase {
                 $definition = "
                     function Get-Something {}
@@ -126,10 +126,10 @@ Describe 'Measure-CommandsNeededToLoadSMO' {
             }
         }
 
-        Context 'When a function have a call to Import-SQLPSModule' {
+        Context 'When a function have a call to Import-SqlDscPreferredModule' {
             It 'Should not return an error record for function <FunctionName>' -ForEach $testCase {
                 $definition = "
-                    function Import-SQLPSModule {}
+                    function Import-SqlDscPreferredModule {}
 
                     function $FunctionName
                     {
@@ -137,7 +137,7 @@ Describe 'Measure-CommandsNeededToLoadSMO' {
                         [OutputType([System.Collections.Hashtable])]
                         param ()
 
-                        Import-SQLPSModule
+                        Import-SqlDscPreferredModule
 
                         return @{}
                     }
@@ -192,7 +192,7 @@ Describe 'Measure-CommandsNeededToLoadSMO' {
             $ruleName = 'SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO'
         }
 
-        Context 'When a function do not have a call to neither Import-SQLPSModule or Connect-SQL' {
+        Context 'When a function do not have a call to neither Import-SqlDscPreferredModule or Connect-SQL' {
             It 'Should write the correct error record for function <FunctionName>' -ForEach $testCase {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = "
                     function Get-Something {}
@@ -236,10 +236,10 @@ Describe 'Measure-CommandsNeededToLoadSMO' {
             }
         }
 
-        Context 'When a function have a call to Import-SQLPSModule' {
+        Context 'When a function have a call to Import-SqlDscPreferredModule' {
             It 'Should not write an error record for function <FunctionName>' -ForEach $testCase {
                 $invokeScriptAnalyzerParameters['ScriptDefinition'] = "
-                    function Import-SQLPSModule {}
+                    function Import-SqlDscPreferredModule {}
 
                     function $FunctionName
                     {
@@ -247,7 +247,7 @@ Describe 'Measure-CommandsNeededToLoadSMO' {
                         [OutputType([System.Collections.Hashtable])]
                         param ()
 
-                        Import-SQLPSModule
+                        Import-SqlDscPreferredModule
 
                         return @{}
                     }

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -2221,16 +2221,6 @@ Describe 'SqlServerDsc.Common\Test-LoginEffectivePermissions' -Tag 'TestLoginEff
     }
 }
 
-Describe 'SqlServerDsc.Common\Import-SQLPSModule' -Tag 'ImportSQLPSModule' {
-    BeforeAll {
-        Mock -CommandName Import-SqlDscPreferredModule
-    }
-
-    It 'Should not throw an exception' {
-        { Import-SQLPSModule } | Should -Not -Throw
-    }
-}
-
 Describe 'SqlServerDsc.Common\Get-SqlInstanceMajorVersion' -Tag 'GetSqlInstanceMajorVersion' {
     BeforeAll {
         $mockSqlMajorVersion = 13

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -1574,7 +1574,7 @@ Describe 'SqlServerDsc.Common\Connect-SQLAnalysis' -Tag 'ConnectSQLAnalysis' {
 
     Context 'When using feature flag ''AnalysisServicesConnection''' {
         BeforeAll {
-            Mock -CommandName Import-SQLPSModule
+            Mock -CommandName Import-SqlDscPreferredModule
 
             $mockExpectedDataSource = "Data Source=$mockComputerName"
         }
@@ -1583,7 +1583,7 @@ Describe 'SqlServerDsc.Common\Connect-SQLAnalysis' -Tag 'ConnectSQLAnalysis' {
             It 'Should not throw when connecting' {
                 { Connect-SQLAnalysis -FeatureFlag 'AnalysisServicesConnection' } | Should -Not -Throw
 
-                Should -Invoke -CommandName Import-SQLPSModule -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-SqlDscPreferredModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It `
                     -ParameterFilter $mockNewObject_MicrosoftAnalysisServicesServer_ParameterFilter
             }
@@ -2635,7 +2635,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
     }
 
     BeforeEach {
-        Mock -CommandName Import-SQLPSModule
+        Mock -CommandName Import-SqlDscPreferredModule
     }
 
     Context 'When connecting to the default instance using integrated Windows Authentication' {
@@ -3207,7 +3207,7 @@ Describe 'SqlServerDsc.Common\Invoke-SqlScript' -Tag 'InvokeSqlScript' {
         BeforeAll {
             $throwMessage = "Failed to import SQLPS module."
 
-            Mock -CommandName Import-SQLPSModule -MockWith {
+            Mock -CommandName Import-SqlDscPreferredModule -MockWith {
                 throw $throwMessage
             }
         }
@@ -3228,7 +3228,7 @@ Describe 'SqlServerDsc.Common\Invoke-SqlScript' -Tag 'InvokeSqlScript' {
             $password = ConvertTo-SecureString -String $mockPasswordPlain -AsPlainText -Force
             $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $mockUsername, $password
 
-            Mock -CommandName Import-SQLPSModule
+            Mock -CommandName Import-SqlDscPreferredModule
             Mock -CommandName Invoke-SqlCmd -ParameterFilter {
                 $Username -eq $mockUsername -and $Password -eq $mockPasswordPlain
             }
@@ -3272,7 +3272,7 @@ Describe 'SqlServerDsc.Common\Invoke-SqlScript' -Tag 'InvokeSqlScript' {
         BeforeEach {
             $errorMessage = 'Failed to run SQL Script'
 
-            Mock -CommandName Import-SQLPSModule
+            Mock -CommandName Import-SqlDscPreferredModule
             Mock -CommandName Invoke-SqlCmd -MockWith {
                 throw $errorMessage
             }
@@ -3292,7 +3292,7 @@ Describe 'SqlServerDsc.Common\Invoke-SqlScript' -Tag 'InvokeSqlScript' {
             # Import PowerShell module SqlServer stub cmdlets.
             Import-SQLModuleStub
 
-            Mock -CommandName Import-SQLPSModule
+            Mock -CommandName Import-SqlDscPreferredModule
             Mock -CommandName Invoke-SqlCmd
         }
 


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc
  - The private function `Import-SQLPSModule` was replaced throughout with
    the public command `Import-SqlDscPreferredModule` (issue #1848).

#### This Pull Request (PR) fixes the following issues

- Fixes #1848

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1862)
<!-- Reviewable:end -->
