### PR TITLE
SqlDatabaseMail: Add parameter UseDefaultCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SqlServerDsc
   - Added build tasks to generate Wiki documentation for public commands.
+- SqlDatabaseMailDsc
+  - Added the parameter `UseDefaultCredentials` that can be set $true so that
+    SMTP server authentication uses the DatabaseEngine service account. The
+    default is $false which uses a login specified for SMTP authorization.
+    If false and no custom login specified, an anonymous login is used.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SqlServerDsc
   - Added build tasks to generate Wiki documentation for public commands.
-- SqlDatabaseMailDsc
-  - Added the parameter `UseDefaultCredentials` that can be set $true so that
-    SMTP server authentication uses the DatabaseEngine service account. The
-    default is $false which uses a login specified for SMTP authorization.
-    If false and no custom login specified, an anonymous login is used.
+- SqlDatabaseMail
+  - Added the parameter `UseDefaultCredentials` to control use of the DatabaseEngine
+    service account for SMTP server authentication.
 
 ### Fixed
 

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
@@ -64,18 +64,19 @@ function Get-TargetResource
     )
 
     $returnValue = @{
-        Ensure         = 'Absent'
-        ServerName     = $ServerName
-        InstanceName   = $InstanceName
-        AccountName    = $null
-        EmailAddress   = $null
-        MailServerName = $null
-        LoggingLevel   = $null
-        ProfileName    = $null
-        DisplayName    = $null
-        ReplyToAddress = $null
-        Description    = $null
-        TcpPort        = $null
+        Ensure                = 'Absent'
+        ServerName            = $ServerName
+        InstanceName          = $InstanceName
+        AccountName           = $null
+        EmailAddress          = $null
+        MailServerName        = $null
+        LoggingLevel          = $null
+        ProfileName           = $null
+        DisplayName           = $null
+        ReplyToAddress        = $null
+        Description           = $null
+        TcpPort               = $null
+        UseDefaultCredentials = $null
     }
 
     Write-Verbose -Message (
@@ -145,6 +146,7 @@ function Get-TargetResource
                 {
                     $returnValue['MailServerName'] = $mailServer.Name
                     $returnValue['TcpPort'] = $mailServer.Port
+                    $returnValue['UseDefaultCredentials'] = $mailServer.UseDefaultCredentials # custom
                 }
 
                 $mailProfile = $databaseMail.Profiles |
@@ -233,6 +235,11 @@ function Get-TargetResource
     .PARAMETER TcpPort
         The TCP port used for communication. Default value is port 25.
 
+    .PARAMETER UseDefaultCredentials
+        Controls SMTP server authentication.  The database engine credentials are
+        the default credentials used when $true.  If not specified, the default is
+        $false and an anonymous login is used unless other credentials are provided.
+
     .NOTES
         Information about the different properties can be found here
         https://docs.microsoft.com/en-us/sql/relational-databases/database-mail/configure-database-mail.
@@ -293,7 +300,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.UInt16]
-        $TcpPort = 25
+        $TcpPort = 25,
+
+        [Parameter()]
+        [System.Boolean]
+        $UseDefaultCredentials
     )
 
     Write-Verbose -Message (
@@ -380,6 +391,11 @@ function Set-TargetResource
                         if ($PSBoundParameters.ContainsKey('TcpPort'))
                         {
                             $mailServer.Port = $TcpPort
+                        }
+
+                        if ($PSBoundParameters.ContainsKey('UseDefaultCredentials')) # custom
+                        {
+                            $mailServer.UseDefaultCredentials = $UseDefaultCredentials
                         }
 
                         $mailServer.Alter()
@@ -481,6 +497,21 @@ function Set-TargetResource
                         )
 
                         $mailServer.Port = $TcpPort
+                        $mailServer.Alter()
+                    }
+
+                    $currentUseDefaultCredentials = $mailServer.UseDefaultCredentials #custom
+                    if ($PSBoundParameters.ContainsKey('UseDefaultCredentials') -and $currentUseDefaultCredentials -ne $UseDefaultCredentials)
+                    {
+                        Write-Verbose -Message (
+                            $script:localizedData.UpdatingPropertyOfMailServer -f @(
+                                $currentUseDefaultCredentials
+                                $UseDefaultCredentials
+                                $script:localizedData.MailServerPropertyUseDefaultCredentials
+                            )
+                        )
+
+                        $mailServer.UseDefaultCredentials = $UseDefaultCredentials
                         $mailServer.Alter()
                     }
                 }
