### PR TITLE
SqlLogin: Attempting to disable and already disabled login throws an error #1952

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlWindowsFirewall
   - Fix duplication of SQL Server Browser Firewall Rule when deploying
     Analysis Services feature ([issue #1942](https://github.com/dsccommunity/SqlServerDsc/issues/1942)).
+- SqlLogin
+  - Attempting to disable and already disabled login throws an error ([issue #1952](https://github.com/dsccommunity/SqlServerDsc/issues/1952))
 
 ## [16.3.1] - 2023-05-06
 

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -621,7 +621,7 @@ function Connect-SQL
             $newObjectParameters = @{
                 TypeName     = 'System.Management.Automation.ErrorRecord'
                 ArgumentList = @(
-                    $invalidOperationException.ToString(),
+                    $invalidOperationException,
                     'CS0001',
                     'InvalidOperation',
                     $databaseEngineInstance
@@ -642,7 +642,7 @@ function Connect-SQL
         $newObjectParameters = @{
             TypeName     = 'System.Management.Automation.ErrorRecord'
             ArgumentList = @(
-                $invalidOperationException.ToString(),
+                $invalidOperationException,
                 'CS0002',
                 'InvalidOperation',
                 $databaseEngineInstance

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -2663,7 +2663,7 @@ Describe 'SqlServerDsc.Common\Connect-SQL' -Tag 'ConnectSql' {
                 $mockErrorMessage = $mockLocalizedString -f 'localhost'
 
                 { Connect-SQL -ServerName 'localhost' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage ('System.InvalidOperationException: {0}*' -f $mockErrorMessage)
+                    Should -Throw -ExpectedMessage $mockErrorMessage
 
                 Should -Invoke -CommandName New-Object -ParameterFilter {
                     $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Server'


### PR DESCRIPTION
#### Pull Request (PR) description

Changes from string Exception to just Exception object so InnerException can be searched for error codes

#### This Pull Request (PR) fixes the following issues

- Fixes #1952 

#### Task list
- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] ~~Resource documentation updated in the resource's README.md.~~
- [ ] ~~Resource parameter descriptions updated in schema.mof.~~
- [ ] ~~Comment-based help updated, including parameter descriptions.~~
- [ ] ~~Localization strings updated.~~
- [ ] ~~Examples updated.~~
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1953)
<!-- Reviewable:end -->
