### PR TITLE
SqlSetup: Fix AddNode failing due to missing setup parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- SqlSetup
+  - Fixed issue with AddNode where cluster IP information was not being passed to
+    setup.exe. ([issue #1171](https://github.com/dsccommunity/SqlServerDsc/issues/1171))
+
 ## [17.0.0] - 2024-09-30
 
 ### Added

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -1269,7 +1269,6 @@ function Set-TargetResource
     # Determine network mapping for specific cluster installation types
     if ($Action -in @('CompleteFailoverCluster', 'InstallFailoverCluster', 'AddNode'))
     {
-        Write-Warning 'Inside the IP Address stuff'
         $clusterIPAddresses = @()
 
         # If no IP Address has been specified, use "DEFAULT"

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -63,7 +63,7 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 #>
 function Get-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Connect-Sql is called implicitly in several function, for example Get-SqlEngineProperties')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification = 'The command Connect-Sql is called implicitly in several function, for example Get-SqlEngineProperties')]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
@@ -722,8 +722,8 @@ function Get-TargetResource
 #>
 function Set-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification='Because $global:DSCMachineStatus is used to trigger a Restart, either by force or when there are pending changes.')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification='Because $global:DSCMachineStatus is only set, never used (by design of Desired State Configuration).')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification = 'Because $global:DSCMachineStatus is used to trigger a Restart, either by force or when there are pending changes.')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Because $global:DSCMachineStatus is only set, never used (by design of Desired State Configuration).')]
     [CmdletBinding()]
     param
     (
@@ -1265,15 +1265,17 @@ function Set-TargetResource
         $setupArguments['FailoverClusterDisks'] = ($failoverClusterDisks | Sort-Object)
     }
 
+
     # Determine network mapping for specific cluster installation types
