### PR TITLE
`Install-SqlDscServer`: Fix bug for `PrepareImage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix duplication of SQL Server Browser Firewall Rule when deploying
     Analysis Services feature ([issue #1942](https://github.com/dsccommunity/SqlServerDsc/issues/1942)).
 - SqlLogin
-  - Attempting to disable and already disabled login throws an error ([issue #1952](https://github.com/dsccommunity/SqlServerDsc/issues/1952))
+  - Attempting to disable and already disabled login throws an error ([issue #1952](https://github.com/dsccommunity/SqlServerDsc/issues/1952)).
+- `Install-SqlDscServer`
+  - Now the parameter `InstanceName` can no longer be specified (as per
+    the SQL Server documentation) for the setup action `PrepareImage`
+    ([issue #1960](https://github.com/dsccommunity/SqlServerDsc/issues/1960)).
 
 ## [16.3.1] - 2023-05-06
 

--- a/source/Private/Invoke-SetupAction.ps1
+++ b/source/Private/Invoke-SetupAction.ps1
@@ -401,7 +401,7 @@
         Uninstalls the database engine from the named instance MyInstance.
 
     .EXAMPLE
-        Invoke-SetupAction -PrepareImage -AcceptLicensingTerms -InstanceName 'MyInstance' -Features 'SQLENGINE' -InstanceId 'MyInstance' -MediaPath 'E:\'
+        Invoke-SetupAction -PrepareImage -AcceptLicensingTerms -Features 'SQLENGINE' -InstanceId 'MyInstance' -MediaPath 'E:\'
 
         Prepares the server for using the database engine for an instance named 'MyInstance'.
 

--- a/source/Private/Invoke-SetupAction.ps1
+++ b/source/Private/Invoke-SetupAction.ps1
@@ -577,7 +577,6 @@ function Invoke-SetupAction
 
         [Parameter(ParameterSetName = 'Install', Mandatory = $true)]
         [Parameter(ParameterSetName = 'Uninstall', Mandatory = $true)]
-        [Parameter(ParameterSetName = 'PrepareImage', Mandatory = $true)]
         [Parameter(ParameterSetName = 'Upgrade', Mandatory = $true)]
         [Parameter(ParameterSetName = 'EditionUpgrade', Mandatory = $true)]
         [Parameter(ParameterSetName = 'Repair', Mandatory = $true)]

--- a/source/Public/Install-SqlDscServer.ps1
+++ b/source/Public/Install-SqlDscServer.ps1
@@ -375,7 +375,7 @@
         Installs SQL Server using the configuration file 'MySqlConfig.ini'.
 
     .EXAMPLE
-        Install-SqlDscServer -PrepareImage -AcceptLicensingTerms -InstanceName 'MyInstance' -Features 'SQLENGINE' -InstanceId 'MyInstance' -MediaPath 'E:\'
+        Install-SqlDscServer -PrepareImage -AcceptLicensingTerms -Features 'SQLENGINE' -InstanceId 'MyInstance' -MediaPath 'E:\'
 
         Prepares the server for using the database engine for an instance named 'MyInstance'.
 

--- a/source/Public/Install-SqlDscServer.ps1
+++ b/source/Public/Install-SqlDscServer.ps1
@@ -471,7 +471,6 @@ function Install-SqlDscServer
         $MediaPath,
 
         [Parameter(ParameterSetName = 'Install', Mandatory = $true)]
-        [Parameter(ParameterSetName = 'PrepareImage', Mandatory = $true)]
         [Parameter(ParameterSetName = 'Upgrade', Mandatory = $true)]
         [Parameter(ParameterSetName = 'EditionUpgrade', Mandatory = $true)]
         [Parameter(ParameterSetName = 'InstallFailoverCluster', Mandatory = $true)]

--- a/tests/Unit/Private/Invoke-SetupAction.Tests.ps1
+++ b/tests/Unit/Private/Invoke-SetupAction.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
         @{
             MockParameterSetName = 'PrepareImage'
             # cSpell: disable-next
-            MockExpectedParameters = '-PrepareImage -AcceptLicensingTerms -MediaPath <string> -InstanceName <string> -Features <string[]> -InstanceId <string> [-IAcknowledgeEntCalLimits] [-Enu] [-UpdateEnabled] [-UpdateSource <string>] [-InstallSharedDir <string>] [-InstanceDir <string>] [-PBEngSvcAccount <string>] [-PBEngSvcPassword <securestring>] [-PBEngSvcStartupType <string>] [-PBStartPortRange <ushort>] [-PBEndPortRange <ushort>] [-PBScaleOut] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            MockExpectedParameters = '-PrepareImage -AcceptLicensingTerms -MediaPath <string> -Features <string[]> -InstanceId <string> [-IAcknowledgeEntCalLimits] [-Enu] [-UpdateEnabled] [-UpdateSource <string>] [-InstallSharedDir <string>] [-InstanceDir <string>] [-PBEngSvcAccount <string>] [-PBEngSvcPassword <securestring>] [-PBEngSvcStartupType <string>] [-PBStartPortRange <ushort>] [-PBEndPortRange <ushort>] [-PBScaleOut] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
         }
         @{
             MockParameterSetName = 'CompleteImage'
@@ -3188,7 +3188,6 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
                         PrepareImage = $true
                         AcceptLicensingTerms = $true
                         MediaPath = '\SqlMedia'
-                        InstanceName = 'INSTANCE'
                         # Intentionally using both upper- and lower-case.
                         Features = 'SqlEngine'
                         InstanceId = 'Instance'
@@ -3205,7 +3204,6 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
                             $ArgumentList | Should -MatchExactly '\/ACTION=PrepareImage'
                             $ArgumentList | Should -MatchExactly '\/IACCEPTSQLSERVERLICENSETERMS' # cspell: disable-line
                             $ArgumentList | Should -MatchExactly '\/FEATURES=SQLENGINE'
-                            $ArgumentList | Should -MatchExactly '\/INSTANCENAME="INSTANCE"' # cspell: disable-line
                             $ArgumentList | Should -MatchExactly '\/INSTANCEID="Instance"' # cspell: disable-line
 
                             # Return $true if none of the above throw.
@@ -3224,7 +3222,6 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
                             $ArgumentList | Should -MatchExactly '\/ACTION=PrepareImage'
                             $ArgumentList | Should -MatchExactly '\/IACCEPTSQLSERVERLICENSETERMS' # cspell: disable-line
                             $ArgumentList | Should -MatchExactly '\/FEATURES=SQLENGINE'
-                            $ArgumentList | Should -MatchExactly '\/INSTANCENAME="INSTANCE"' # cspell: disable-line
                             $ArgumentList | Should -MatchExactly '\/INSTANCEID="Instance"' # cspell: disable-line
 
                             # Return $true if none of the above throw.
@@ -3307,7 +3304,6 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
                         PrepareImage = $true
                         AcceptLicensingTerms = $true
                         MediaPath = '\SqlMedia'
-                        InstanceName = 'INSTANCE'
                         # Intentionally using both upper- and lower-case.
                         Features = 'SqlEngine'
                         InstanceId = 'Instance'

--- a/tests/Unit/Public/Install-SqlDscServer.Tests.ps1
+++ b/tests/Unit/Public/Install-SqlDscServer.Tests.ps1
@@ -72,7 +72,7 @@ Describe 'Install-SqlDscServer' -Tag 'Public' {
         @{
             MockParameterSetName = 'PrepareImage'
             # cSpell: disable-next
-            MockExpectedParameters = '-PrepareImage -AcceptLicensingTerms -MediaPath <string> -InstanceName <string> -Features <string[]> -InstanceId <string> [-IAcknowledgeEntCalLimits] [-Enu] [-UpdateEnabled] [-UpdateSource <string>] [-InstallSharedDir <string>] [-InstanceDir <string>] [-PBEngSvcAccount <string>] [-PBEngSvcPassword <securestring>] [-PBEngSvcStartupType <string>] [-PBStartPortRange <ushort>] [-PBEndPortRange <ushort>] [-PBScaleOut] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            MockExpectedParameters = '-PrepareImage -AcceptLicensingTerms -MediaPath <string> -Features <string[]> -InstanceId <string> [-IAcknowledgeEntCalLimits] [-Enu] [-UpdateEnabled] [-UpdateSource <string>] [-InstallSharedDir <string>] [-InstanceDir <string>] [-PBEngSvcAccount <string>] [-PBEngSvcPassword <securestring>] [-PBEngSvcStartupType <string>] [-PBStartPortRange <ushort>] [-PBEndPortRange <ushort>] [-PBScaleOut] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
         }
         @{
             MockParameterSetName = 'Upgrade'
@@ -2035,7 +2035,6 @@ Describe 'Install-SqlDscServer' -Tag 'Public' {
                     PrepareImage = $true
                     AcceptLicensingTerms = $true
                     MediaPath = '\SqlMedia'
-                    InstanceName = 'INSTANCE'
                     # Intentionally using both upper- and lower-case.
                     Features = 'SqlEngine'
                     InstanceId = 'Instance'
@@ -2050,7 +2049,6 @@ Describe 'Install-SqlDscServer' -Tag 'Public' {
                         $ArgumentList | Should -MatchExactly '\/ACTION=PrepareImage'
                         $ArgumentList | Should -MatchExactly '\/IACCEPTSQLSERVERLICENSETERMS' # cspell: disable-line
                         $ArgumentList | Should -MatchExactly '\/FEATURES=SQLENGINE'
-                        $ArgumentList | Should -MatchExactly '\/INSTANCENAME="INSTANCE"' # cspell: disable-line
                         $ArgumentList | Should -MatchExactly '\/INSTANCEID="Instance"' # cspell: disable-line
 
                         # Return $true if none of the above throw.
@@ -2067,7 +2065,6 @@ Describe 'Install-SqlDscServer' -Tag 'Public' {
                         $ArgumentList | Should -MatchExactly '\/ACTION=PrepareImage'
                         $ArgumentList | Should -MatchExactly '\/IACCEPTSQLSERVERLICENSETERMS' # cspell: disable-line
                         $ArgumentList | Should -MatchExactly '\/FEATURES=SQLENGINE'
-                        $ArgumentList | Should -MatchExactly '\/INSTANCENAME="INSTANCE"' # cspell: disable-line
                         $ArgumentList | Should -MatchExactly '\/INSTANCEID="Instance"' # cspell: disable-line
 
                         # Return $true if none of the above throw.
@@ -2146,7 +2143,6 @@ Describe 'Install-SqlDscServer' -Tag 'Public' {
                     PrepareImage = $true
                     AcceptLicensingTerms = $true
                     MediaPath = '\SqlMedia'
-                    InstanceName = 'INSTANCE'
                     # Intentionally using both upper- and lower-case.
                     Features = 'SqlEngine'
                     InstanceId = 'Instance'


### PR DESCRIPTION

#### Pull Request (PR) description
- `Install-SqlDscServer`
  - Now the parameter `InstanceName` can no longer be specified (as per
    the SQL Server documentation) for the setup action `PrepareImage`
    (issue #1960).

#### This Pull Request (PR) fixes the following issues

- Fixes #1960

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1961)
<!-- Reviewable:end -->