@@ -633,6 +664,11 @@ function Set-TargetResource
 
     .PARAMETER TcpPort
         The TCP port used for communication. Default value is port 25.
+
+    .PARAMETER UseDefaultCredentials
+        Controls SMTP server authentication.  The database engine credentials are
+        the default credentials used when $true.  If not specified, the default is
+        $false and an anonymous login is used unless other credentials are provided.
 #>
 function Test-TargetResource
 {
@@ -691,7 +727,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.UInt16]
-        $TcpPort = 25
+        $TcpPort = 25,
+
+        [Parameter()]
+        [System.Boolean]
+        $UseDefaultCredentials
     )
 
     $getTargetResourceParameters = @{
@@ -727,6 +767,7 @@ function Test-TargetResource
                 'DisplayName'
                 'Description'
                 'LoggingLevel'
+                'UseDefaultCredentials'
             )
             TurnOffTypeChecking = $true
             Verbose             = $VerbosePreference

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
@@ -146,7 +146,7 @@ function Get-TargetResource
                 {
                     $returnValue['MailServerName'] = $mailServer.Name
                     $returnValue['TcpPort'] = $mailServer.Port
-                    $returnValue['UseDefaultCredentials'] = $mailServer.UseDefaultCredentials # custom
+                    $returnValue['UseDefaultCredentials'] = $mailServer.UseDefaultCredentials
                 }
 
                 $mailProfile = $databaseMail.Profiles |
@@ -236,13 +236,17 @@ function Get-TargetResource
         The TCP port used for communication. Default value is port 25.
 
     .PARAMETER UseDefaultCredentials
-        Controls SMTP server authentication.  The database engine credentials are
-        the default credentials used when $true.  If not specified, the default is
-        $false and an anonymous login is used unless other credentials are provided.
+        Controls use of the DatabaseEngine service account for SMTP server authentication.
+        If $true, the DatabaseEngine service account is used access the SMTP server.
+        If $false, DatabaseEngine service account is not used.
 
     .NOTES
         Information about the different properties can be found here
         https://docs.microsoft.com/en-us/sql/relational-databases/database-mail/configure-database-mail.
+
+        "UseDefaultCredentials" corresponds to "Windows Authentication using Database Engine service credentials" 
+        described at the above link.  This dsc resource does not yet address setting state for basic or anonymous 
+        SMTP access that's used when UseDefaultCredentials is false.
 
 #>
 function Set-TargetResource
@@ -666,9 +670,9 @@ function Set-TargetResource
         The TCP port used for communication. Default value is port 25.
 
     .PARAMETER UseDefaultCredentials
-        Controls SMTP server authentication.  The database engine credentials are
-        the default credentials used when $true.  If not specified, the default is
-        $false and an anonymous login is used unless other credentials are provided.
+        Controls use of the DatabaseEngine service account for SMTP server authentication.
+        If $true, the DatabaseEngine service account is used access the SMTP server.
+        If $false, DatabaseEngine service account is not used.
 #>
 function Test-TargetResource
 {

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
@@ -244,8 +244,8 @@ function Get-TargetResource
         Information about the different properties can be found here
         https://docs.microsoft.com/en-us/sql/relational-databases/database-mail/configure-database-mail.
 
-        "UseDefaultCredentials" corresponds to "Windows Authentication using Database Engine service credentials" 
-        described at the above link.  This dsc resource does not yet address setting state for basic or anonymous 
+        "UseDefaultCredentials" corresponds to "Windows Authentication using Database Engine service credentials"
+        described at the above link.  This dsc resource does not yet address setting state for basic or anonymous
         SMTP access that's used when UseDefaultCredentials is false.
 
 #>
@@ -397,7 +397,7 @@ function Set-TargetResource
                             $mailServer.Port = $TcpPort
                         }
 
-                        if ($PSBoundParameters.ContainsKey('UseDefaultCredentials')) # custom
+                        if ($PSBoundParameters.ContainsKey('UseDefaultCredentials'))
                         {
                             $mailServer.UseDefaultCredentials = $UseDefaultCredentials
                         }
