### PR TITLE
SqlSecureConnection: Added new parameter `ServerName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SqlSecureConnection`
   - Added new parameter `ServerName` that will be used as the host name when
     restarting the SQL Server instance. The specified value should be the same
-    name that is used in the certificate.
+    name that is used in the certificate ([issue #1888](https://github.com/dsccommunity/SqlServerDsc/issues/1888)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     other values that the default values.
   - Now updates GitHub Actions automatically by allowing dependabot sending
     in pull requests.
+- `SqlSecureConnection`
+  - Added new parameter `ServerName` that will be used as the host name when
+    restarting the SQL Server instance. The specified value should be the same
+    name that is used in the certificate.
 
 ### Changed
 

--- a/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
+++ b/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
@@ -29,6 +29,13 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
         If set to $true then the required restart will be suppressed.
         You will need to restart the service before changes will take effect.
         The default value is $false.
+
+    .PARAMETER ServerName
+        Specifies the host name that will be used when restarting the SQL Server
+        instance. If the SQL Server belongs to a cluster or availability group
+        specify the host name for the listener or cluster group. The specified
+        name must match the name that is used by the certificate specified for
+        the parameter `Thumbprint`. Default value is `localhost`.
 #>
 function Get-TargetResource
 {
@@ -61,7 +68,11 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $SuppressRestart = $false
+        $SuppressRestart = $false,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = 'localhost'
     )
 
     Write-Verbose -Message (
@@ -165,6 +176,7 @@ function Get-TargetResource
         Ensure          = [System.String] $ensureValue
         ServiceAccount  = [System.String] $ServiceAccount
         SuppressRestart = [System.Boolean] $SuppressRestart
+        ServerName      = [System.String] $ServerName
     }
 }
 
@@ -191,6 +203,13 @@ function Get-TargetResource
         If set to $true then the required restart will be suppressed.
         You will need to restart the service before changes will take effect.
         The default value is $false.
+
+    .PARAMETER ServerName
+        Specifies the host name that will be used when restarting the SQL Server
+        instance. If the SQL Server belongs to a cluster or availability group
+        specify the host name for the listener or cluster group. The specified
+        name must match the name that is used by the certificate specified for
+        the parameter `Thumbprint`. Default value is `localhost`.
 #>
 function Set-TargetResource
 {
@@ -222,7 +241,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $SuppressRestart = $false
+        $SuppressRestart = $false,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = 'localhost'
     )
 
     # Configuration manager requires thumbprint to be lowercase or it won't display the configured certificate.
@@ -282,7 +305,7 @@ function Set-TargetResource
             $script:localizedData.RestartingService -f $InstanceName
         )
 
-        Restart-SqlService -ServerName localhost -InstanceName $InstanceName
+        Restart-SqlService -ServerName $ServerName -InstanceName $InstanceName
     }
 }
 
@@ -309,6 +332,15 @@ function Set-TargetResource
         If set to $true then the required restart will be suppressed.
         You will need to restart the service before changes will take effect.
         The default value is $false.
+
+        Not used in Test-TargetResource.
+
+    .PARAMETER ServerName
+        Specifies the host name that will be used when restarting the SQL Server
+        instance. If the SQL Server belongs to a cluster or availability group
+        specify the host name for the listener or cluster group. The specified
+        name must match the name that is used by the certificate specified for
+        the parameter `Thumbprint`. Default value is `localhost`.
 
         Not used in Test-TargetResource.
 #>
@@ -343,7 +375,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $SuppressRestart = $false
+        $SuppressRestart = $false,
+
+        [Parameter()]
+        [System.String]
+        $ServerName = 'localhost'
     )
 
     $parameters = @{

--- a/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.schema.mof
+++ b/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.schema.mof
@@ -8,5 +8,5 @@ class DSC_SqlSecureConnection : OMI_BaseResource
     [Required, Description("Name of the account running the _SQL Server_ _Windows_ service. If this parameter is set to `'LocalSystem'` then a connection error is displayed, instead use the value `'SYSTEM'`.")] String ServiceAccount;
     [Write, Description("If set to `$true` then the required restart will be suppressed. You will need to restart the service before changes will take effect. The default value is `$false`.")] Boolean SuppressRestart;
     [Write, Description("If encryption should be enabled (`'Present'`) or disabled (`'Absent'`)."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies the host name that will be used when restarting the SQL Server instance. If the SQL Server belongs to a cluster or availability group specify the host name for the listener or cluster group. The specified name must match the name that is used by the certificate specified for the parameter `Thumbprint`. Default value is `localhost`.")] String ServerName;
 };
-

--- a/source/Examples/Resources/SqlSecureConnection/1-ForceSecureConnection.ps1
+++ b/source/Examples/Resources/SqlSecureConnection/1-ForceSecureConnection.ps1
@@ -15,6 +15,7 @@ Configuration Example
             ForceEncryption = $true
             Ensure          = 'Present'
             ServiceAccount  = 'SqlSvc'
+            ServerName      = 'host.company.local'
         }
     }
 }

