### PR TITLE
`Import-SqlDscPreferredModule`: Fix re-evaluate PSModulePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Re-enable integration tests for dbatools.
   - Bumped dbatools to v2.0.1 for the integration tests.
 
+### fixed
+
+- `Import-SqlDscPreferredModule`
+  - Now when parameter `Force` is passed the command correctly invoke
+    `Get-SqlDscPreferredModule` using the parameter `Refresh`.
+
 ## [16.3.1] - 2023-05-06
 
 ### Changed

--- a/source/Public/Import-SqlDscPreferredModule.ps1
+++ b/source/Public/Import-SqlDscPreferredModule.ps1
@@ -65,6 +65,11 @@ function Import-SqlDscPreferredModule
         $getSqlDscPreferredModuleParameters.Name = @($Name, 'SQLPS')
     }
 
+    if ($PSBoundParameters.ContainsKey('Force'))
+    {
+        $getSqlDscPreferredModuleParameters.Refresh = $true
+    }
+
     $availableModuleName = Get-SqlDscPreferredModule @getSqlDscPreferredModuleParameters
 
     if ($Force.IsPresent)

--- a/tests/Unit/Public/Import-SqlDscPreferredModule.Tests.ps1
+++ b/tests/Unit/Public/Import-SqlDscPreferredModule.Tests.ps1
@@ -236,7 +236,10 @@ Describe 'Import-SqlDscPreferredModule' -Tag 'Public' {
         It 'Should import the SqlServer module without throwing' {
             { Import-SqlDscPreferredModule -Force } | Should -Not -Throw
 
-            Should -Invoke -CommandName Get-SqlDscPreferredModule -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Get-SqlDscPreferredModule -ParameterFilter {
+                $PesterBoundParameters.ContainsKey('Refresh') -and $Refresh -eq $true
+            } -Exactly -Times 1 -Scope It
+
             Should -Invoke -CommandName Push-Location -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Pop-Location -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Remove-Module -Exactly -Times 1 -Scope It


### PR DESCRIPTION

#### Pull Request (PR) description
- `Import-SqlDscPreferredModule`
  - Now when parameter `Force` is passed the command correctly invoke
    `Get-SqlDscPreferredModule` using the parameter `Refresh`.

#### This Pull Request (PR) fixes the following issues
None. But might be the reason PR #1932 fails.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1938)
<!-- Reviewable:end -->