@@ -504,7 +504,7 @@ function Set-TargetResource
                         $mailServer.Alter()
                     }
 
-                    $currentUseDefaultCredentials = $mailServer.UseDefaultCredentials #custom
+                    $currentUseDefaultCredentials = $mailServer.UseDefaultCredentials
                     if ($PSBoundParameters.ContainsKey('UseDefaultCredentials') -and $currentUseDefaultCredentials -ne $UseDefaultCredentials)
                     {
                         Write-Verbose -Message (

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.schema.mof
@@ -13,5 +13,5 @@ class DSC_SqlDatabaseMail : OMI_BaseResource
     [Write, Description("The description for the _Database Mail_ profile and account.")] String Description;
     [Write, Description("The logging level that the _Database Mail_ will use. If not specified the default logging level is `'Extended'`."), ValueMap{"Normal","Extended","Verbose"}, Values{"Normal","Extended","Verbose"}] String LoggingLevel;
     [Write, Description("The TCP port used for communication. Default value is port `25`.")] UInt16 TcpPort;
-    [Write, Description("Controls SMTP server authentication.  The database engine credentials are the default credentials used when $true. If not specified, the default is $false and an anonymous login is used unless other credentials are provided.")] Boolean UseDefaultCredentials;
+    [Write, Description("Specifies if the DatabaseEngine credentials are used for SMTP server authentication. The default is `$false`.")] Boolean UseDefaultCredentials;
 };

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.schema.mof
@@ -13,5 +13,5 @@ class DSC_SqlDatabaseMail : OMI_BaseResource
     [Write, Description("The description for the _Database Mail_ profile and account.")] String Description;
     [Write, Description("The logging level that the _Database Mail_ will use. If not specified the default logging level is `'Extended'`."), ValueMap{"Normal","Extended","Verbose"}, Values{"Normal","Extended","Verbose"}] String LoggingLevel;
     [Write, Description("The TCP port used for communication. Default value is port `25`.")] UInt16 TcpPort;
-    [Write, Description("Specifies if the DatabaseEngine credentials are used for SMTP server authentication. The default is `$false`.")] Boolean UseDefaultCredentials;
+    [Write, Description("Specifies if the DatabaseEngine credentials are used for SMTP server authentication.")] Boolean UseDefaultCredentials;
 };

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.schema.mof
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.schema.mof
@@ -13,4 +13,5 @@ class DSC_SqlDatabaseMail : OMI_BaseResource
     [Write, Description("The description for the _Database Mail_ profile and account.")] String Description;
     [Write, Description("The logging level that the _Database Mail_ will use. If not specified the default logging level is `'Extended'`."), ValueMap{"Normal","Extended","Verbose"}, Values{"Normal","Extended","Verbose"}] String LoggingLevel;
     [Write, Description("The TCP port used for communication. Default value is port `25`.")] UInt16 TcpPort;
+    [Write, Description("Controls SMTP server authentication.  The database engine credentials are the default credentials used when $true. If not specified, the default is $false and an anonymous login is used unless other credentials are provided.")] Boolean UseDefaultCredentials;
 };

--- a/source/DSCResources/DSC_SqlDatabaseMail/en-US/DSC_SqlDatabaseMail.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/en-US/DSC_SqlDatabaseMail.strings.psd1
@@ -22,7 +22,7 @@ ConvertFrom-StringData @'
     MailServerPropertyReplyToEmailAddress = reply to e-mail address
     MailServerPropertyServerName = server name
     MailServerPropertyTcpPort = TCP port
-    MailServerPropertyUseDefaultCredentials = SMTP server authentication
+    MailServerPropertyUseDefaultCredentials = Use default credentials
     CreatingMailProfile = Creating a public default profile '{0}'.
     MailProfileExist = The public default profile '{0}' already exist.
     ConfigureSqlAgent = Configure the SQL Agent to use Database Mail.

--- a/source/DSCResources/DSC_SqlDatabaseMail/en-US/DSC_SqlDatabaseMail.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/en-US/DSC_SqlDatabaseMail.strings.psd1
@@ -22,6 +22,7 @@ ConvertFrom-StringData @'
     MailServerPropertyReplyToEmailAddress = reply to e-mail address
     MailServerPropertyServerName = server name
     MailServerPropertyTcpPort = TCP port
