### PR TITLE
SqlSetup: Add parameter ServerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New public command:
     - `Get-SqlDscPreferredModule` - Returns the name of the first available
       preferred module ([issue #1879](https://github.com/dsccommunity/SqlServerDsc/issues/1879)).
-- `SqlSecureConnection`
+- SqlSecureConnection
   - Added new parameter `ServerName` that will be used as the host name when
     restarting the SQL Server instance. The specified value should be the same
     name that is used in the certificate ([issue #1888](https://github.com/dsccommunity/SqlServerDsc/issues/1888)).
+- SqlSetup
+  - Added new parameter `ServerName` that will be used as the host name when
+    evaluating the SQL Server instance. If using a secure connection the
+    specified value should be the same name that is used in the certificate
+    ([issue #1893](https://github.com/dsccommunity/SqlServerDsc/issues/1893)).
 
 ### Changed
 

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -47,10 +47,11 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
         the language corresponding to the operating system.
 
     .PARAMETER ServerName
-        Specifies the host name of the SQL Server to be configured. If the SQL
-        Server belongs to a cluster or availability group specify the host name
-        for the listener or cluster group. Default value is the current computer
-        name.
+        Specifies the host or network name of the _SQL Server_ instance. If the
+        SQL Server belongs to a cluster or availability group it could be set to
+        the host name for the listener or cluster group. If using a secure connection
+        the specified value should be the same name that is used in the certificate.
+        Default value is the current computer name.
 #>
 function Get-TargetResource
 {
@@ -662,10 +663,11 @@ function Get-TargetResource
         Specifies optional skip rules during setup.
 
     .PARAMETER ServerName
-        Specifies the host name of the SQL Server to be configured. If the SQL
-        Server belongs to a cluster or availability group specify the host name
-        for the listener or cluster group. Default value is the current computer
-        name.
+        Specifies the host or network name of the _SQL Server_ instance. If the
+        SQL Server belongs to a cluster or availability group it could be set to
+        the host name for the listener or cluster group. If using a secure connection
+        the specified value should be the same name that is used in the certificate.
+        Default value is the current computer name.
 #>
 function Set-TargetResource
 {
@@ -1889,10 +1891,11 @@ function Set-TargetResource
         Not used in Test-TargetResource.
 
     .PARAMETER ServerName
-        Specifies the host name of the SQL Server to be configured. If the SQL
-        Server belongs to a cluster or availability group specify the host name
-        for the listener or cluster group. Default value is the current computer
-        name.
+        Specifies the host or network name of the _SQL Server_ instance. If the
+        SQL Server belongs to a cluster or availability group it could be set to
+        the host name for the listener or cluster group. If using a secure connection
+        the specified value should be the same name that is used in the certificate.
+        Default value is the current computer name.
 #>
 function Test-TargetResource
 {

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -45,6 +45,12 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
         Specifies to install the English version of SQL Server on a localized operating
         system when the installation media includes language packs for both English and
         the language corresponding to the operating system.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. If the SQL
+        Server belongs to a cluster or availability group specify the host name
+        for the listener or cluster group. Default value is the current computer
+        name.
 #>
 function Get-TargetResource
 {
@@ -85,7 +91,11 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $UseEnglish
+        $UseEnglish,
+
+        [Parameter()]
+        [System.String]
+        $ServerName
     )
 
     if ($FeatureFlag)
@@ -144,6 +154,7 @@ function Get-TargetResource
         FailoverClusterGroupName   = $null
         FailoverClusterIPAddress   = $null
         UseEnglish                 = $UseEnglish
+        ServerName                 = $ServerName
     }
 
     <#
@@ -156,7 +167,14 @@ function Get-TargetResource
     }
     else
     {
-        $sqlHostName = Get-ComputerName
+        if ($PSBoundParameters.ContainsKey('ServerName'))
+        {
+            $sqlHostName = $ServerName
+        }
+        else
+        {
+            $sqlHostName = Get-ComputerName
+        }
     }
 
     # Force drive list update, to pick up any newly mounted volumes
@@ -642,6 +660,12 @@ function Get-TargetResource
 
     .PARAMETER SkipRule
         Specifies optional skip rules during setup.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. If the SQL
+        Server belongs to a cluster or availability group specify the host name
+        for the listener or cluster group. Default value is the current computer
+        name.
 #>
 function Set-TargetResource
 {
@@ -903,7 +927,11 @@ function Set-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String[]]
-        $SkipRule
+        $SkipRule,
+
+        [Parameter()]
+        [System.String]
+        $ServerName
     )
 
     <#
@@ -925,6 +953,11 @@ function Set-TargetResource
         InstanceName               = $InstanceName
         FailoverClusterNetworkName = $FailoverClusterNetworkName
         FeatureFlag                = $FeatureFlag
+    }
+
+    if ($PSBoundParameters.ContainsKey('ServerName'))
+    {
+        $getTargetResourceParameters.ServerName = $ServerName
     }
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
@@ -1854,6 +1887,12 @@ function Set-TargetResource
         Specifies optional skip rules during setup.
 
         Not used in Test-TargetResource.
+
+    .PARAMETER ServerName
+        Specifies the host name of the SQL Server to be configured. If the SQL
+        Server belongs to a cluster or availability group specify the host name
+        for the listener or cluster group. Default value is the current computer
+        name.
 #>
 function Test-TargetResource
 {
@@ -2115,7 +2154,11 @@ function Test-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String[]]
-        $SkipRule
+        $SkipRule,
+
+        [Parameter()]
+        [System.String]
+        $ServerName
     )
 
     <#
@@ -2136,9 +2179,13 @@ function Test-TargetResource
         FeatureFlag                = $FeatureFlag
     }
 
-    $boundParameters = $PSBoundParameters
+    if ($PSBoundParameters.ContainsKey('ServerName'))
+    {
+        $getTargetResourceParameters.ServerName = $ServerName
+    }
 
     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+
     if ($null -eq $getTargetResourceResult.Features -or $getTargetResourceResult.Features -eq '')
     {
         Write-Verbose -Message $script:localizedData.NoFeaturesFound
@@ -2160,6 +2207,7 @@ function Test-TargetResource
             if ($feature -notin $foundFeaturesArray)
             {
                 Write-Verbose -Message ($script:localizedData.UnableToFindFeature -f $feature, $($getTargetResourceResult.Features))
+
                 $result = $false
             }
         }
@@ -2173,14 +2221,15 @@ function Test-TargetResource
     {
         Write-Verbose -Message $script:localizedData.EvaluatingClusterParameters
 
-        $variableNames = $boundParameters.Keys |
+        $variableNames = $PSBoundParameters.Keys |
             Where-Object -FilterScript { $_ -imatch "^FailoverCluster" }
 
         foreach ($variableName in $variableNames)
         {
-            if ($getTargetResourceResult.$variableName -ne $boundParameters[$variableName])
+            if ($getTargetResourceResult.$variableName -ne $PSBoundParameters.$variableName)
             {
-                Write-Verbose -Message ($script:localizedData.ClusterParameterIsNotInDesiredState -f $variableName, $($boundParameters[$variableName]))
+                Write-Verbose -Message ($script:localizedData.ClusterParameterIsNotInDesiredState -f $variableName, ($PSBoundParameters.$variableName))
+
                 $result = $false
             }
         }

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
@@ -68,6 +68,6 @@ class DSC_SqlSetup : OMI_BaseResource
     [Write, Description("Feature flags are used to toggle DSC resource functionality on or off. See the DSC resource documentation for what additional functionality exist through a feature flag.")] String FeatureFlag[];
     [Write, Description("Specifies to install the English version of _SQL Server_ on a localized operating system when the installation media includes language packs for both English and the language corresponding to the operating system.")] Boolean UseEnglish;
     [Write, Description("Specifies optional skip rules during setup.")] String SkipRule[];
-    [Write, Description("Specifies the host or network name of the _SQL Server_ instance. If the SQL Server belongs to a cluster or availability group specify the host name for the listener or cluster group. Default value is the current computer name.")] String ServerName;
+    [Write, Description("Specifies the host or network name of the _SQL Server_ instance. If the SQL Server belongs to a cluster or availability group it could be set to the host name for the listener or cluster group. If using a secure connection the specified value should be the same name that is used in the certificate. Default value is the current computer name.")] String ServerName;
     [Read, Description("Returns a boolean value of `$true` if the instance is clustered, otherwise it returns `$false`.")] Boolean IsClustered;
 };

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
@@ -68,5 +68,6 @@ class DSC_SqlSetup : OMI_BaseResource
     [Write, Description("Feature flags are used to toggle DSC resource functionality on or off. See the DSC resource documentation for what additional functionality exist through a feature flag.")] String FeatureFlag[];
     [Write, Description("Specifies to install the English version of _SQL Server_ on a localized operating system when the installation media includes language packs for both English and the language corresponding to the operating system.")] Boolean UseEnglish;
     [Write, Description("Specifies optional skip rules during setup.")] String SkipRule[];
+    [Write, Description("Specifies the host or network name of the _SQL Server_ instance. If the SQL Server belongs to a cluster or availability group specify the host name for the listener or cluster group. Default value is the current computer name.")] String ServerName;
     [Read, Description("Returns a boolean value of `$true` if the instance is clustered, otherwise it returns `$false`.")] Boolean IsClustered;
 };

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -311,6 +311,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                     SourceCredential = $null
                     SourcePath = $TestDrive
                     Feature = 'NewFeature' # Test enabling a code-feature.
+                    ServerName = 'host.company.local'
                 }
             }
         }
