### PR TITLE
SqlSetup: Remove value `Windows` from parameter `SecurityMode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Connect-SqlDscDatabaseEngine`
   - Update comment-based help with more examples.
+- SqlSetup
+  - The parameter `SecurityMode` now only (correctly) allows the value
+    `SQL` ([issue #1185](https://github.com/dsccommunity/SqlServerDsc/issues/1185)).
 
 ### Fixed
 

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -553,9 +553,7 @@ function Get-TargetResource
 
     .PARAMETER SecurityMode
         Security mode to apply to the
-        SQL Server instance. 'SQL' indicates mixed-mode authentication while
-        'Windows' indicates Windows authentication.
-        Default is Windows. { *Windows* | SQL }
+        SQL Server instance. 'SQL' indicates mixed-mode authentication.
 
     .PARAMETER SAPwd
         SA password, if SecurityMode is set to 'SQL'.
@@ -795,7 +793,7 @@ function Set-TargetResource
         $SQLSysAdminAccounts,
 
         [Parameter()]
-        [ValidateSet('SQL', 'Windows')]
+        [ValidateSet('SQL')]
         [System.String]
         $SecurityMode,
 
@@ -1804,9 +1802,7 @@ function Set-TargetResource
 
     .PARAMETER SecurityMode
         Security mode to apply to the
-        SQL Server instance. 'SQL' indicates mixed-mode authentication while
-        'Windows' indicates Windows authentication.
-        Default is Windows. { *Windows* | SQL }
+        SQL Server instance. 'SQL' indicates mixed-mode authentication.
 
     .PARAMETER SAPwd
         SA password, if SecurityMode is set to 'SQL'.
@@ -2054,7 +2050,7 @@ function Test-TargetResource
         $SQLSysAdminAccounts,
 
         [Parameter()]
-        [ValidateSet('SQL', 'Windows')]
+        [ValidateSet('SQL')]
         [System.String]
         $SecurityMode,
 
@@ -2690,7 +2686,7 @@ function Get-SqlEngineProperties
     }
     else
     {
-        $securityMode = 'Windows'
+        $securityMode = $null
     }
 
     return @{

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.schema.mof
@@ -23,7 +23,7 @@ class DSC_SqlSetup : OMI_BaseResource
     [Read, Description("Returns the username for the _SQL Agent_'s _Windows_ service.")] String AgtSvcAccountUsername;
     [Write, Description("Collation for _SQL Server Database Engine_.")] String SQLCollation;
     [Write, Description("An array of accounts to be made _SQL Server_ administrators.")] String SQLSysAdminAccounts[];
-    [Write, Description("Security mode to apply to the _SQL Server_ instance. The value `'SQL'` indicates mixed-mode authentication while the value `'Windows'` indicates _Windows Authentication_. Default value is `'Windows'`."), ValueMap{"SQL", "Windows"}, Values{"SQL", "Windows"}] String SecurityMode;
+    [Write, Description("Security mode to apply to the _SQL Server_ instance. The value `'SQL'` indicates mixed-mode authentication."), ValueMap{"SQL"}, Values{"SQL"}] String SecurityMode;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Specifies the SA account's password. Only applicable if parameter **SecurityMode** is set to `'SQL'`.")] String SAPwd;
     [Write, Description("Root path for _SQL Server_ database files.")] String InstallSQLDataDir;
     [Write, Description("Path for _SQL Server_ database files.")] String SQLUserDBDir;

--- a/tests/Integration/Resources/DSC_SqlSetup.Integration.Tests.ps1
+++ b/tests/Integration/Resources/DSC_SqlSetup.Integration.Tests.ps1
@@ -509,7 +509,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             $resourceCurrentState.RSSvcAccount               | Should -BeNullOrEmpty
             $resourceCurrentState.RSSvcAccountUsername       | Should -BeNullOrEmpty
             $resourceCurrentState.SAPwd                      | Should -BeNullOrEmpty
-            $resourceCurrentState.SecurityMode               | Should -Be 'Windows'
+            $resourceCurrentState.SecurityMode               | Should -BeNullOrEmpty
             $resourceCurrentState.SetupProcessTimeout        | Should -BeNullOrEmpty
             $resourceCurrentState.SourceCredential           | Should -BeNullOrEmpty
             $resourceCurrentState.SourcePath                 | Should -Be "$($ConfigurationData.AllNodes.DriveLetter):\"

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -449,7 +449,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                     SQLUserDBDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                     SQLUserDBLogDir       = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                     SQLBackupDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\Backup"
-                    SecurityMode          = 'Windows'
+                    SecurityMode          = $null
                 }
             }
 
@@ -547,7 +547,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                 $result.AgtSvcAccountUsername | Should -Be 'COMPANY\AgentAccount'
                 $result.SqlCollation | Should -Be 'Finnish_Swedish_CI_AS'
                 $result.SQLSysAdminAccounts | Should -Be 'COMPANY\Stacy'
