### PR TITLE
`Test-SqlDscIsRole`: New command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ The format is based on and uses the types of changes according to [Keep a Change
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- SqlServerDsc
-  - Added Test-SqlDscIsRole to be used like Test-SqlDscIsLogin but tests for a server role as principal
-
 ### Removed
 
 - SqlServerDsc.Common
@@ -61,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix style formatting in all PowerShell script files.
   - Update module description on GitHub, in the conceptual help, and in
     the module manifest.
+  - Added Test-SqlDscIsRole to be used like Test-SqlDscIsLogin but tests for a server role as principal.
 - SqlSetup
   - Fixed issue with AddNode where cluster IP information was not being passed to
     setup.exe ([issue #1171](https://github.com/dsccommunity/SqlServerDsc/issues/1171)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on and uses the types of changes according to [Keep a Change
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- SqlServerDsc
+  - Added Test-SqlDscIsRole to be used like Test-SqlDscIsLogin but tests for a server role as principal
 
 ### Removed
 

--- a/source/Public/Test-SqlDscIsRole.ps1
+++ b/source/Public/Test-SqlDscIsRole.ps1
@@ -16,7 +16,7 @@
 
     .EXAMPLE
         $serverInstance = Connect-SqlDscDatabaseEngine
-        Test-SqlDscIsDatabaseRole -ServerObject $serverInstance -Name 'MyPrincipal'
+        Test-SqlDscIsRole -ServerObject $serverInstance -Name 'MyPrincipal'
 
         Returns $true if the principal exist as role, if not $false is returned.
 #>

--- a/source/Public/Test-SqlDscIsRole.ps1
+++ b/source/Public/Test-SqlDscIsRole.ps1
@@ -1,26 +1,26 @@
 <#
     .SYNOPSIS
-        Returns whether the server principal exist and is a login.
+        Returns whether the database principal exists and is a database role.
 
     .DESCRIPTION
-        Returns whether the server principal exist and is a login.
+        Returns whether the database principal exist and is a database role.
 
     .PARAMETER ServerObject
         Specifies current server connection object.
 
     .PARAMETER Name
-        Specifies the name of the server principal.
+        Specifies the name of the database principal.
 
     .OUTPUTS
         [System.Boolean]
 
     .EXAMPLE
         $serverInstance = Connect-SqlDscDatabaseEngine
-        Test-SqlDscIsLogin -ServerObject $serverInstance -Name 'MyPrincipal'
+        Test-SqlDscIsDatabaseRole -ServerObject $serverInstance -Name 'MyPrincipal'
 
-        Returns $true if the principal exist as a login, if not $false is returned.
+        Returns $true if the principal exist as role, if not $false is returned.
 #>
-function Test-SqlDscIsLogin
+function Test-SqlDscIsRole
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [CmdletBinding()]
@@ -38,13 +38,13 @@ function Test-SqlDscIsLogin
 
     process
     {
-        $loginExist = $false
+        $principalExist = $false
 
-        if ($ServerObject.Logins[$Name])
+        if ($ServerObject.Roles[$Name])
         {
-            $loginExist = $true
+            $principalExist = $true
         }
 
-        return $loginExist
+        return $principalExist
     }
 }

--- a/tests/Unit/Public/Test-SqlDscIsRole.Tests.ps1
+++ b/tests/Unit/Public/Test-SqlDscIsRole.Tests.ps1
@@ -1,0 +1,96 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    $env:SqlServerDscCI = $true
+
+    Import-Module -Name $script:dscModuleName
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Item -Path 'env:SqlServerDscCI'
+}
+
+Describe 'Test-SqlDscIsRole' -Tag 'Public' {
+    Context 'When the instance does not have the specified principal' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Roles' -Value {
+                    return @{
+                        'JuniorDBA' = New-Object -TypeName Object |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Name' -Value 'JuniorDBA' -PassThru -Force
+                    }
+                } -PassThru -Force
+        }
+
+        It 'Should return $false' {
+            $result = Test-SqlDscIsRole -ServerObject $mockServerObject -Name 'UnknownUser'
+
+            $result | Should -BeFalse
+        }
+    }
+
+    Context 'When the instance have the specified principal' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Roles' -Value {
+                    return @{
+                        'JuniorDBA' = New-Object -TypeName Object |
+                            Add-Member -MemberType 'NoteProperty' -Name 'Name' -Value 'JuniorDBA' -PassThru -Force
+                    }
+                } -PassThru -Force
+        }
+
+        It 'Should return $true' {
+            $result = Test-SqlDscIsRole -ServerObject $mockServerObject -Name 'JuniorDBA'
+
+            $result | Should -BeTrue
+        }
+
+        Context 'When passing ServerObject over the pipeline' {
+            It 'Should return $true' {
+                $result = $mockServerObject | Test-SqlDscIsRole -Name 'JuniorDBA'
+
+                $result | Should -BeTrue
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description
Added a public command that returns whether the server role exists.
Implemented new Test-SqlDscIsRole for testing whether a server principal is a Role. Fixed documentation in Test-SqlDscIsLogin

#### This Pull Request (PR) fixes the following issues
- Fixes #2058 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2060)
<!-- Reviewable:end -->
