### PR TITLE
SqlServerDsc: Fix handling of `-Force` and `-Confirm $true` in commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Return SQLPS version as 12.0 instead of 120
   - `Get-SqlDscPreferredModule`
     - Fix sort to get the latest version
+  - Public commands no handles when both `-Force` and `-Confirm $true`
+    would be passed to command.
 - `Assert-Feature`
   - Fixed unit tests.
 - SqlAGReplica

--- a/source/Private/Invoke-SetupAction.ps1
+++ b/source/Private/Invoke-SetupAction.ps1
@@ -1372,7 +1372,7 @@ function Invoke-SetupAction
         $Force
     )
 
-    if ($Force.IsPresent)
+    if ($Force.IsPresent -and -not $Confirm)
     {
         $ConfirmPreference = 'None'
     }

--- a/source/Public/Add-SqlDscTraceFlag.ps1
+++ b/source/Public/Add-SqlDscTraceFlag.ps1
@@ -82,7 +82,7 @@ function Add-SqlDscTraceFlag
 
     begin
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Disable-SqlDscAudit.ps1
+++ b/source/Public/Disable-SqlDscAudit.ps1
@@ -70,7 +70,7 @@ function Disable-SqlDscAudit
 
     process
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Disconnect-SqlDscDatabaseEngine.ps1
+++ b/source/Public/Disconnect-SqlDscDatabaseEngine.ps1
@@ -43,7 +43,7 @@ function Disconnect-SqlDscDatabaseEngine
 
     begin
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Enable-SqlDscAudit.ps1
+++ b/source/Public/Enable-SqlDscAudit.ps1
@@ -70,7 +70,7 @@ function Enable-SqlDscAudit
 
     process
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Import-SqlDscPreferredModule.ps1
+++ b/source/Public/Import-SqlDscPreferredModule.ps1
@@ -88,7 +88,7 @@ function Import-SqlDscPreferredModule
         )
     }
 
-    if ($Force.IsPresent)
+    if ($Force.IsPresent -and -not $Confirm)
     {
         Write-Verbose -Message $script:localizedData.PreferredModule_ForceRemoval
 

--- a/source/Public/Invoke-SqlDscQuery.ps1
+++ b/source/Public/Invoke-SqlDscQuery.ps1
@@ -153,7 +153,7 @@ function Invoke-SqlDscQuery
 
     begin
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/New-SqlDscAudit.ps1
+++ b/source/Public/New-SqlDscAudit.ps1
@@ -202,7 +202,7 @@ function New-SqlDscAudit
 
     process
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Remove-SqlDscAudit.ps1
+++ b/source/Public/Remove-SqlDscAudit.ps1
@@ -70,7 +70,7 @@ function Remove-SqlDscAudit
 
     process
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Remove-SqlDscTraceFlag.ps1
+++ b/source/Public/Remove-SqlDscTraceFlag.ps1
@@ -82,7 +82,7 @@ function Remove-SqlDscTraceFlag
 
     begin
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Set-SqlDscAudit.ps1
+++ b/source/Public/Set-SqlDscAudit.ps1
@@ -245,7 +245,7 @@ function Set-SqlDscAudit
 
     process
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Set-SqlDscDatabasePermission.ps1
+++ b/source/Public/Set-SqlDscDatabasePermission.ps1
@@ -100,7 +100,7 @@ function Set-SqlDscDatabasePermission
             Write-Warning -Message $script:localizedData.DatabasePermission_IgnoreWithGrantForStateDeny
         }
 
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Set-SqlDscServerPermission.ps1
+++ b/source/Public/Set-SqlDscServerPermission.ps1
@@ -89,7 +89,7 @@ function Set-SqlDscServerPermission
             Write-Warning -Message $script:localizedData.ServerPermission_IgnoreWithGrantForStateDeny
         }
 
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Set-SqlDscStartupParameter.ps1
+++ b/source/Public/Set-SqlDscStartupParameter.ps1
@@ -93,7 +93,7 @@ function Set-SqlDscStartupParameter
     {
         Assert-ElevatedUser -ErrorAction 'Stop'
 
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }

--- a/source/Public/Set-SqlDscTraceFlag.ps1
+++ b/source/Public/Set-SqlDscTraceFlag.ps1
@@ -89,7 +89,7 @@ function Set-SqlDscTraceFlag
 
     begin
     {
-        if ($Force.IsPresent)
+        if ($Force.IsPresent -and -not $Confirm)
         {
             $ConfirmPreference = 'None'
         }


### PR DESCRIPTION
#### Pull Request (PR) description
- SqlServerDsc
  - Public commands no handles when both `-Force` and `-Confirm $true`
    would be passed to command.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/1994)
<!-- Reviewable:end -->