@@ -376,6 +377,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                 $result.ASConfigDir | Should -BeNullOrEmpty
                 $result.ASServerMode | Should -BeNullOrEmpty
                 $result.ISSvcAccountUsername | Should -BeNullOrEmpty
+                $result.ServerName | Should -Be 'host.company.local'
             }
         }
     }
@@ -1734,6 +1736,7 @@ Describe 'SqlSetup\Test-TargetResource' -Tag 'Test' {
                     $mockTestTargetResourceParameters.InstanceName = 'MSSQLSERVER'
                     $mockTestTargetResourceParameters.SourceCredential = $null
                     $mockTestTargetResourceParameters.SourcePath = $TestDrive
+                    $mockTestTargetResourceParameters.ServerName = 'host.company.local'
 
                     $result = Test-TargetResource @mockTestTargetResourceParameters
 
@@ -2300,6 +2303,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
                             SourcePath = $TestDrive
                             ProductKey = '1FAKE-2FAKE-3FAKE-4FAKE-5FAKE'
                             NpEnabled = $true
+                            ServerName = 'host.company.local'
                         }
 
                         { Set-TargetResource @mockSetTargetResourceParameters } | Should -Not -Throw


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlSetup
  - Added new parameter `ServerName` that will be used as the host name when
    evaluating the SQL Server instance. If using a secure connection the
    specified value should be the same name that is used in the certificate
    (issue #1893).

#### This Pull Request (PR) fixes the following issues

- Fixes #1893

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1900)
<!-- Reviewable:end -->
