### PR TITLE
`Restart-SqlService`: Correctly evaluate timeout value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     is more correct and not a duplicate.
   - Integration tests configuration names was renamed to better tell what
     the configuration does ([issue #1880](https://github.com/dsccommunity/SqlServerDsc/issues/1880)).
+- SqlServerDsc.Common
+  - The command `Restart-SqlService` was updated to correctly evaluate when
+    the timeout value is reached ([issue #1889](https://github.com/dsccommunity/SqlServerDsc/issues/1889)).
 
 ## [16.1.0] - 2023-02-28
 

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -1030,7 +1030,7 @@ function Restart-SqlService
 
             # Waiting 2 seconds to not hammer the SQL Server instance.
             Start-Sleep -Seconds 2
-        } until ($connectTimer.Elapsed.Seconds -ge $Timeout)
+        } until ($connectTimer.Elapsed.TotalSeconds -ge $Timeout)
 
         $connectTimer.Stop()
 


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc.Common
  - The command `Restart-SqlService` was updated to correctly evaluate when
    the timeout value is reached (issue #1889).

#### This Pull Request (PR) fixes the following issues

- Fixes #1889

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1890)
<!-- Reviewable:end -->
