### PR TITLE
`Invoke-SetupAction`: Expand environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Assert-SetupActionProperties` was changed to throw
     an exception when a feature is not supported (calls `Assert-Feature`).
     The private command is indirectly used by the setup action commands.
+  - `Invoke-SetupAction` was changed to expand environment variables that
+    is passed as the media path.
 - SqlSetup
   - Update to support checking non-supported features using the command
     `SqlDscIsSupportedFeature` ([issue #1872](https://github.com/dsccommunity/SqlServerDsc/issues/1872)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Gitversion no longer evaluates bumping major version using the word "major".
-- Update private command:
+- Update private commands:
   - `Assert-SetupActionProperties` was changed to throw
     an exception when a feature is not supported (calls `Assert-Feature`).
     The private command is indirectly used by the setup action commands.

--- a/source/Private/Invoke-SetupAction.ps1
+++ b/source/Private/Invoke-SetupAction.ps1
@@ -1672,8 +1672,10 @@ function Invoke-SetupAction
 
     if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
     {
+        $expandedMediaPath = [System.Environment]::ExpandEnvironmentVariables($MediaPath)
+
         $startProcessParameters = @{
-            FilePath     = Join-Path -Path $MediaPath -ChildPath 'setup.exe'
+            FilePath     = Join-Path -Path $expandedMediaPath -ChildPath 'setup.exe'
             ArgumentList = $setupArgument
             Timeout      = $Timeout
         }


### PR DESCRIPTION

#### Pull Request (PR) description
- Update private command:
  - `Invoke-SetupAction` was changed to expand environment variables that
    is passed as the media path.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1914)
<!-- Reviewable:end -->