-                $result.SecurityMode | Should -Be 'Windows'
+                $result.SecurityMode | Should -BeNullOrEmpty
                 $result.InstallSQLDataDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL"
                 $result.SQLUserDBDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                 $result.SQLUserDBLogDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
@@ -766,7 +766,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                     SqlSvcStartupType     = 'Auto'
                     AgtSvcStartupType     = 'Auto'
                     SQLCollation          = 'Finnish_Swedish_CI_AS'
-                    SecurityMode          = 'Windows'
+                    SecurityMode          = $null
                 }
             }
 
@@ -884,7 +884,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                     SQLUserDBDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                     SQLUserDBLogDir       = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                     SQLBackupDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\Backup"
-                    SecurityMode          = 'Windows'
+                    SecurityMode          = $null
                 }
             }
 
@@ -1008,7 +1008,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                 $result.AgtSvcAccountUsername | Should -Be 'COMPANY\AgentAccount'
                 $result.SqlCollation | Should -Be 'Finnish_Swedish_CI_AS'
                 $result.SQLSysAdminAccounts | Should -Be 'COMPANY\Stacy'
-                $result.SecurityMode | Should -Be 'Windows'
+                $result.SecurityMode | Should -BeNullOrEmpty
                 $result.InstallSQLDataDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL"
                 $result.SQLUserDBDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                 $result.SQLUserDBLogDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
@@ -1114,7 +1114,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                     SQLUserDBDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                     SQLUserDBLogDir       = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                     SQLBackupDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\Backup"
-                    SecurityMode          = 'Windows'
+                    SecurityMode          = $null
                 }
             }
 
@@ -1241,7 +1241,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                 $result.AgtSvcAccountUsername | Should -Be 'COMPANY\AgentAccount'
                 $result.SqlCollation | Should -Be 'Finnish_Swedish_CI_AS'
                 $result.SQLSysAdminAccounts | Should -Be 'COMPANY\Stacy'
-                $result.SecurityMode | Should -Be 'Windows'
+                $result.SecurityMode | Should -BeNullOrEmpty
                 $result.InstallSQLDataDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL"
                 $result.SQLUserDBDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
                 $result.SQLUserDBLogDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).MSSQLSERVER\MSSQL\DATA\"
@@ -1428,7 +1428,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                     SQLUserDBDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).TEST\MSSQL\DATA\"
                     SQLUserDBLogDir       = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).TEST\MSSQL\DATA\"
                     SQLBackupDir          = "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).TEST\MSSQL\Backup"
-                    SecurityMode          = 'Windows'
+                    SecurityMode          = $null
                 }
             }
 
@@ -1550,7 +1550,7 @@ Describe 'SqlSetup\Get-TargetResource' -Tag 'Get' {
                 $result.AgtSvcAccountUsername | Should -Be 'COMPANY\AgentAccount'
                 $result.SqlCollation | Should -Be 'Finnish_Swedish_CI_AS'
                 $result.SQLSysAdminAccounts | Should -Be 'COMPANY\Stacy'
-                $result.SecurityMode | Should -Be 'Windows'
+                $result.SecurityMode | Should -BeNullOrEmpty
                 $result.InstallSQLDataDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).TEST\MSSQL"
                 $result.SQLUserDBDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).TEST\MSSQL\DATA\"
                 $result.SQLUserDBLogDir | Should -Be "C:\Program Files\Microsoft SQL Server\MSSQL$($MockSqlMajorVersion).TEST\MSSQL\DATA\"
@@ -4628,7 +4628,7 @@ Describe 'Get-SqlEngineProperties' -Tag 'Helper' {
                 $result.SQLUserDBDir | Should -Be 'K:\MSSQL\Data'
                 $result.SQLUserDBLogDir | Should -Be 'L:\MSSQL\Logs'
                 $result.SQLBackupDir | Should -Be 'O:\MSSQL\Backup'
-                $result.SecurityMode | Should -Be 'Windows'
+                $result.SecurityMode | Should -BeNullOrEmpty
             }
         }
 
@@ -4643,7 +4643,7 @@ Describe 'Get-SqlEngineProperties' -Tag 'Helper' {
 
                     $result = Get-SqlEngineProperties -ServerName 'localhost' -InstanceName 'MSSQLSERVER'
 
-                    $result.SecurityMode | Should -BeExactly 'Windows'
+                    $result.SecurityMode | Should -BeNullOrEmpty
                 }
             }
         }


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlSetup
  - The parameter `SecurityMode` now only (correctly) allows the value
    `SQL` (issue #1185).

#### This Pull Request (PR) fixes the following issues

- Fixes #1185

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2032)
<!-- Reviewable:end -->
