### PR TITLE
SqlProtocolTcpIp: Auto-detect the TCP/IP address group name by IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added new public command:
     - `Get-SqlDscConfigurationOption` - Returns the available configuration
       options that can be used with the DSC resource _SqlConfiguration_.
+- SqlProtocolTcpIp
+  - Auto-detect the TCP/IP address group name by IP address
 
 ### Changed
 

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
@@ -818,7 +818,7 @@ function Find-IpAddressGroup
             }
         }
 
-        throw (
+        Write-Warning (
             $script:localizedData.IpAddressGroupNotFoundError -f $IpAddressGroup
         )
     }

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
@@ -769,7 +769,6 @@ function Convert-IpAdressGroupCasing
 #>
 function Find-IpAddressGroup
 {
-
     [CmdletBinding()]
     [OutputType([System.String])]
     param

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/en-US/DSC_SqlProtocolTcpIp.strings.psd1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/en-US/DSC_SqlProtocolTcpIp.strings.psd1
@@ -14,4 +14,6 @@ ConvertFrom-StringData @'
     GroupIsInDesiredState = The TCP/IP address group '{0}' on the instance '{1}' is already in desired state. (SSPTI0013)
     RestartSuppressed = The restart was suppressed. The configuration will not be active until the node is manually restart. (SSPTI0014)
     FailedToGetSqlServerProtocol = Failed to get the settings for the SQL Server Database Engine server protocol TCP/IP. (SSPTI0015)
+    GetIpAddressGroupByIpAddress = Detect the TCP/IP address group by using the TCP/IP address '{0}'. (SSPTI0016)
+    IpAddressGroupNotFoundError = The TCP/IP address group was not detected because the TCP/IP address '{0}' is not assigned to any TCP/IP address group. (SSPTI0017)
 '@

--- a/source/Examples/Resources/SqlProtocolTcpIp/4-ConfigureIPAddressGroupByDetecting.ps1
+++ b/source/Examples/Resources/SqlProtocolTcpIp/4-ConfigureIPAddressGroupByDetecting.ps1
@@ -1,0 +1,31 @@
+<#
+    .DESCRIPTION
+        This example will set the TCP/IP address group by detecting the group name. Not required to specify the group name.
+
+        The resource will be run as the account provided in $SystemAdministratorAccount.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]
+        $SystemAdministratorAccount
+    )
+
+    Import-DscResource -ModuleName 'SqlServerDsc'
+
+    node localhost
+    {
+        SqlProtocolTcpIP 'ChangeIP'
+        {
+            InstanceName         = 'MSSQLSERVER'
+            IpAddressGroup       = 'fe80::7894:a6b6:59dd:c8fe%9'
+            Enabled              = $true
+            IpAddress            = 'fe80::7894:a6b6:59dd:c8fe%9'
+            TcpPort              = '1433,1500,1501'
+
+            PsDscRunAsCredential = $SystemAdministratorAccount
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

Currently, it's not possible to detect an TCP/IP address group by using the IP. The TCP/IP address group name is mandatory during compilation time. For SQL Server running multiple instances with multiple per-instance IP's, it's important to define con compile time, which IPx address group belongs to which TCP/IP address.

#### This Pull Request (PR) fixes the following issues

The resource should support entering the IP address in the group name field, so that the group is detected by the IP address.

- Fixes #1939

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [x] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1940)
<!-- Reviewable:end -->