+    MailServerPropertyUseDefaultCredentials = SMTP server authentication
     CreatingMailProfile = Creating a public default profile '{0}'.
     MailProfileExist = The public default profile '{0}' already exist.
     ConfigureSqlAgent = Configure the SQL Agent to use Database Mail.

--- a/tests/Unit/DSC_SqlDatabaseMail.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseMail.Tests.ps1
@@ -75,6 +75,7 @@ Describe 'DSC_SqlDatabaseMail\Get-TargetResource' -Tag 'Get' {
         $mockDisplayName = $mockMailServerName
         $mockDescription = 'My mail description'
         $mockTcpPort = 25
+        $mockUseDefaultCredentials = $false
 
         $mockDatabaseMailDisabledConfigValue = 0
         $mockDatabaseMailEnabledConfigValue = 1
@@ -91,7 +92,8 @@ Describe 'DSC_SqlDatabaseMail\Get-TargetResource' -Tag 'Get' {
                     return @(
                         New-Object -TypeName Object |
                             Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockMailServerName -PassThru |
-                            Add-Member -MemberType NoteProperty -Name 'Port' -Value $mockTcpPort -PassThru -Force
+                            Add-Member -MemberType NoteProperty -Name 'Port' -Value $mockTcpPort -PassThru -Force |
+                            Add-Member -MemberType NoteProperty -Name 'UseDefaultCredentials' -Value $mockUseDefaultCredentials -PassThru -Force
                         )
                     } -PassThru -Force
         }
@@ -200,6 +202,7 @@ Describe 'DSC_SqlDatabaseMail\Get-TargetResource' -Tag 'Get' {
                     $getTargetResourceResult.ReplyToAddress | Should -BeNullOrEmpty
                     $getTargetResourceResult.Description | Should -BeNullOrEmpty
                     $getTargetResourceResult.TcpPort | Should -BeNullOrEmpty
+                    $getTargetResourceResult.UseDefaultCredentials | Should -BeNullOrEmpty
                 }
 
                 Should -Invoke -CommandName Connect-SQL -Exactly -Times 1 -Scope It