--- a/tests/Integration/DSC_SqlSecureConnection.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSecureConnection.Integration.Tests.ps1
@@ -171,7 +171,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
                 -and $_.ResourceId -eq $resourceId
             }
 
-            $resourceCurrentState.Thumbprint | Should -BeNullOrEmpty
+            $resourceCurrentState.Thumbprint | Should -Be 'Empty'
             $resourceCurrentState.ForceEncryption | Should -BeFalse
             $resourceCurrentState.ServerName | Should -Be 'localhost'
         }

--- a/tests/Integration/DSC_SqlSecureConnection.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SqlSecureConnection.Integration.Tests.ps1
@@ -114,8 +114,10 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
                 $_.ConfigurationName -eq $configurationName `
                 -and $_.ResourceId -eq $resourceId
             }
+
             $resourceCurrentState.Thumbprint | Should -Be $env:SqlCertificateThumbprint
-            $resourceCurrentState.ForceEncryption | Should -Be $true
+            $resourceCurrentState.ForceEncryption | Should -BeTrue
+            $resourceCurrentState.ServerName | Should -Be 'localhost'
         }
 
         It 'Should return $true when Test-DscConfiguration is run' {
@@ -169,8 +171,9 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
                 -and $_.ResourceId -eq $resourceId
             }
 
-            $resultObject.Thumbprint | Should -BeNullOrEmpty
-            $resourceCurrentState.ForceEncryption | Should -Be $false
+            $resourceCurrentState.Thumbprint | Should -BeNullOrEmpty
+            $resourceCurrentState.ForceEncryption | Should -BeFalse
+            $resourceCurrentState.ServerName | Should -Be 'localhost'
         }
 
         It 'Should return $true when Test-DscConfiguration is run' {

--- a/tests/Integration/DSC_SqlSecureConnection.config.ps1
+++ b/tests/Integration/DSC_SqlSecureConnection.config.ps1
@@ -43,11 +43,12 @@ Configuration DSC_SqlSecureConnection_AddSecureConnection_Config
     {
         SqlSecureConnection 'Integration_Test'
         {
-            InstanceName = $Node.InstanceName
-            Ensure = 'Present'
-            Thumbprint = $Node.Thumbprint
-            ServiceAccount = $Node.ServiceAccount
+            InstanceName    = $Node.InstanceName
+            Ensure          = 'Present'
+            Thumbprint      = $Node.Thumbprint
+            ServiceAccount  = $Node.ServiceAccount
             ForceEncryption = $true
+            ServerName      = 'localhost'
         }
     }
 }
@@ -64,9 +65,9 @@ Configuration DSC_SqlSecureConnection_RemoveSecureConnection_Config
     {
         SqlSecureConnection 'Integration_Test'
         {
-            InstanceName = $Node.InstanceName
-            Ensure = 'Absent'
-            Thumbprint = ''
+            InstanceName   = $Node.InstanceName
+            Ensure         = 'Absent'
+            Thumbprint     = ''
             ServiceAccount = $Node.ServiceAccount
         }
     }

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -1088,6 +1088,10 @@ Describe 'SqlServerDsc.Common\Restart-SqlService' -Tag 'RestartSqlService' {
                     Restart-SqlService -ServerName $env:ComputerName -InstanceName 'MSSQLSERVER' -Timeout 4 -SkipClusterCheck
                 } | Should -Throw -ExpectedMessage $mockErrorMessage
 
+                <#
+                    Not using -Exactly to handle when CI is slower, result is
+                    that there are 3 calls to Connect-SQL.
+                #>
                 Should -Invoke -CommandName Connect-SQL -ParameterFilter {
                     <#
                         Make sure we assert the second call to Connect-SQL
@@ -1096,7 +1100,7 @@ Describe 'SqlServerDsc.Common\Restart-SqlService' -Tag 'RestartSqlService' {
                         we cannot use `$PSBoundParameters.ContainsKey('ErrorAction') -eq $true`.
                     #>
                     $ErrorAction -eq 'SilentlyContinue'
-                } -Scope It -Exactly -Times 2
+                } -Scope It -Times 2
             }
         }
     }


### PR DESCRIPTION

#### Pull Request (PR) description
- `SqlSecureConnection`
  - Added new parameter `ServerName` that will be used as the host name when
    restarting the SQL Server instance. The specified value should be the same
    name that is used in the certificate (issue #1888).

#### This Pull Request (PR) fixes the following issues

- Fixes #1888

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1892)
<!-- Reviewable:end -->
