### PR TITLE
SqlServerDsc: fix sort in SqlDscPreferredModule to get the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SqlServerDsc
+  - `Get-SMOModuleCalculatedVersion`
+    - Return SQLPS version as 12.0 instead of 120
+  - `Get-SqlDscPreferredModule`
+    - Fix sort to get the latest version
+
 ### Changed
 
 - SqlServerDsc

--- a/source/Private/Get-SMOModuleCalculatedVersion.ps1
+++ b/source/Private/Get-SMOModuleCalculatedVersion.ps1
@@ -46,7 +46,7 @@ function Get-SMOModuleCalculatedVersion
                 Parse the build version number '120', '130' from the Path.
                 Older version of SQLPS did not have correct versioning.
             #>
-            $version = (Select-String -InputObject $PSModuleInfo.Path -Pattern '\\([0-9]{3})\\' -List).Matches.Groups[1].Value
+            $version = $PSModuleInfo.Path -replace '.*\\(\d{2})(\d)\\.*', '$1.$2'
         }
         else
         {

--- a/source/Public/Get-SqlDscPreferredModule.ps1
+++ b/source/Public/Get-SqlDscPreferredModule.ps1
@@ -118,7 +118,7 @@ function Get-SqlDscPreferredModule
             {
                 # Get the latest version if available
                 $availableModule = $preferredModules |
-                    Sort-Object -Property 'CalculatedVersion' -Descending |
+                    Sort-Object -Property { ($_.CalculatedVersion -replace '-.+$') -as [version] }, { $_ } -Descending |
                     Select-Object -First 1
             }
 

--- a/source/Public/Get-SqlDscPreferredModule.ps1
+++ b/source/Public/Get-SqlDscPreferredModule.ps1
@@ -118,7 +118,7 @@ function Get-SqlDscPreferredModule
             {
                 # Get the latest version if available
                 $availableModule = $preferredModules |
-                    Sort-Object -Property { ($_.CalculatedVersion -replace '-.+$') -as [version] }, { $_ } -Descending |
+                    Sort-Object -Property { ($_.CalculatedVersion -replace '-.+$') -as [System.Version] }, { $_.CalculatedVersion } -Descending |
                     Select-Object -First 1
             }
 

--- a/tests/Unit/Private/Get-SMOModuleCalculatedVersion.Tests.ps1
+++ b/tests/Unit/Private/Get-SMOModuleCalculatedVersion.Tests.ps1
@@ -95,7 +95,7 @@ Describe 'Get-SMOModuleCalculatedVersion' -Tag 'Private' {
                     Path = 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\SQLPS\Sqlps.ps1'
                 }
 
-                $sqlServerModule | Get-SMOModuleCalculatedVersion | Should -Be '130'
+                $sqlServerModule | Get-SMOModuleCalculatedVersion | Should -Be '13.0'
             }
         }
     }

--- a/tests/Unit/Public/Get-SqlDscPreferredModule.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscPreferredModule.Tests.ps1
@@ -368,6 +368,15 @@ Describe 'Get-SqlDscPreferredModule' -Tag 'Public' {
                         }
                     }
                 }
+                $sqlServerModule3 = New-MockObject -Type 'PSModuleInfo' -Properties @{
+                    Name = 'SqlServer'
+                    Version = [Version]::new(22, 1, 1)
+                    PrivateData = @{
+                        PSData = @{
+                            PreRelease = 'preview2'
+                        }
+                    }
+                }
                 $sqlpsModule1 = New-MockObject -Type 'PSModuleInfo' -Properties @{
                     Name = 'SQLPS'
                     Path = 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\SQLPS\Sqlps.ps1'
@@ -381,6 +390,7 @@ Describe 'Get-SqlDscPreferredModule' -Tag 'Public' {
                     return @(
                         $sqlServerModule1,
                         $sqlServerModule2,
+                        $sqlServerModule3,
                         $sqlpsModule1,
                         $sqlpsModule2
                     )
@@ -388,7 +398,7 @@ Describe 'Get-SqlDscPreferredModule' -Tag 'Public' {
             }
 
             It 'Should return the latest first preferred module' {
-                Get-SqlDscPreferredModule -Name @('SqlServer', 'SQLPS') | Should -Be $sqlServerModule2
+                Get-SqlDscPreferredModule -Name @('SqlServer', 'SQLPS') | Should -Be $sqlServerModule3
             }
 
             Context 'When the environment variable SMODefaultModuleVersion is assigned a module version' {

--- a/tests/Unit/Public/Get-SqlDscPreferredModule.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscPreferredModule.Tests.ps1
@@ -510,7 +510,7 @@ Describe 'Get-SqlDscPreferredModule' -Tag 'Public' {
             Context 'When the environment variable SMODefaultModuleVersion is assigned a module version' {
                 Context 'When the version of the module exists' {
                     BeforeAll {
-                        $env:SMODefaultModuleVersion = '130'
+                        $env:SMODefaultModuleVersion = '13.0'
                     }
 
                     AfterAll {


### PR DESCRIPTION
#### Pull Request (PR) description

- SqlServerDsc
  - `Get-SMOModuleCalculatedVersion`
    - Return SQLPS version as 12.0 instead of 120
  - `Get-SqlDscPreferredModule`
    - Fix sort to get the latest version

#### This Pull Request (PR) fixes the following issues

With multiple version of SqlServer installed:

```console
Version
-------
22.1.1
22.0.59
21.1.18256
21.1.18246
```

Get-SqlDscPreferredModule was selecting:

```console
Version
-------
21.1.18256
```

This proposed change update the sort to get the latest version;

```console
Version
-------
22.1.1
```

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1976)
<!-- Reviewable:end -->
