### PR TITLE
SqlServerDsc: Add release asset for Wiki documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlServerDsc
   - Updated pipeline files to support ModuleFast.
   - `Get-SqlDscPreferredModule`
-    - Optionally specify what version of the the SQL preferred module to be imported using the SMODefaultModuleVersion environment variable ([issue #1965](https://github.com/dsccommunity/SqlServerDsc/issues/1965)).
+    - Optionally specify what version of the the SQL preferred module to
+      be imported using the SMODefaultModuleVersion environment variable
+      ([issue #1965](https://github.com/dsccommunity/SqlServerDsc/issues/1965)).
+  - Now package the Wiki content and adds it as a GitHub Release asset so it
+    is simpler to get the documentation for a specific version.
 - New private command:
-  - Get-SMOModuleCalculatedVersion - Returns the version of the SMO module as a string. SQLPS version 120 and 130 do not have the correct version set, so the file path is used to calculate the version.
+  - Get-SMOModuleCalculatedVersion - Returns the version of the SMO module
+    as a string. SQLPS version 120 and 130 do not have the correct version set,
+    so the file path is used to calculate the version.
 - SqlSetup
   - Added the parameter `SqlVersion` that can be used to set the SQL Server
     version to be installed instead of it looking for version in the setup

--- a/build.yaml
+++ b/build.yaml
@@ -14,6 +14,7 @@ BuildWorkflow:
     - Create_Changelog_Release_Output
     - Generate_Conceptual_Help
     - Generate_Wiki_Content
+    - Package_WikContent
 
   fastbuild:
     - Clean
@@ -36,6 +37,42 @@ BuildWorkflow:
     - Publish_Release_To_GitHub
     - Publish_Module_To_gallery
     - Publish_GitHub_Wiki_Content
+
+  Package_WikContent: |
+    {
+        <#
+            This is quick fix for issue https://github.com/PoshCode/ModuleBuilder/issues/103.
+            Aliases need to be added to module manifest, and we can only use
+            New-Alias or Set-Alias together with build tasks. This module
+            already automatically exports aliases using [Alias()] so this quick
+            fix is meant as a workaround until the above issue is resolved.
+        #>
+        param
+        (
+            $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+            $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
+            $BuildInfo = (property BuildInfo @{ })
+        )
+
+        "`tProject Name             = {0}" -f $ProjectName
+        "`tOutput Directory         = {0}" -f $OutputDirectory
+
+        $wikiOutputPath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent'
+        $wikiArchiveSourcePath = Join-Path -Path $wikiOutputPath -ChildPath '*'
+        $wikiPackagePath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent.zip'
+
+        "`tWiki Output Path         = $wikiOutputPath"
+        "`tWiki Archive Source Path = $wikiArchiveSourcePath"
+        "`tWiki Package Path        = $wikiPackagePath"
+
+        if (-not (Test-Path -Path $wikiOutputPath))
+        {
+            throw 'The Wiki Output Path does not exist. Please run the task Generate_Wiki_Content prior to running this task.'
+        }
+
+        # Overwrites any existing archive.
+        Compress-Archive -Path $wikiArchiveSourcePath -DestinationPath $wikiPackagePath -CompressionLevel 'Optimal' -Force -ErrorAction 'Stop'
+    }
 
 ####################################################
 #           ModuleBuilder Configuration            #
@@ -151,6 +188,8 @@ Resolve-Dependency:
 GitHubConfig:
   GitHubFilesToAdd:
     - 'CHANGELOG.md'
+  ReleaseAssets:
+    - output/WikiContent.zip
   GitHubConfigUserName: dscbot # cSpell: disable-line
   GitHubConfigUserEmail: dsccommunity@outlook.com
   UpdateChangelogOnPrerelease: false


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc
  - Now package the Wiki content and adds it as a GitHub Release asset so it
    is simpler to get the documentation for a specific version.
 
#### This Pull Request (PR) fixes the following issues
- Closes #1968 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1970)
<!-- Reviewable:end -->