-    if ($Action -in @('CompleteFailoverCluster', 'InstallFailoverCluster'))
+    if ($Action -in @('CompleteFailoverCluster', 'InstallFailoverCluster', 'AddNode'))
     {
+        Write-Warning 'Inside the IP Address stuff'
         $clusterIPAddresses = @()
 
         # If no IP Address has been specified, use "DEFAULT"
         if ($FailoverClusterIPAddress.Count -eq 0)
         {
-            $clusterIPAddresses += "DEFAULT"
+            $clusterIPAddresses += 'DEFAULT'
         }
         else
         {
@@ -1525,7 +1527,7 @@ function Set-TargetResource
                 $setupArguments['ASSysAdminAccounts'] = @($PsDscContext.RunAsUser)
             }
 
-            if ($PSBoundParameters.ContainsKey("ASSysAdminAccounts"))
+            if ($PSBoundParameters.ContainsKey('ASSysAdminAccounts'))
             {
                 $setupArguments['ASSysAdminAccounts'] += $ASSysAdminAccounts
             }
@@ -1636,12 +1638,12 @@ function Set-TargetResource
 
     if ($SecurityMode -eq 'SQL')
     {
-        $log = $log.Replace($SAPwd.GetNetworkCredential().Password, "********")
+        $log = $log.Replace($SAPwd.GetNetworkCredential().Password, '********')
     }
 
-    if ($ProductKey -ne "")
+    if ($ProductKey -ne '')
     {
-        $log = $log.Replace($ProductKey, "*****-*****-*****-*****-*****")
+        $log = $log.Replace($ProductKey, '*****-*****-*****-*****-*****')
     }
 
     $logVars = @('AgtSvcAccount', 'SQLSvcAccount', 'FTSvcAccount', 'RSSvcAccount', 'ASSvcAccount', 'ISSvcAccount')
@@ -1649,7 +1651,7 @@ function Set-TargetResource
     {
         if ($PSBoundParameters.ContainsKey($logVar))
         {
-            $log = $log.Replace((Get-Variable -Name $logVar).Value.GetNetworkCredential().Password, "********")
+            $log = $log.Replace((Get-Variable -Name $logVar).Value.GetNetworkCredential().Password, '********')
         }
     }
 
@@ -1996,7 +1998,7 @@ function Set-TargetResource
 #>
 function Test-TargetResource
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification='The command Connect-Sql is implicitly called when Get-TargetResource is called')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('SqlServerDsc.AnalyzerRules\Measure-CommandsNeededToLoadSMO', '', Justification = 'The command Connect-Sql is implicitly called when Get-TargetResource is called')]
     [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
@@ -2342,7 +2344,7 @@ function Test-TargetResource
         Write-Verbose -Message $script:localizedData.EvaluatingClusterParameters
 
         $variableNames = $PSBoundParameters.Keys |
-            Where-Object -FilterScript { $_ -imatch "^FailoverCluster" }
+            Where-Object -FilterScript { $_ -imatch '^FailoverCluster' }
 
         foreach ($variableName in $variableNames)
         {

--- a/source/DSCResources/DSC_SqlSetup/README.md
+++ b/source/DSCResources/DSC_SqlSetup/README.md
@@ -156,5 +156,3 @@ AnalysisServicesConnection | A new method of loading the assembly *Microsoft.Ana
 ## Known issues
 
 All issues are not listed here, see [here for all open issues](https://github.com/dsccommunity/SqlServerDsc/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+SqlSetup).
-
-> [!IMPORTANT] The setup action AddNode is not currently functional.

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -3226,6 +3226,22 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
                     Features = ''
                 }
             }
+
+            $mockDynamicClusterSites = @(
+                @{
+                    Name    = 'SiteA'
+                    Address = '10.0.0.10' # First site IP address
+                    Mask    = '255.255.255.0'
+                }
+            )
+
+            Mock -CommandName Get-CimInstance -MockWith $mockGetCimInstance_MSClusterNetwork -ParameterFilter {
+                ($Namespace -eq 'root/MSCluster') -and ($ClassName -eq 'MSCluster_Network') -and ($Filter -eq 'Role >= 2')
+            }
+
+            Mock -CommandName Test-IPAddress -MockWith {
+                return $true
+            }
         }
 
         It 'Should pass proper parameters to setup' {
@@ -3240,6 +3256,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
                 SqlSvcPassword               = 'SqlS3v!c3P@ssw0rd'
                 AsSvcAccount                 = 'COMPANY\AnalysisAccount'
                 AsSvcPassword                = 'AnalysisS3v!c3P@ssw0rd'
+                FailoverClusterIPAddresses   = 'IPv4;10.0.0.10;SiteA_Prod;255.255.255.0'
             }
 
             InModuleScope -ScriptBlock {
@@ -3255,6 +3272,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
                     SqlSvcAccount              = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @('COMPANY\SqlAccount', ('SqlS3v!c3P@ssw0rd' | ConvertTo-SecureString -AsPlainText -Force))
                     ASSvcAccount               = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @('COMPANY\AnalysisAccount', ('AnalysisS3v!c3P@ssw0rd' | ConvertTo-SecureString -AsPlainText -Force))
                     FailoverClusterNetworkName = 'TestDefaultCluster'
+                    FailoverClusterIPAddress   = '10.0.0.10'
                     SQLSysAdminAccounts        = 'COMPANY\User1', 'COMPANY\SQLAdmins'
                 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

As [documented](https://learn.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt?view=sql-server-ver16#AddNode) by Microsoft, the "AddNode" action requires a value for the parameter `FailoverClusterIPAddresses`. The SqlServerDsc module was incorrectly excluding this property from the arguments passed to the setup program. This caused any DSC operations for "AddNode" to fail during the `Set-TargetResource` process. This PR makes a minor adjustment to allow the IP property to be emitted when `$Action` is set to "AddNode".

#### This Pull Request (PR) fixes the following issues

- Fixes #1171 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2047)
<!-- Reviewable:end -->
