### PR TITLE
`Get-SqlDscPreferredModule`: Using command `Get-PSModulePath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New public command:
     - `Get-SqlDscPreferredModule` - Returns the name of the first available
       preferred module ([issue #1879](https://github.com/dsccommunity/SqlServerDsc/issues/1879)).
+      - Re-using the command `Get-PSModulePath` from the module DscResource.Common.
 - SqlSecureConnection
   - Added new parameter `ServerName` that will be used as the host name when
     restarting the SQL Server instance. The specified value should be the same

--- a/source/Public/Get-SqlDscPreferredModule.ps1
+++ b/source/Public/Get-SqlDscPreferredModule.ps1
@@ -70,28 +70,7 @@ function Get-SqlDscPreferredModule
                 contains all paths.
             #>
 
-            <#
-                TODO: This should be replaced by Get-PSModulePath that is in
-                PR https://github.com/dsccommunity/DscResource.Common/pull/104.
-            #>
-
-            <#
-                Get the environment variables from all targets session, user and machine.
-                Casts the value to System.String to convert $null values to empty string.
-            #>
-            $modulePathSession = [System.String] [System.Environment]::GetEnvironmentVariable('PSModulePath')
-            $modulePathUser = [System.String] [System.Environment]::GetEnvironmentVariable('PSModulePath', 'User')
-            $modulePathMachine = [System.String] [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
-
-            $modulePath = $modulePathSession, $modulePathUser, $modulePathMachine -join ';'
-
-            $modulePathArray = $modulePath -split ';' |
-                Where-Object -FilterScript {
-                    -not [System.String]::IsNullOrEmpty($_)
-                } |
-                Sort-Object -Unique
-
-            $modulePath = $modulePathArray -join ';'
+            $modulePath = Get-PSModulePath -FromTarget 'Session', 'User', 'Machine'
 
             Set-PSModulePath -Path $modulePath
         }

--- a/tests/Unit/Public/Get-SqlDscPreferredModule.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscPreferredModule.Tests.ps1
@@ -406,6 +406,10 @@ Describe 'Get-SqlDscPreferredModule' -Tag 'Public' {
     Context 'When specifying the parameter Refresh' {
         BeforeAll {
             Mock -CommandName Set-PSModulePath
+            Mock -CommandName Get-PSModulePath -MockWith {
+                return 'MockPath'
+            }
+
             Mock -CommandName Get-Module -MockWith {
                 return @{
                     Name = 'SqlServer'


### PR DESCRIPTION

#### Pull Request (PR) description
- `Get-SqlDscPreferredModule`
  - Re-using the command `Get-PSModulePath` from the module DscResource.Common.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1905)
<!-- Reviewable:end -->