@@ -257,15 +260,16 @@ Describe 'DSC_SqlDatabaseMail\Get-TargetResource' -Tag 'Get' {
 
             It 'Should return the correct values for the rest of the properties' {
                 $inModuleScopeParameters = @{
-                    MockAccountName    = $mockAccountName
-                    MockEmailAddress   = $mockEmailAddress
-                    MockMailServerName = $mockMailServerName
-                    MockProfileName    = $mockProfileName
-                    MockLoggingLevel   = $mockLoggingLevelNormal
-                    MockDisplayName    = $mockDisplayName
-                    MockReplyToAddress = $mockReplyToAddress
-                    MockDescription    = $mockDescription
-                    MockTcpPort        = $mockTcpPort
+                    MockAccountName       = $mockAccountName
+                    MockEmailAddress      = $mockEmailAddress
+                    MockMailServerName    = $mockMailServerName
+                    MockProfileName       = $mockProfileName
+                    MockLoggingLevel      = $mockLoggingLevelNormal
+                    MockDisplayName       = $mockDisplayName
+                    MockReplyToAddress    = $mockReplyToAddress
+                    MockDescription       = $mockDescription
+                    MockTcpPort           = $mockTcpPort
+                    MockUseDefaultCredentials = $mockUseDefaultCredentials
                 }
 
                 InModuleScope -Parameters $inModuleScopeParameters -ScriptBlock {
@@ -280,6 +284,7 @@ Describe 'DSC_SqlDatabaseMail\Get-TargetResource' -Tag 'Get' {
                     $getTargetResourceResult.ReplyToAddress | Should -Be $MockReplyToAddress
                     $getTargetResourceResult.Description | Should -Be $MockDescription
                     $getTargetResourceResult.TcpPort | Should -Be $MockTcpPort
+                    $getTargetResourceResult.UseDefaultCredentials | Should -Be $MockUseDefaultCredentials
                 }
 
                 Should -Invoke -CommandName Connect-SQL -Exactly -Times 1 -Scope It
@@ -410,6 +415,7 @@ Describe 'DSC_SqlDatabaseMail\Test-TargetResource' -Tag 'Test' {
         $mockDisplayName = $mockMailServerName
         $mockDescription = 'My mail description'
         $mockTcpPort = 25
+        $mockUseDefaultCredentials = $false
         $mockLoggingLevel = 'Normal'
 
         InModuleScope -ScriptBlock {
@@ -454,29 +460,31 @@ Describe 'DSC_SqlDatabaseMail\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        Ensure         = 'Present'
-                        ServerName     = $mockServerName
-                        InstanceName   = $mockInstanceName
-                        AccountName    = $mockAccountName
-                        EmailAddress   = $mockEmailAddress
-                        MailServerName = $mockMailServerName
-                        LoggingLevel   = $mockLoggingLevel
-                        ProfileName    = $mockProfileName
-                        DisplayName    = $mockDisplayName
-                        ReplyToAddress = $mockReplyToAddress
-                        Description    = $mockDescription
-                        TcpPort        = $mockTcpPort
+                        Ensure                = 'Present'
+                        ServerName            = $mockServerName
+                        InstanceName          = $mockInstanceName
+                        AccountName           = $mockAccountName
+                        EmailAddress          = $mockEmailAddress
+                        MailServerName        = $mockMailServerName
+                        LoggingLevel          = $mockLoggingLevel
+                        ProfileName           = $mockProfileName
+                        DisplayName           = $mockDisplayName
+                        ReplyToAddress        = $mockReplyToAddress
+                        Description           = $mockDescription
+                        TcpPort               = $mockTcpPort
+                        UseDefaultCredentials = $mockUseDefaultCredentials
                     }
                 }
             }
 
             It 'Should return the state as $true' {
                 $inModuleScopeParameters = @{
-                    MockLoggingLevel   = $mockLoggingLevel
-                    MockDisplayName    = $mockDisplayName
-                    MockReplyToAddress = $mockReplyToAddress
-                    MockDescription    = $mockDescription
-                    MockTcpPort        = $mockTcpPort
+                    MockLoggingLevel          = $mockLoggingLevel
+                    MockDisplayName           = $mockDisplayName
+                    MockReplyToAddress        = $mockReplyToAddress
+                    MockDescription           = $mockDescription
+                    MockTcpPort               = $mockTcpPort
+                    MockUseDefaultCredentials = $mockUseDefaultCredentials
                 }
 
                 InModuleScope -Parameters $inModuleScopeParameters -ScriptBlock {
@@ -486,6 +494,7 @@ Describe 'DSC_SqlDatabaseMail\Test-TargetResource' -Tag 'Test' {
                     $testTargetResourceParameters.ReplyToAddress = $MockReplyToAddress
                     $testTargetResourceParameters.Description = $MockDescription
                     $testTargetResourceParameters.TcpPort = $MockTcpPort
+                    $testTargetResourceParameters.UseDefaultCredentials = $MockUseDefaultCredentials
 
                     $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
@@ -555,24 +564,29 @@ Describe 'DSC_SqlDatabaseMail\Test-TargetResource' -Tag 'Test' {
                         Property      = 'TcpPort'
                         PropertyValue = '2525'
                     }
+                    @{
+                        Property      = 'UseDefaultCredentials'
+                        PropertyValue = $true
+                    }
                 )
             }
 
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        Ensure         = 'Present'
-                        ServerName     = $mockServerName
-                        InstanceName   = $mockInstanceName
-                        AccountName    = $mockAccountName
-                        EmailAddress   = $mockEmailAddress
-                        MailServerName = $mockMailServerName
-                        LoggingLevel   = 'Normal'
-                        ProfileName    = $mockProfileName
-                        DisplayName    = $mockDisplayName
-                        ReplyToAddress = $mockReplyToAddress
-                        Description    = $mockDescription
-                        TcpPort        = $mockTcpPort
+                        Ensure                = 'Present'
+                        ServerName            = $mockServerName
+                        InstanceName          = $mockInstanceName
+                        AccountName           = $mockAccountName
+                        EmailAddress          = $mockEmailAddress
+                        MailServerName        = $mockMailServerName
+                        LoggingLevel          = 'Normal'
+                        ProfileName           = $mockProfileName
+                        DisplayName           = $mockDisplayName
+                        ReplyToAddress        = $mockReplyToAddress
+                        Description           = $mockDescription
+                        TcpPort               = $mockTcpPort
+                        UseDefaultCredentials = $mockUseDefaultCredentials
                     }
                 }
             }
