### PR TITLE
SqlServerDsc: Add public command `Get-SqlDscConfigurationOption`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,7 +70,8 @@
         "GetxPDTVariable",
         "Dbcc",
         "creplace",
-        "dbatools"
+        "dbatools",
+        "fastbuild"
     ],
     "cSpell.ignorePaths": [
         ".git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SqlServerDsc
+  - Added new public command:
+    - `Get-SqlDscConfigurationOption` - Returns the available configuration
+      options that can be used with the DSC resource _SqlConfiguration_.
+
 ### Changed
 
 - SqlServerDsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - SqlServerDsc
+  - Added a new build task `fastbuild` that can be used during development
+    process when there are no need to generate documentation.
   - Added new public command:
     - `Get-SqlDscConfigurationOption` - Returns the available configuration
       options that can be used with the DSC resource _SqlConfiguration_.

--- a/build.yaml
+++ b/build.yaml
@@ -15,11 +15,16 @@ BuildWorkflow:
     - Generate_Conceptual_Help
     - Generate_Wiki_Content
 
+  fastbuild:
+    - Clean
+    - Build_Module_ModuleBuilder
+    - Build_NestedModules_ModuleBuilder
+
   pack:
     - build
-    - package_module_nupkg
+    - package_module_nupkg # cSpell: disable-line
 
-  hqrmtest:
+  hqrmtest: # cSpell: disable-line
     - Invoke_HQRM_Tests_Stop_On_Fail
 
   test:
@@ -146,7 +151,7 @@ Resolve-Dependency:
 GitHubConfig:
   GitHubFilesToAdd:
     - 'CHANGELOG.md'
-  GitHubConfigUserName: dscbot
+  GitHubConfigUserName: dscbot # cSpell: disable-line
   GitHubConfigUserEmail: dsccommunity@outlook.com
   UpdateChangelogOnPrerelease: false
 

--- a/source/DSCResources/DSC_SqlConfiguration/README.md
+++ b/source/DSCResources/DSC_SqlConfiguration/README.md
@@ -3,6 +3,13 @@
 The `SqlConfiguration` DSC resource manages the [SQL Server Configuration Options](https://msdn.microsoft.com/en-us/library/ms189631.aspx)
 on a SQL Server instance.
 
+To list the available configuration option names run:
+
+```powershell
+$serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'SQL2022'
+$serverObject | Get-SqlDscConfigurationOption | ft
+```
+
 ## Requirements
 
 * Target machine must be running Windows Server 2012 or later.

--- a/source/Public/Get-SqlDscConfigurationOption.ps1
+++ b/source/Public/Get-SqlDscConfigurationOption.ps1
@@ -11,6 +11,12 @@
     .PARAMETER Name
         Specifies the name of the configuration option to get.
 
+    .PARAMETER Refresh
+        Specifies that the **ServerObject**'s configuration property should be
+        refreshed before trying get the available configuration options. This is
+        helpful when run values or configuration values have been modified outside
+        of the specified **ServerObject**.
+
     .EXAMPLE
         $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
         $sqlServerObject | Get-SqlDscConfigurationOption
@@ -40,11 +46,21 @@ function Get-SqlDscConfigurationOption
 
         [Parameter()]
         [System.String]
-        $Name
+        $Name,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Refresh
     )
 
     process
     {
+        if ($Refresh.IsPresent)
+        {
+            # Make sure the configuration option values are up-to-date.
+            $serverObject.Configuration.Refresh()
+        }
+
         if ($PSBoundParameters.ContainsKey('Name'))
         {
             $configurationOption = $serverObject.Configuration.Properties |

--- a/source/Public/Get-SqlDscConfigurationOption.ps1
+++ b/source/Public/Get-SqlDscConfigurationOption.ps1
@@ -1,0 +1,79 @@
+<#
+    .SYNOPSIS
+        Get server configuration option.
+
+    .DESCRIPTION
+        This command gets the available configuration options from a SQL Server Database Engine instance.
+
+    .PARAMETER ServerObject
+        Specifies current server connection object.
+
+    .PARAMETER Name
+        Specifies the name of the configuration option to get.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $sqlServerObject | Get-SqlDscConfigurationOption
+
+        Get all the available configuration options.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $sqlServerObject | Get-SqlDscConfigurationOption -Name '*threshold*'
+
+        Get the configuration options that contains the word **threshold**.
+
+    .OUTPUTS
+        `[Microsoft.SqlServer.Management.Smo.ConfigProperty[]]`
+#>
+function Get-SqlDscConfigurationOption
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
+    [OutputType([Microsoft.SqlServer.Management.Smo.ConfigProperty[]])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Microsoft.SqlServer.Management.Smo.Server]
+        $ServerObject,
+
+        [Parameter()]
+        [System.String]
+        $Name
+    )
+
+    process
+    {
+        if ($PSBoundParameters.ContainsKey('Name'))
+        {
+            $configurationOption = $serverObject.Configuration.Properties |
+                Where-Object -FilterScript {
+                    $_.DisplayName -like $Name
+                }
+
+            if (-not $configurationOption)
+            {
+                $missingConfigurationOptionMessage = $script:localizedData.ConfigurationOption_Get_Missing -f $Name
+
+                $writeErrorParameters = @{
+                    Message = $missingConfigurationOptionMessage
+                    Category = 'InvalidOperation'
+                    ErrorId = 'GSDCO0001' # cspell: disable-line
+                    TargetObject = $Name
+                }
+
+                Write-Error @writeErrorParameters
+            }
+        }
+        else
+        {
+            $configurationOption = $serverObject.Configuration.Properties.ForEach({ $_ })
+        }
+
+        return , [Microsoft.SqlServer.Management.Smo.ConfigProperty[]] (
+            $configurationOption |
+                Sort-Object -Property 'DisplayName'
+        )
+    }
+}

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -178,4 +178,7 @@ ConvertFrom-StringData @'
 
     ## Get-FileVersionInformation
     FileVersionInformation_Get_FilePathIsNotFile = The specified path is not a file.
+
+    ## Get-SqlDscConfigurationOption
+    ConfigurationOption_Get_Missing = There is no configuration option with the name '{0}'.
 '@

--- a/tests/Unit/Public/Get-SqlDscConfigurationOption.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscConfigurationOption.Tests.ps1
@@ -1,0 +1,187 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    $env:SqlServerDscCI = $true
+
+    Import-Module -Name $script:dscModuleName
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Item -Path 'env:SqlServerDscCI'
+}
+
+Describe 'Get-SqlDscConfigurationOption' -Tag 'Public' {
+    It 'Should have the correct parameters in parameter set <MockParameterSetName>' -ForEach @(
+        @{
+            MockParameterSetName = '__AllParameterSets'
+            MockExpectedParameters = '[-ServerObject] <Server> [[-Name] <string>] [<CommonParameters>]'
+        }
+    ) {
+        $result = (Get-Command -Name 'Get-SqlDscConfigurationOption').ParameterSets |
+            Where-Object -FilterScript {
+                $_.Name -eq $mockParameterSetName
+            } |
+            Select-Object -Property @(
+                @{
+                    Name = 'ParameterSetName'
+                    Expression = { $_.Name }
+                },
+                @{
+                    Name = 'ParameterListAsString'
+                    Expression = { $_.ToString() }
+                }
+            )
+
+        $result.ParameterSetName | Should -Be $MockParameterSetName
+        $result.ParameterListAsString | Should -Be $MockExpectedParameters
+    }
+
+    Context 'When the specified configuration option exist' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Configuration' -Value {
+                    return @{
+                        Properties = @()
+                    }
+                } -PassThru -Force
+
+            $mockDefaultParameters = @{
+                ServerObject = $mockServerObject
+                Name = 'Unknown Option Name'
+            }
+        }
+
+        Context 'When specifying to throw on error' {
+            BeforeAll {
+                $mockErrorMessage = InModuleScope -ScriptBlock {
+                    $script:localizedData.ConfigurationOption_Get_Missing
+                }
+            }
+
+            It 'Should throw the correct error' {
+                { Get-SqlDscConfigurationOption @mockDefaultParameters -ErrorAction 'Stop' } |
+                    Should -Throw -ExpectedMessage ($mockErrorMessage -f 'Unknown Option Name')
+            }
+        }
+
+        Context 'When ignoring the error' {
+            It 'Should not throw an exception and return $null' {
+                Get-SqlDscConfigurationOption @mockDefaultParameters -ErrorAction 'SilentlyContinue' |
+                    Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'When getting a specific configuration option' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Configuration' -Value {
+                    $configOption1 = [Microsoft.SqlServer.Management.Smo.ConfigProperty]::CreateTypeInstance()
+                    $configOption1.DisplayName = 'blocked process threshold (s)'
+
+                    return @{
+                        Properties = @($configOption1)
+                    }
+                } -PassThru -Force
+        }
+
+        It 'Should return the correct values' {
+            $mockDefaultParameters = @{
+                ServerObject = $mockServerObject
+                Name = 'blocked process threshold (s)'
+            }
+
+            $result = Get-SqlDscConfigurationOption @mockDefaultParameters
+
+            $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.ConfigProperty'
+
+            $result.DisplayName | Should -Be 'blocked process threshold (s)'
+        }
+
+        Context 'When passing parameter ServerObject over the pipeline' {
+            It 'Should return the correct values' {
+                $result = $mockServerObject | Get-SqlDscConfigurationOption -Name 'blocked process threshold (s)'
+
+                $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.ConfigProperty'
+
+                $result.DisplayName | Should -Be 'blocked process threshold (s)'
+            }
+        }
+    }
+
+    Context 'When getting all available configuration options' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Configuration' -Value {
+                    $configOption1 = [Microsoft.SqlServer.Management.Smo.ConfigProperty]::CreateTypeInstance()
+                    $configOption1.DisplayName = 'blocked process threshold (s)'
+
+                    $configOption2 = [Microsoft.SqlServer.Management.Smo.ConfigProperty]::CreateTypeInstance()
+                    $configOption2.DisplayName = 'show advanced options'
+
+                    return @{
+                        Properties = @($configOption1, $configOption2)
+                    }
+                } -PassThru -Force
+        }
+
+        It 'Should return the correct values' {
+            $result = Get-SqlDscConfigurationOption -ServerObject $mockServerObject
+
+            $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.ConfigProperty'
+
+            $result.DisplayName | Should -Contain 'show advanced options'
+            $result.DisplayName | Should -Contain 'blocked process threshold (s)'
+        }
+
+        Context 'When passing parameter ServerObject over the pipeline' {
+            It 'Should return the correct values' {
+                $result = $mockServerObject | Get-SqlDscConfigurationOption
+
+                $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.ConfigProperty'
+
+                $result.DisplayName | Should -Contain 'show advanced options'
+                $result.DisplayName | Should -Contain 'blocked process threshold (s)'
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Get-SqlDscConfigurationOption.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscConfigurationOption.Tests.ps1
@@ -53,7 +53,7 @@ Describe 'Get-SqlDscConfigurationOption' -Tag 'Public' {
     It 'Should have the correct parameters in parameter set <MockParameterSetName>' -ForEach @(
         @{
             MockParameterSetName = '__AllParameterSets'
-            MockExpectedParameters = '[-ServerObject] <Server> [[-Name] <string>] [<CommonParameters>]'
+            MockExpectedParameters = '[-ServerObject] <Server> [[-Name] <string>] [-Refresh] [<CommonParameters>]'
         }
     ) {
         $result = (Get-Command -Name 'Get-SqlDscConfigurationOption').ParameterSets |

--- a/tests/Unit/Stubs/SMO.cs
+++ b/tests/Unit/Stubs/SMO.cs
@@ -959,6 +959,43 @@ namespace Microsoft.SqlServer.Management.Smo
         }
     }
 
+    public class ConfigProperty
+    {
+        // Property
+        public System.String DisplayName { get; set; }
+        public System.Int32 Number { get; set; }
+        public System.Int32 Minimum { get; set; }
+        public System.Int32 Maximum { get; set; }
+        public System.Boolean IsDynamic { get; set; }
+        public System.Boolean IsAdvanced { get; set; }
+        public System.String Description { get; set; }
+        public System.Int32 RunValue { get; set; }
+        public System.Int32 ConfigValue { get; set; }
+
+        // Fabricated constructor
+        private ConfigProperty() { }
+        public static ConfigProperty CreateTypeInstance()
+        {
+            return new ConfigProperty();
+        }
+    }
+
+    public class ConfigPropertyCollection
+    {
+        // Property
+        public System.Int32 Count { get; set; }
+        public System.Boolean IsSynchronized { get; set; }
+        public System.Object SyncRoot { get; set; }
+        public Microsoft.SqlServer.Management.Smo.ConfigProperty Item { get; set; }
+
+        // Fabricated constructor
+        private ConfigPropertyCollection() { }
+        public static ConfigPropertyCollection CreateTypeInstance()
+        {
+            return new ConfigPropertyCollection();
+        }
+    }
+
     #endregion Public Classes
 }
 


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc
  - Added new public command:
    - `Get-SqlDscConfigurationOption` - Returns the available configuration
      options that can be used with the DSC resource _SqlConfiguration_.

#### This Pull Request (PR) fixes the following issues

- Helps with issue #1931 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1935)
<!-- Reviewable:end -->
