### PR TITLE
`Import-SqlDscPreferredModule`: Fix checking that SQLPS is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (tested v21.0.17099). The parameter will be ignored if SQLPS module will be
     used.
 
+### Fixed
+
+- `Import-SqlDscPreferredModule`
+  - Now the command does not fail when checking if SQLPS is loaded into the
+    session ([issue #1928](https://github.com/dsccommunity/SqlServerDsc/issues/1928)).
+
 ## [16.3.0] - 2023-04-26
 
 ### Remove

--- a/source/Public/Import-SqlDscPreferredModule.ps1
+++ b/source/Public/Import-SqlDscPreferredModule.ps1
@@ -96,8 +96,12 @@ function Import-SqlDscPreferredModule
     {
         if (-not $Force.IsPresent)
         {
-            # Check if the preferred module is already loaded into the session.
-            $loadedModuleName = (Get-Module -Name $availableModuleName | Select-Object -First 1).Name
+            <#
+                Check if the preferred module is already loaded into the session.
+                If the module name is a path the leaf part must be used, which is
+                the module name.
+            #>
+            $loadedModuleName = (Get-Module -Name (Split-Path -Path $availableModuleName -Leaf) | Select-Object -First 1).Name
 
             if ($loadedModuleName)
             {


### PR DESCRIPTION

#### Pull Request (PR) description
- `Import-SqlDscPreferredModule`
  - Now the command does not fail when checking if SQLPS is loaded into the
    session (issue #1928).

#### This Pull Request (PR) fixes the following issues

- Fixes #1928

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1929)
<!-- Reviewable:end -->
