### PR TITLE
SqlServerDsc: Forcibly use a specific version of dbatools.library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- SqlServerDsc
+  - Forcibly use a specific version of dbatools.library to pass integration
+    tests (workaround for issue [#1926 (comment)](https://github.com/dsccommunity/SqlServerDsc/pull/1926#issuecomment-1531685591)).
+
 ## [16.3.0] - 2023-04-26
 
 ### Remove

--- a/tests/Integration/DSC_SqlSetup.config.ps1
+++ b/tests/Integration/DSC_SqlSetup.config.ps1
@@ -436,6 +436,23 @@ Configuration DSC_SqlSetup_InstallSMOModule_Config
                 # Make sure we use TLS 1.2.
                 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
+                if ($using:Node.SMOModuleName -eq 'dbatools')
+                {
+                    $installModuleParameters = @{
+                        Name            = 'dbatools.library'
+                        Scope           = 'AllUsers'
+                        Force           = $true
+                        RequiredVersion = '2023.4.18'
+                        AllowPrerelease = $Using:Node.SMOModuleVersionIsPrerelease
+                        PassThru        = $true
+                    }
+
+                    # Install the required dbatools.library version module version.
+                    $installedModule = Install-Module @installModuleParameters
+
+                    Write-Verbose -Message ('Installed {0} module version {1}' -f 'dbatools.library', $installedModule.Version)
+                }
+
                 $installModuleParameters = @{
                     Name            = $using:Node.SMOModuleName
                     Scope           = 'AllUsers'
@@ -446,7 +463,7 @@ Configuration DSC_SqlSetup_InstallSMOModule_Config
                     PassThru        = $true
                 }
 
-                # Install the required SqlServer module version.
+                # Install the required SMO module version.
                 $installedModule = Install-Module @installModuleParameters |
                     Where-Object -FilterScript {
                         <#


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc
  - Forcibly use a specific version of dbatools.library to pass integration
    tests (workaround for issue [#1926 (comment)](https://github.com/dsccommunity/SqlServerDsc/pull/1926#issuecomment-1531685591)).

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1927)
<!-- Reviewable:end -->