@@ -631,6 +645,7 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
         $mockDisplayName = $mockMailServerName
         $mockDescription = 'My mail description'
         $mockTcpPort = 25
+        $mockUseDefaultCredentials = $false
 
         $mockDatabaseMailDisabledConfigValue = 0
         $mockDatabaseMailEnabledConfigValue = 1
@@ -670,6 +685,7 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                     New-Object -TypeName Object |
                         Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockMailServerName -PassThru |
                         Add-Member -MemberType NoteProperty -Name 'Port' -Value $mockTcpPort -PassThru |
+                        Add-Member -MemberType NoteProperty -Name 'UseDefaultCredentials' -Value $mockUseDefaultCredentials -PassThru |
                         Add-Member -MemberType ScriptMethod -Name 'Rename' -Value {
                             InModuleScope -ScriptBlock {
                                 $script:MailServerRenameMethodCallCount += 1
@@ -872,11 +888,12 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
 
             It 'Should call the correct methods without throwing' {
                 $inModuleScopeParameters = @{
-                    MockLoggingLevel   = $mockLoggingLevelNormal
-                    MockDisplayName    = $mockDisplayName
-                    MockReplyToAddress = $mockReplyToAddress
-                    MockDescription    = $mockDescription
-                    MockTcpPort        = $mockTcpPort
+                    MockLoggingLevel          = $mockLoggingLevelNormal
+                    MockDisplayName           = $mockDisplayName
+                    MockReplyToAddress        = $mockReplyToAddress
+                    MockDescription           = $mockDescription
+                    MockTcpPort               = $mockTcpPort
+                    MockUseDefaultCredentials = $mockUseDefaultCredentials
                 }
 
                 InModuleScope -Parameters $inModuleScopeParameters -ScriptBlock {
@@ -886,6 +903,7 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                     $setTargetResourceParameters['Description'] = $MockDescription
                     $setTargetResourceParameters['LoggingLevel'] = $MockLoggingLevel
                     $setTargetResourceParameters['TcpPort'] = $MockTcpPort
+                    $setTargetResourceParameters['UseDefaultCredentials'] = $MockUseDefaultCredentials
 
                     { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
 
@@ -975,6 +993,7 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                         $setTargetResourceParameters['ProfileName'] = 'MissingProfile'
                         # Also passing TcpPort when passing in MailServerName to add to code coverage
                         $setTargetResourceParameters['TcpPort'] = 2525
+                        $setTargetResourceParameters['UseDefaultCredentials'] = $true
 
                         { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
 
@@ -1029,6 +1048,10 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                             Property      = 'TcpPort'
                             PropertyValue = '2525'
                         }
+                        @{
+                            Property      = 'UseDefaultCredentials'
+                            PropertyValue = $true
+                        }
                     )
                 }
 
@@ -1064,6 +1087,18 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                             $script:LoggingLevelAlterMethodCallCount | Should -Be 0
                         }
                         elseif ($Property -eq 'TcpPort')
+                        {
+                            $script:MailServerRenameMethodCallCount | Should -Be 0
+                            $script:MailServerAlterMethodCallCount | Should -Be 1
+                            $script:MailAccountAlterMethodCallCount | Should -Be 0
+                            $script:MailProfileCreateMethodCallCount | Should -Be 0
+                            $script:MailProfileAlterMethodCallCount | Should -Be 0
+                            $script:MailProfileAddPrincipalMethodCallCount | Should -Be 0
+                            $script:MailProfileAddAccountMethodCallCount | Should -Be 0
+                            $script:JobServerAlterMethodCallCount | Should -Be 0
+                            $script:LoggingLevelAlterMethodCallCount | Should -Be 0
+                        }
+                        elseif ($Property -eq 'UseDefaultCredentials')
                         {
                             $script:MailServerRenameMethodCallCount | Should -Be 0
                             $script:MailServerAlterMethodCallCount | Should -Be 1


### PR DESCRIPTION
#### Pull Request (PR) description

Added the parameter UseDefaultCredentials to the SqlDatabaseMailDsc resource to allow the DatabaseEngine service account to be used for SMTP server authentication.  Changes required to this resource to support configuration of the account and password for "basic" or "anonymous" SMTP access is not addressed by this PR.   

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2001)
<!-- Reviewable:end -->
