### PR TITLE
`Invoke-ReportServerSetupAction`: Add private command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix localization strings in `Assert` method.
 - `Save-SqlDscSqlServerMediaFile`
   - Fix localizations strings that used wrong keys.
+  - Fix unit tests so the work cross-platform.
 - `SqlConfiguration`
   - Change the alias command to real command name, to pass HQRM tests.
 - `SqlDatabaseUser`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Private function:
+  - `Invoke-ReportServerSetupAction`
+
 ### Changed
 
 - SqlServerDsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Save-SqlDscSqlServerMediaFile`
   - Fix localizations strings that used wrong keys.
   - Fix unit tests so the work cross-platform.
+- `Install-SqlDscServer` and private function `Invoke-SetupAction`
+  - Fix localization string keys naming.
+  - Fix unit tests to use correct localization string names.
 - `SqlConfiguration`
   - Change the alias command to real command name, to pass HQRM tests.
 - `SqlDatabaseUser`

--- a/source/Private/Invoke-ReportServerSetupAction.ps1
+++ b/source/Private/Invoke-ReportServerSetupAction.ps1
@@ -7,9 +7,18 @@
 
         See the link in the commands help for information on each parameter.
 
+    .PARAMETER Install
+        Specifies that a new installation should be performed.
+
+    .PARAMETER Uninstall
+        Specifies that an uninstallation should be performed.
+
+    .PARAMETER Repair
+        Specifies that a repair should be performed on an existing installation.
+
     .PARAMETER AcceptLicensingTerms
         Required parameter to be able to run unattended install. By specifying this
-        parameter you acknowledge the acceptance all license terms and notices for
+        parameter you acknowledge the acceptance of all license terms and notices for
         the specified features, the terms and notices that the setup executable
         normally asks for.
 

--- a/source/Private/Invoke-ReportServerSetupAction.ps1
+++ b/source/Private/Invoke-ReportServerSetupAction.ps1
@@ -154,7 +154,9 @@ function Invoke-ReportServerSetupAction
         [Parameter(ParameterSetName = 'Install')]
         [Parameter(ParameterSetName = 'Repair')]
         [ValidateScript({
-                if (-not (Test-Path -Path (Split-Path -Path $_ -Parent) -PathType 'Container'))
+                $parentInstallFolder = Split-Path -Path $_ -Parent
+
+                if (-not (Test-Path -Path $parentInstallFolder))
                 {
                     throw $script:localizedData.ReportServerSetupAction_InstallFolderNotFound
                 }

--- a/source/Private/Invoke-ReportServerSetupAction.ps1
+++ b/source/Private/Invoke-ReportServerSetupAction.ps1
@@ -58,14 +58,34 @@
         None.
 
     .EXAMPLE
-        Invoke-ReportServerSetup -ReportingServices -AcceptLicensingTerms -MediaPath 'E:\' -SQLSysAdminAccounts @('MyAdminAccount') -ReportingServicesInstallType 'InstallOnly'
+        Invoke-ReportServerSetupAction -Install -AcceptLicensingTerms -MediaPath 'E:\SQLServerReportingServices.exe'
 
-        Installs Reporting Services.
+        Installs SQL Server Reporting Services with default settings.
 
     .EXAMPLE
-        Invoke-ReportServerSetup -BIReportServer -AcceptLicensingTerms -MediaPath 'E:\' -SQLSysAdminAccounts @('MyAdminAccount') -ReportingServicesInstallType 'InstallOnly'
+        Invoke-ReportServerSetupAction -Install -AcceptLicensingTerms -MediaPath 'E:\SQLServerReportingServices.exe' -ProductKey '12345-12345-12345-12345-12345'
 
-        Installs BI Report Server.
+        Installs SQL Server Reporting Services using a product key.
+
+    .EXAMPLE
+        Invoke-ReportServerSetupAction -Install -AcceptLicensingTerms -MediaPath 'E:\PowerBIReportServer.exe' -Edition 'Evaluation' -InstallFolder 'C:\Program Files\Power BI Report Server'
+
+        Installs Power BI Report Server in evaluation edition to a custom folder.
+
+    .EXAMPLE
+        Invoke-ReportServerSetupAction -Install -AcceptLicensingTerms -MediaPath 'E:\SQLServerReportingServices.exe' -ProductKey '12345-12345-12345-12345-12345' -EditionUpgrade -LogPath 'C:\Logs\SSRS_Install.log'
+
+        Installs SQL Server Reporting Services and upgrades the edition using a product key. Also specifies a custom log path.
+
+    .EXAMPLE
+        Invoke-ReportServerSetupAction -Repair -AcceptLicensingTerms -MediaPath 'E:\SQLServerReportingServices.exe'
+
+        Repairs an existing installation of SQL Server Reporting Services.
+
+    .EXAMPLE
+        Invoke-ReportServerSetupAction -Uninstall -MediaPath 'E:\SQLServerReportingServices.exe' -Force
+
+        Uninstalls SQL Server Reporting Services without prompting for confirmation.
 #>
 function Invoke-ReportServerSetupAction
 {

--- a/source/Private/Invoke-ReportServerSetupAction.ps1
+++ b/source/Private/Invoke-ReportServerSetupAction.ps1
@@ -50,6 +50,10 @@
         Reporting Services: %ProgramFiles%\Microsoft SQL Server Reporting Services
         PI Report Server: %ProgramFiles%\Microsoft Power BI Report Server
 
+    .PARAMETER SuppressRestart
+        Suppresses the restart of the computer after the installation is finished.
+        By default the computer is restarted after the installation is finished.
+
     .PARAMETER Timeout
         Specifies how long to wait for the setup process to finish. Default value
         is `7200` seconds (2 hours). If the setup process does not finish before
@@ -167,6 +171,10 @@ function Invoke-ReportServerSetupAction
         $InstallFolder,
 
         [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $SuppressRestart,
+
+        [Parameter()]
         [System.UInt32]
         $Timeout = 7200,
 
@@ -240,6 +248,11 @@ function Invoke-ReportServerSetupAction
     if ($InstallFolder)
     {
         $setupArgument += ' /InstallFolder="{0}"' -f $InstallFolder
+    }
+
+    if ($SuppressRestart.IsPresent)
+    {
+        $setupArgument += ' /norestart'
     }
 
     $verboseSetupArgument = $setupArgument

--- a/source/Private/Invoke-ReportServerSetupAction.ps1
+++ b/source/Private/Invoke-ReportServerSetupAction.ps1
@@ -1,0 +1,280 @@
+<#
+    .SYNOPSIS
+        Executes setup using the provided setup executable.
+
+    .DESCRIPTION
+        Executes Reporting Services or BI Report Server setup using the provided setup executable.
+
+        See the link in the commands help for information on each parameter.
+
+    .PARAMETER AcceptLicensingTerms
+        Required parameter to be able to run unattended install. By specifying this
+        parameter you acknowledge the acceptance all license terms and notices for
+        the specified features, the terms and notices that the setup executable
+        normally asks for.
+
+    .PARAMETER MediaPath
+        Specifies the path where to find the SQL Server installation media. On this
+        path the SQL Server setup executable must be found.
+
+    .PARAMETER ProductKey
+        Specifies the product key to use for the installation, e.g. '12345-12345-12345-12345-12345'.
+        This parameter is mutually exclusive with the parameter Edition.
+
+    .PARAMETER EditionUpgrade
+        Upgrades the edition of the installed product. Requires that either the
+        ProductKey or the Edition parameter is also assigned. By default no edition
+        upgrade is performed.
+
+    .PARAMETER Edition
+        Specifies a free custom edition to use for the installation. This parameter
+        is mutually exclusive with the parameter ProductKey.
+
+    .PARAMETER LogPath
+        Specifies the file path where to write the log files, e.g. 'C:\Logs\Install.log'.
+        By default log files are created under %TEMP%.
+
+    .PARAMETER InstallFolder
+        Specifies the folder where to install the product, e.g. 'C:\Program Files\SSRS'.
+        By default the product is installed under the default installation folder.
+
+        Reporting Services: %ProgramFiles%\Microsoft SQL Server Reporting Services
+        PI Report Server: %ProgramFiles%\Microsoft Power BI Report Server
+
+    .PARAMETER Timeout
+        Specifies how long to wait for the setup process to finish. Default value
+        is `7200` seconds (2 hours). If the setup process does not finish before
+        this time, an exception will be thrown.
+
+    .PARAMETER Force
+        If specified the command will not ask for confirmation. Same as if Confirm:$false
+        is used.
+
+    .LINK
+        https://learn.microsoft.com/en-us/power-bi/report-server/install-report-server
+        https://learn.microsoft.com/en-us/sql/reporting-services/install-windows/install-reporting-services
+
+    .OUTPUTS
+        None.
+
+    .EXAMPLE
+        Invoke-ReportServerSetup -ReportingServices -AcceptLicensingTerms -MediaPath 'E:\' -SQLSysAdminAccounts @('MyAdminAccount') -ReportingServicesInstallType 'InstallOnly'
+
+        Installs Reporting Services.
+
+    .EXAMPLE
+        Invoke-ReportServerSetup -BIReportServer -AcceptLicensingTerms -MediaPath 'E:\' -SQLSysAdminAccounts @('MyAdminAccount') -ReportingServicesInstallType 'InstallOnly'
+
+        Installs BI Report Server.
+#>
+function Invoke-ReportServerSetupAction
+{
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType()]
+    param
+    (
+        [Parameter(ParameterSetName = 'Install', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $Install,
+
+        [Parameter(ParameterSetName = 'Uninstall', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $Uninstall,
+
+        [Parameter(ParameterSetName = 'Repair', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $Repair,
+
+        [Parameter(ParameterSetName = 'Install', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'Repair', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $AcceptLicensingTerms,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({
+                if (-not (Test-Path -Path $_ -PathType 'Leaf'))
+                {
+                    throw $script:localizedData.ReportServerSetupAction_ReportServerExecutableNotFound
+                }
+
+                return $true
+            })]
+        [System.String]
+        $MediaPath,
+
+        [Parameter(ParameterSetName = 'Install')]
+        [Parameter(ParameterSetName = 'Repair')]
+        [System.String]
+        $ProductKey,
+
+        [Parameter(ParameterSetName = 'Install')]
+        [Parameter(ParameterSetName = 'Repair')]
+        [System.Management.Automation.SwitchParameter]
+        $EditionUpgrade,
+
+        [Parameter(ParameterSetName = 'Install')]
+        [Parameter(ParameterSetName = 'Repair')]
+        [ValidateSet('Development', 'Evaluation', 'ExpressAdvanced')]
+        [System.String]
+        $Edition,
+
+        [Parameter()]
+        [System.String]
+        $LogPath,
+
+        [Parameter(ParameterSetName = 'Install')]
+        [Parameter(ParameterSetName = 'Repair')]
+        [ValidateScript({
+                if (-not (Test-Path -Path (Split-Path -Path $_ -Parent) -PathType 'Container'))
+                {
+                    throw $script:localizedData.ReportServerSetupAction_InstallFolderNotFound
+                }
+
+                return $true
+            })]
+        [System.String]
+        $InstallFolder,
+
+        [Parameter()]
+        [System.UInt32]
+        $Timeout = 7200,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Force
+    )
+
+    if ($Force.IsPresent -and -not $Confirm)
+    {
+        $ConfirmPreference = 'None'
+    }
+
+    Assert-ElevatedUser -ErrorAction 'Stop'
+
+    $assertBoundParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @(
+            'Edition'
+        )
+        MutuallyExclusiveList2 = @(
+            'ProductKey'
+        )
+    }
+
+    # Either ProductKey or Edition must be specified, never both.
+    Assert-BoundParameter @assertBoundParameters
+
+    # If EditionUpgrade is specified then the parameter ProductKey or Edition must be specified.
+    $assertBoundParameters = @{
+        BoundParameterList = $PSBoundParameters
+        IfParameterPresent = @('EditionUpgrade')
+        RequiredParameter  = ('ProductKey', 'Edition')
+        RequiredBehavior   = 'Any'
+    }
+
+    Assert-BoundParameter @assertBoundParameters
+
+    # Default action is install or upgrade.
+    $setupArgument = '/quiet /IAcceptLicenseTerms'
+
+    if ($Uninstall.IsPresent)
+    {
+        $setupArgument += ' /uninstall'
+    }
+    elseif ($Repair.IsPresent)
+    {
+        $setupArgument += ' /repair'
+    }
+
+    if ($ProductKey)
+    {
+        $setupArgument += ' /PID={0}' -f $ProductKey
+    }
+
+    if ($EditionUpgrade.IsPresent)
+    {
+        $setupArgument += ' /EditionUpgrade'
+    }
+
+    if ($Edition)
+    {
+        $setupArgument += ' /Edition={0}' -f $Edition
+    }
+
+    if ($LogPath)
+    {
+        $setupArgument += ' /log "{0}"' -f $LogPath
+    }
+
+    if ($InstallFolder)
+    {
+        $setupArgument += ' /InstallFolder="{0}"' -f $InstallFolder
+    }
+
+    $verboseSetupArgument = $setupArgument
+
+    # Sensitive values.
+    $sensitiveValue = @(
+        $ProductKey
+    )
+
+    # Obfuscate sensitive values.
+    foreach ($currentSensitiveValue in $sensitiveValue)
+    {
+        $escapedRegExString = [System.Text.RegularExpressions.Regex]::Escape($currentSensitiveValue)
+
+        $verboseSetupArgument = $verboseSetupArgument -replace $escapedRegExString, '********'
+    }
+
+    # Clear sensitive values.
+    $sensitiveValue = $null
+
+    Write-Verbose -Message ($script:localizedData.ReportServerSetupAction_SetupArguments -f $verboseSetupArgument)
+
+    $verboseDescriptionMessage = $script:localizedData.ReportServerSetupAction_ShouldProcessVerboseDescription -f $PSCmdlet.ParameterSetName
+    $verboseWarningMessage = $script:localizedData.ReportServerSetupAction_ShouldProcessVerboseWarning -f $PSCmdlet.ParameterSetName
+    $captionMessage = $script:localizedData.ReportServerSetupAction_ShouldProcessCaption
+
+    if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
+    {
+        $expandedMediaPath = [System.Environment]::ExpandEnvironmentVariables($MediaPath)
+
+        $startProcessParameters = @{
+            FilePath     = $expandedMediaPath
+            ArgumentList = $setupArgument
+            Timeout      = $Timeout
+        }
+
+        # Clear setupArgument to remove any sensitive values.
+        $setupArgument = $null
+
+        # Run setup executable.
+        $processExitCode = Start-SqlSetupProcess @startProcessParameters
+
+        $setupExitMessage = ($script:localizedData.SetupAction_SetupExitMessage -f $processExitCode)
+
+        if ($processExitCode -eq 3010)
+        {
+            Write-Warning -Message (
+                '{0} {1}' -f $setupExitMessage, $script:localizedData.SetupAction_SetupSuccessfulRebootRequired
+            )
+        }
+        elseif ($processExitCode -ne 0)
+        {
+            $PSCmdlet.ThrowTerminatingError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    $setupExitMessage,
+                    'IRS0001', # cspell: disable-line
+                    [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                    $PSCmdlet.ParameterSetName
+                )
+            )
+        }
+        else
+        {
+            Write-Verbose -Message (
+                '{0} {1}' -f $setupExitMessage, ($script:localizedData.SetupAction_SetupSuccessful)
+            )
+        }
+    }
+}

--- a/source/Private/Invoke-SetupAction.ps1
+++ b/source/Private/Invoke-SetupAction.ps1
@@ -55,9 +55,9 @@
 
     .PARAMETER AcceptLicensingTerms
         Required parameter to be able to run unattended install. By specifying this
-        parameter you acknowledge the acceptance all license terms and notices for
+        parameter you acknowledge the acceptance of all license terms and notices for
         the specified features, the terms and notices that the Microsoft SQL Server
-        setup executable normally ask for.
+        setup executable normally asks for.
 
     .PARAMETER MediaPath
         Specifies the path where to find the SQL Server installation media. On this

--- a/source/Private/Invoke-SetupAction.ps1
+++ b/source/Private/Invoke-SetupAction.ps1
@@ -528,7 +528,7 @@ function Invoke-SetupAction
         [ValidateScript({
                 if (-not (Test-Path -Path $_))
                 {
-                    throw $script:localizedData.Server_ConfigurationFileNotFound
+                    throw $script:localizedData.Invoke_SetupAction_ConfigurationFileNotFound
                 }
 
                 return $true
@@ -567,7 +567,7 @@ function Invoke-SetupAction
         [ValidateScript({
                 if (-not (Test-Path -Path (Join-Path -Path $_ -ChildPath 'setup.exe')))
                 {
-                    throw $script:localizedData.Server_MediaPathNotFound
+                    throw $script:localizedData.Invoke_SetupAction_MediaPathNotFound
                 }
 
                 return $true
@@ -1674,11 +1674,11 @@ function Invoke-SetupAction
     # Clear sensitive values.
     $sensitiveValue = $null
 
-    Write-Verbose -Message ($script:localizedData.Server_SetupArguments -f $verboseSetupArgument)
+    Write-Verbose -Message ($script:localizedData.Invoke_SetupAction_SetupArguments -f $verboseSetupArgument)
 
-    $verboseDescriptionMessage = $script:localizedData.Server_Install_ShouldProcessVerboseDescription -f $PSCmdlet.ParameterSetName
-    $verboseWarningMessage = $script:localizedData.Server_Install_ShouldProcessVerboseWarning -f $PSCmdlet.ParameterSetName
-    $captionMessage = $script:localizedData.Server_Install_ShouldProcessCaption
+    $verboseDescriptionMessage = $script:localizedData.Invoke_SetupAction_ShouldProcessVerboseDescription -f $PSCmdlet.ParameterSetName
+    $verboseWarningMessage = $script:localizedData.Invoke_SetupAction_ShouldProcessVerboseWarning -f $PSCmdlet.ParameterSetName
+    $captionMessage = $script:localizedData.Invoke_SetupAction_ShouldProcessCaption
 
     if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
     {
@@ -1696,19 +1696,19 @@ function Invoke-SetupAction
         # Run setup executable.
         $processExitCode = Start-SqlSetupProcess @startProcessParameters
 
-        $setupExitMessage = ($script:localizedData.Server_SetupExitMessage -f $processExitCode)
+        $setupExitMessage = ($script:localizedData.SetupAction_SetupExitMessage -f $processExitCode)
 
         if ($processExitCode -eq 3010)
         {
             Write-Warning -Message (
-                '{0} {1}' -f $setupExitMessage, $script:localizedData.Server_SetupSuccessfulRebootRequired
+                '{0} {1}' -f $setupExitMessage, $script:localizedData.SetupAction_SetupSuccessfulRebootRequired
             )
         }
         elseif ($processExitCode -ne 0)
         {
             $PSCmdlet.ThrowTerminatingError(
                 [System.Management.Automation.ErrorRecord]::new(
-                    ('{0} {1}' -f $setupExitMessage, $script:localizedData.Server_SetupFailed),
+                    ('{0} {1}' -f $setupExitMessage, $script:localizedData.Invoke_SetupAction_SetupFailed),
                     'ISA0001', # cspell: disable-line
                     [System.Management.Automation.ErrorCategory]::InvalidOperation,
                     $InstanceName
@@ -1718,7 +1718,7 @@ function Invoke-SetupAction
         else
         {
             Write-Verbose -Message (
-                '{0} {1}' -f $setupExitMessage, ($script:localizedData.Server_SetupSuccessful)
+                '{0} {1}' -f $setupExitMessage, ($script:localizedData.SetupAction_SetupSuccessful)
             )
         }
     }

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -98,7 +98,6 @@ ConvertFrom-StringData @'
     ReportServerSetupAction_ReportServerExecutableNotFound = The specified executable does not exist.
     ReportServerSetupAction_InstallFolderNotFound = The parent of the specified install folder does not exist.
     ReportServerSetupAction_SetupArguments = Specified executable arguments: {0}
-    ReportServerSetupAction_TimeoutExceeded = The setup action has exceeded the specified timeout of {0} seconds.
     ReportServerSetupAction_ShouldProcessVerboseDescription = Invoking the setup action '{0}'.
     ReportServerSetupAction_ShouldProcessVerboseWarning = Are you sure you want to invoke the setup action '{0}'?
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -79,18 +79,30 @@ ConvertFrom-StringData @'
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
     Audit_Disable_ShouldProcessCaption = Disable audit on instance
 
-    ## Install-SqlDscServer
-    Server_Install_ShouldProcessVerboseDescription = Invoking the Microsoft SQL Server setup action '{0}'.
-    Server_Install_ShouldProcessVerboseWarning = Are you sure you want to invoke the setup action '{0}'?
+    ## Invoke-SetupAction, Invoke-ReportServerSetupAction
+    SetupAction_SetupExitMessage = Setup exited with code '{0}'.
+    SetupAction_SetupSuccessful = Setup finished successfully.
+    SetupAction_SetupSuccessfulRebootRequired = Setup finished successfully, but a reboot is required.
+
+    ## Invoke-SetupAction
+    Invoke_SetupAction_ShouldProcessVerboseDescription = Invoking the Microsoft SQL Server setup action '{0}'.
+    Invoke_SetupAction_ShouldProcessVerboseWarning = Are you sure you want to invoke the setup action '{0}'?
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
-    Server_Install_ShouldProcessCaption = Invoke a Microsoft SQL Server setup action
-    Server_SetupExitMessage = Setup exited with code '{0}'.
-    Server_SetupSuccessful = Setup finished successfully.
-    Server_SetupSuccessfulRebootRequired = Setup finished successfully, but a reboot is required.
-    Server_SetupFailed = Please see the 'Summary.txt' log file in the 'Setup Bootstrap\\Log' folder.
-    Server_SetupArguments = Specified setup executable arguments: {0}
-    Server_MediaPathNotFound = The specified media path does not exist or does not contain 'setup.exe'.
-    Server_ConfigurationFileNotFound = The specified configuration file was not found.
+    Invoke_SetupAction_ShouldProcessCaption = Invoke a Microsoft SQL Server setup action
+    Invoke_SetupAction_ConfigurationFileNotFound = The specified configuration file was not found.
+    Invoke_SetupAction_MediaPathNotFound = The specified media path does not exist or does not contain 'setup.exe'.
+    Invoke_SetupAction_SetupArguments = Specified setup executable arguments: {0}
+    Invoke_SetupAction_SetupFailed = Please see the 'Summary.txt' log file in the 'Setup Bootstrap\\Log' folder.
+
+    ## Invoke-ReportServerSetupAction
+    ReportServerSetupAction_ReportServerExecutableNotFound = The specified executable does not exist.
+    ReportServerSetupAction_InstallFolderNotFound = The parent of the specified install folder does not exist.
+    ReportServerSetupAction_SetupArguments = Specified executable arguments: {0}
+    ReportServerSetupAction_TimeoutExceeded = The setup action has exceeded the specified timeout of {0} seconds.
+    ReportServerSetupAction_ShouldProcessVerboseDescription = Invoking the setup action '{0}'.
+    ReportServerSetupAction_ShouldProcessVerboseWarning = Are you sure you want to invoke the setup action '{0}'?
+    # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
+    ReportServerSetupAction_ShouldProcessCaption = Invoke a setup action
 
     ## Assert-SetupActionProperties
     InstallSqlServerProperties_ASServerModeInvalidValue = The value for ASServerMode is not valid for the setup action {0}.

--- a/tests/Unit/Private/Invoke-ReportServerSetupAction.Tests.ps1
+++ b/tests/Unit/Private/Invoke-ReportServerSetupAction.Tests.ps1
@@ -65,17 +65,17 @@ Describe 'Invoke-ReportServerSetupAction' -Tag 'Private' {
         @{
             MockParameterSetName = 'Install'
             # cSpell: disable-next
-            MockExpectedParameters = '-Install -AcceptLicensingTerms -MediaPath <string> [-ProductKey <string>] [-EditionUpgrade] [-Edition <string>] [-LogPath <string>] [-InstallFolder <string>] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            MockExpectedParameters = '-Install -AcceptLicensingTerms -MediaPath <string> [-ProductKey <string>] [-EditionUpgrade] [-Edition <string>] [-LogPath <string>] [-InstallFolder <string>] [-SuppressRestart] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
         }
         @{
             MockParameterSetName = 'Uninstall'
             # cSpell: disable-next
-            MockExpectedParameters = '-Uninstall -MediaPath <string> [-LogPath <string>] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            MockExpectedParameters = '-Uninstall -MediaPath <string> [-LogPath <string>] [-SuppressRestart] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
         }
         @{
             MockParameterSetName = 'Repair'
             # cSpell: disable-next
-            MockExpectedParameters = '-Repair -AcceptLicensingTerms -MediaPath <string> [-ProductKey <string>] [-EditionUpgrade] [-Edition <string>] [-LogPath <string>] [-InstallFolder <string>] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            MockExpectedParameters = '-Repair -AcceptLicensingTerms -MediaPath <string> [-ProductKey <string>] [-EditionUpgrade] [-Edition <string>] [-LogPath <string>] [-InstallFolder <string>] [-SuppressRestart] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
         }
     ) {
         InModuleScope -Parameters $_ -ScriptBlock {
@@ -231,8 +231,17 @@ Describe 'Invoke-ReportServerSetupAction' -Tag 'Private' {
                 MockParameterValue = 'C:\Program Files\ReportServer'
                 MockExpectedRegEx = '\/InstallFolder="C:\\Program Files\\ReportServer"'
             }
+            @{
+                MockParameterName = 'SuppressRestart'
+                MockParameterValue = $true
+                MockExpectedRegEx = '\/norestart'
+            }
         ) {
             BeforeAll {
+                Mock -CommandName Test-Path -MockWith {
+                    return $true
+                }
+
                 Mock -CommandName Start-SqlSetupProcess -MockWith {
                     return 0
                 } -RemoveParameterValidation 'FilePath'
@@ -570,6 +579,10 @@ Describe 'Invoke-ReportServerSetupAction' -Tag 'Private' {
             }
         ) {
             BeforeAll {
+                Mock -CommandName Test-Path -MockWith {
+                    return $true
+                }
+
                 Mock -CommandName Start-SqlSetupProcess -MockWith {
                     return 0
                 } -RemoveParameterValidation 'FilePath'

--- a/tests/Unit/Private/Invoke-ReportServerSetupAction.Tests.ps1
+++ b/tests/Unit/Private/Invoke-ReportServerSetupAction.Tests.ps1
@@ -99,6 +99,56 @@ Describe 'Invoke-ReportServerSetupAction' -Tag 'Private' {
         }
     }
 
+    Context 'When passing no existent path to parameter MediaPath' {
+        BeforeAll {
+            Mock -CommandName Assert-ElevatedUser
+
+            InModuleScope -ScriptBlock {
+                $script:mockDefaultParameters = @{
+                    Install = $true
+                    AcceptLicensingTerms = $true
+                    # Invalid path to test error handling
+                    MediaPath = $TestDrive
+                    Force = $true
+                }
+            }
+        }
+
+        It 'Should throw an error when the MediaPath does not exist' {
+            InModuleScope -ScriptBlock {
+                { Invoke-ReportServerSetupAction @mockDefaultParameters } |
+                    Should -Throw -ExpectedMessage "Cannot validate argument on parameter 'MediaPath'. The specified executable does not exist."
+            }
+        }
+    }
+
+    Context 'When passing no existent path to parameter InstallFolder' {
+        BeforeAll {
+            Mock -CommandName Assert-ElevatedUser
+
+            # Create the file "$TestDrive/ssrs.exe"
+            New-Item -Path "$TestDrive/ssrs.exe" -ItemType File -Force | Out-Null
+
+            InModuleScope -ScriptBlock {
+                $script:mockDefaultParameters = @{
+                    Install = $true
+                    AcceptLicensingTerms = $true
+                    MediaPath = "$TestDrive/ssrs.exe"
+                    # Invalid path to test error handling
+                    InstallFolder = "$TestDrive/MissingFolder2/SSRS"
+                    Force = $true
+                }
+            }
+        }
+
+        It 'Should throw an error when the InstallFolder does not exist' {
+            InModuleScope -ScriptBlock {
+                { Invoke-ReportServerSetupAction @mockDefaultParameters } |
+                    Should -Throw -ExpectedMessage "Cannot validate argument on parameter 'InstallFolder'. The parent of the specified install folder does not exist."
+            }
+        }
+    }
+
     Context 'When setup action is ''Install''' {
         BeforeAll {
             Mock -CommandName Assert-ElevatedUser

--- a/tests/Unit/Private/Invoke-ReportServerSetupAction.Tests.ps1
+++ b/tests/Unit/Private/Invoke-ReportServerSetupAction.Tests.ps1
@@ -1,0 +1,671 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'because ConvertTo-SecureString is used to simplify the tests.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    $env:SqlServerDscCI = $true
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+
+    # Adding these mocks to handle the ValidateScript blocks
+    Mock -CommandName Test-Path -ParameterFilter {
+        $Path -match 'setup\.exe'
+    } -MockWith {
+        return $true
+    }
+
+    Mock -CommandName Test-Path -ParameterFilter {
+        $PathType -eq 'Container'
+    } -MockWith {
+        return $true
+    }
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Item -Path 'env:SqlServerDscCI'
+}
+
+Describe 'Invoke-ReportServerSetupAction' -Tag 'Private' {
+    It 'Should have the correct parameters in parameter set <MockParameterSetName>' -ForEach @(
+        @{
+            MockParameterSetName = 'Install'
+            # cSpell: disable-next
+            MockExpectedParameters = '-Install -AcceptLicensingTerms -MediaPath <string> [-ProductKey <string>] [-EditionUpgrade] [-Edition <string>] [-LogPath <string>] [-InstallFolder <string>] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+        @{
+            MockParameterSetName = 'Uninstall'
+            # cSpell: disable-next
+            MockExpectedParameters = '-Uninstall -MediaPath <string> [-LogPath <string>] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+        @{
+            MockParameterSetName = 'Repair'
+            # cSpell: disable-next
+            MockExpectedParameters = '-Repair -AcceptLicensingTerms -MediaPath <string> [-ProductKey <string>] [-EditionUpgrade] [-Edition <string>] [-LogPath <string>] [-InstallFolder <string>] [-Timeout <uint>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+    ) {
+        InModuleScope -Parameters $_ -ScriptBlock {
+            $result = (Get-Command -Name 'Invoke-ReportServerSetupAction').ParameterSets |
+                Where-Object -FilterScript {
+                    $_.Name -eq $mockParameterSetName
+                } |
+                Select-Object -Property @(
+                    @{
+                        Name = 'ParameterSetName'
+                        Expression = { $_.Name }
+                    },
+                    @{
+                        Name = 'ParameterListAsString'
+                        Expression = { $_.ToString() }
+                    }
+                )
+
+            $result.ParameterSetName | Should -Be $MockParameterSetName
+            $result.ParameterListAsString | Should -Be $MockExpectedParameters
+        }
+    }
+
+    Context 'When setup action is ''Install''' {
+        BeforeAll {
+            Mock -CommandName Assert-ElevatedUser
+        }
+
+        Context 'When specifying only mandatory parameters' {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Install = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                    }
+                }
+            }
+
+            Context 'When using parameter Confirm with value $false' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -Confirm:$false @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms'
+
+                            # Return $true if none of the above throw.
+                            $true
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When using parameter Force' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -Force @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms'
+
+                            # Return $true if none of the above throw.
+                            $true
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When using parameter WhatIf' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -WhatIf @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 0 -Scope It
+                    }
+                }
+            }
+        }
+
+        Context 'When specifying optional parameter <MockParameterName>' -ForEach @(
+            @{
+                MockParameterName = 'ProductKey'
+                MockParameterValue = '22222-00000-00000-00000-00000'
+                MockExpectedRegEx = '\/PID=22222-00000-00000-00000-00000'
+            }
+            @{
+                MockParameterName = 'Edition'
+                MockParameterValue = 'Evaluation'
+                MockExpectedRegEx = '\/Edition=Evaluation'
+            }
+            @{
+                MockParameterName = 'LogPath'
+                MockParameterValue = 'C:\Temp\Log.txt'
+                MockExpectedRegEx = '\/log "C:\\Temp\\Log\.txt"'
+            }
+            @{
+                MockParameterName = 'InstallFolder'
+                MockParameterValue = 'C:\Program Files\ReportServer'
+                MockExpectedRegEx = '\/InstallFolder="C:\\Program Files\\ReportServer"'
+            }
+        ) {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Install = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                    }
+                }
+            }
+
+            BeforeEach {
+                InModuleScope -ScriptBlock {
+                    $script:installSqlDscServerParameters = $mockDefaultParameters.Clone()
+                }
+            }
+
+            It 'Should call the mock with the correct argument string' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters.$MockParameterName = $MockParameterValue
+
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters
+
+                    Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                        $ArgumentList | Should -MatchExactly $MockExpectedRegEx
+
+                        # Return $true if none of the above throw.
+                        $true
+                    } -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+
+        Context 'When specifying optional parameter EditionUpgrade' {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+            }
+
+            It 'Should throw the correct error message when missing either parameter Edition or ProductKey' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters = @{
+                        Install = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                        EditionUpgrade = $true
+                    }
+
+                    { Invoke-ReportServerSetupAction @installSqlDscServerParameters } |
+                        Should -Throw -ErrorId 'ARCP0002,Assert-RequiredCommandParameter'
+                }
+            }
+
+            It 'Should require the parameter Edition' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters = @{
+                        Install = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                        EditionUpgrade = $true
+                        Edition = 'Evaluation'
+                    }
+
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters
+
+                    Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
+                }
+            }
+
+            It 'Should require the parameter ProductKey' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters = @{
+                        Install = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                        EditionUpgrade = $true
+                        ProductKey = '22222-00000-00000-00000-00000'
+                    }
+
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters
+
+                    Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+
+        Context 'When specifying sensitive parameter <MockParameterName>' -ForEach @(
+            @{
+                MockParameterName = 'ProductKey' # cspell: disable-line
+                MockParameterValue = '22222-00000-00000-00000-00000'
+                MockExpectedRegEx = '\/PID=\*{8}' # cspell: disable-line
+            }
+        ) {
+            BeforeAll {
+                Mock -CommandName Write-Verbose
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Install = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                    }
+                }
+            }
+
+            BeforeEach {
+                InModuleScope -ScriptBlock {
+                    $script:installSqlDscServerParameters = $mockDefaultParameters.Clone()
+                }
+            }
+
+            It 'Should obfuscate the value in the verbose string' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters.$MockParameterName = $MockParameterValue
+
+                    # Redirect all verbose stream to $null to ge no output from ShouldProcess.
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters -Verbose 4> $null
+
+                    $mockVerboseMessage = $script:localizedData.ReportServerSetupAction_SetupArguments
+
+                    Should -Invoke -CommandName Write-Verbose -ParameterFilter {
+                        # Only test the command that output the string that should be tested.
+                        $correctMessage = $Message -match $mockVerboseMessage
+
+                        # Only test string if it is the correct verbose command
+                        if ($correctMessage)
+                        {
+                            $Message | Should -MatchExactly $MockExpectedRegEx
+                        }
+
+                        # Return wether the correct command was called or not.
+                        $correctMessage
+                    } -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+    }
+
+    Context 'When setup action is ''Uninstall''' {
+        BeforeAll {
+            Mock -CommandName Assert-ElevatedUser
+        }
+
+        Context 'When specifying only mandatory parameters' {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Uninstall = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                    }
+                }
+            }
+
+            Context 'When using parameter Confirm with value $false' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -Confirm:$false @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms \/uninstall'
+
+                            # Return $true if none of the above throw.
+                            $true
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When using parameter Force' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -Force @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms \/uninstall'
+
+                            # Return $true if none of the above throw.
+                            $true
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When using parameter WhatIf' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -WhatIf @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 0 -Scope It
+                    }
+                }
+            }
+        }
+
+        Context 'When specifying optional parameter <MockParameterName>' -ForEach @(
+            @{
+                MockParameterName = 'LogPath'
+                MockParameterValue = 'C:\Temp\Log.txt'
+                MockExpectedRegEx = '\/log "C:\\Temp\\Log\.txt"'
+            }
+        ) {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Uninstall = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                    }
+                }
+            }
+
+            BeforeEach {
+                InModuleScope -ScriptBlock {
+                    $script:installSqlDscServerParameters = $mockDefaultParameters.Clone()
+                }
+            }
+
+            It 'Should call the mock with the correct argument string' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters.$MockParameterName = $MockParameterValue
+
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters
+
+                    Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                        $ArgumentList | Should -MatchExactly $MockExpectedRegEx
+
+                        # Return $true if none of the above throw.
+                        $true
+                    } -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+    }
+
+    Context 'When setup action is ''Repair''' {
+        BeforeAll {
+            Mock -CommandName Assert-ElevatedUser
+        }
+
+        Context 'When specifying only mandatory parameters' {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Repair = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                    }
+                }
+            }
+
+            Context 'When using parameter Confirm with value $false' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -Confirm:$false @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms \/repair'
+
+                            # Return $true if none of the above throw.
+                            $true
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When using parameter Force' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -Force @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms \/repair'
+
+                            # Return $true if none of the above throw.
+                            $true
+                        } -Exactly -Times 1 -Scope It
+                    }
+                }
+            }
+
+            Context 'When using parameter WhatIf' {
+                It 'Should call the mock with the correct argument string' {
+                    InModuleScope -ScriptBlock {
+                        Invoke-ReportServerSetupAction -WhatIf @mockDefaultParameters
+
+                        Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 0 -Scope It
+                    }
+                }
+            }
+        }
+
+        Context 'When specifying optional parameter <MockParameterName>' -ForEach @(
+            @{
+                MockParameterName = 'ProductKey'
+                MockParameterValue = '22222-00000-00000-00000-00000'
+                MockExpectedRegEx = '\/PID=22222-00000-00000-00000-00000'
+            }
+            @{
+                MockParameterName = 'Edition'
+                MockParameterValue = 'Evaluation'
+                MockExpectedRegEx = '\/Edition=Evaluation'
+            }
+            @{
+                MockParameterName = 'LogPath'
+                MockParameterValue = 'C:\Temp\Log.txt'
+                MockExpectedRegEx = '\/log "C:\\Temp\\Log\.txt"'
+            }
+            @{
+                MockParameterName = 'InstallFolder'
+                MockParameterValue = 'C:\Program Files\ReportServer'
+                MockExpectedRegEx = '\/InstallFolder="C:\\Program Files\\ReportServer"'
+            }
+        ) {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Repair = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                    }
+                }
+            }
+
+            BeforeEach {
+                InModuleScope -ScriptBlock {
+                    $script:installSqlDscServerParameters = $mockDefaultParameters.Clone()
+                }
+            }
+
+            It 'Should call the mock with the correct argument string' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters.$MockParameterName = $MockParameterValue
+
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters
+
+                    Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                        $ArgumentList | Should -MatchExactly $MockExpectedRegEx
+
+                        # Return $true if none of the above throw.
+                        $true
+                    } -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+
+        Context 'When specifying optional parameter EditionUpgrade' {
+            BeforeAll {
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+            }
+
+            It 'Should throw the correct error message when missing either parameter Edition or ProductKey' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters = @{
+                        Repair = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                        EditionUpgrade = $true
+                    }
+
+                    { Invoke-ReportServerSetupAction @installSqlDscServerParameters } |
+                        Should -Throw -ErrorId 'ARCP0002,Assert-RequiredCommandParameter'
+                }
+            }
+
+            It 'Should require the parameter Edition' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters = @{
+                        Repair = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                        EditionUpgrade = $true
+                        Edition = 'Evaluation'
+                    }
+
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters
+
+                    Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
+                }
+            }
+
+            It 'Should require the parameter ProductKey' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters = @{
+                        Repair = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                        EditionUpgrade = $true
+                        ProductKey = '22222-00000-00000-00000-00000'
+                    }
+
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters
+
+                    Should -Invoke -CommandName Start-SqlSetupProcess -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+
+        Context 'When specifying sensitive parameter <MockParameterName>' -ForEach @(
+            @{
+                MockParameterName = 'ProductKey' # cspell: disable-line
+                MockParameterValue = '22222-00000-00000-00000-00000'
+                MockExpectedRegEx = '\/PID=\*{8}' # cspell: disable-line
+            }
+        ) {
+            BeforeAll {
+                Mock -CommandName Write-Verbose
+                Mock -CommandName Start-SqlSetupProcess -MockWith {
+                    return 0
+                } -RemoveParameterValidation 'FilePath'
+
+                InModuleScope -ScriptBlock {
+                    $script:mockDefaultParameters = @{
+                        Repair = $true
+                        AcceptLicensingTerms = $true
+                        MediaPath = '\SqlMedia\setup.exe' # Added setup.exe to match the Test-Path mock
+                        Force = $true
+                    }
+                }
+            }
+
+            BeforeEach {
+                InModuleScope -ScriptBlock {
+                    $script:installSqlDscServerParameters = $mockDefaultParameters.Clone()
+                }
+            }
+
+            It 'Should obfuscate the value in the verbose string' {
+                InModuleScope -Parameters $_ -ScriptBlock {
+                    $installSqlDscServerParameters.$MockParameterName = $MockParameterValue
+
+                    # Redirect all verbose stream to $null to ge no output from ShouldProcess.
+                    Invoke-ReportServerSetupAction @installSqlDscServerParameters -Verbose 4> $null
+
+                    $mockVerboseMessage = $script:localizedData.ReportServerSetupAction_SetupArguments
+
+                    Should -Invoke -CommandName Write-Verbose -ParameterFilter {
+                        # Only test the command that output the string that should be tested.
+                        $correctMessage = $Message -match $mockVerboseMessage
+
+                        # Only test string if it is the correct verbose command
+                        if ($correctMessage)
+                        {
+                            $Message | Should -MatchExactly $MockExpectedRegEx
+                        }
+
+                        # Return wether the correct command was called or not.
+                        $correctMessage
+                    } -Exactly -Times 1 -Scope It
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Invoke-SetupAction.Tests.ps1
+++ b/tests/Unit/Private/Invoke-SetupAction.Tests.ps1
@@ -785,7 +785,7 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
                     # Redirect all verbose stream to $null to ge no output from ShouldProcess.
                     Invoke-SetupAction @installSqlDscServerParameters -Verbose 4> $null
 
-                    $mockVerboseMessage = $script:localizedData.Server_SetupArguments
+                    $mockVerboseMessage = $script:localizedData.Invoke_SetupAction_SetupArguments
 
                     Should -Invoke -CommandName Write-Verbose -ParameterFilter {
                         # Only test the command that output the string that should be tested.
@@ -3880,7 +3880,7 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
                         # Redirect all verbose stream to $null to ge no output from ShouldProcess.
                         Invoke-SetupAction @installSqlDscServerParameters -Verbose 4> $null
 
-                        $mockVerboseMessage = $script:localizedData.Server_SetupArguments
+                        $mockVerboseMessage = $script:localizedData.Invoke_SetupAction_SetupArguments
 
                         Should -Invoke -CommandName Write-Verbose -ParameterFilter {
                             # Only test the command that output the string that should be tested.

--- a/tests/Unit/Private/Invoke-SetupAction.Tests.ps1
+++ b/tests/Unit/Private/Invoke-SetupAction.Tests.ps1
@@ -151,6 +151,51 @@ Describe 'Invoke-SetupAction' -Tag 'Private' {
         }
     }
 
+    Context 'When passing no existent path to parameter MediaPath' {
+        BeforeAll {
+            Mock -CommandName Assert-ElevatedUser
+
+            InModuleScope -ScriptBlock {
+                $script:mockDefaultParameters = @{
+                    Install = $true
+                    AcceptLicensingTerms = $true
+                    MediaPath = $TestDrive # Updated to an invalid path to test error handling
+                    Force = $true
+                }
+            }
+        }
+
+        It 'Should throw an error when the MediaPath does not exist' {
+            InModuleScope -ScriptBlock {
+                { Invoke-SetupAction @mockDefaultParameters } |
+                    Should -Throw -ExpectedMessage "Cannot validate argument on parameter 'MediaPath'. The specified media path does not exist or does not contain 'setup.exe'."
+            }
+        }
+    }
+
+    Context 'When passing no existent path to parameter ConfigurationFile' {
+        BeforeAll {
+            Mock -CommandName Assert-ElevatedUser
+
+            InModuleScope -ScriptBlock {
+                $script:mockDefaultParameters = @{
+                    Install = $true
+                    AcceptLicensingTerms = $true
+                    # Invalid path to test error handling
+                    ConfigurationFile = "$TestDrive/config.ini"
+                    Force = $true
+                }
+            }
+        }
+
+        It 'Should throw an error when the MediaPath does not exist' {
+            InModuleScope -ScriptBlock {
+                { Invoke-SetupAction @mockDefaultParameters } |
+                    Should -Throw -ExpectedMessage "Cannot validate argument on parameter 'ConfigurationFile'. The specified configuration file was not found."
+            }
+        }
+    }
+
     Context 'When setup action is ''Install''' {
         BeforeAll {
             Mock -CommandName Assert-SetupActionProperties

--- a/tests/Unit/Public/Install-SqlDscServer.Tests.ps1
+++ b/tests/Unit/Public/Install-SqlDscServer.Tests.ps1
@@ -730,7 +730,7 @@ Describe 'Install-SqlDscServer' -Tag 'Public' {
                 Install-SqlDscServer @installSqlDscServerParameters -Verbose 4> $null
 
                 $mockVerboseMessage = InModuleScope -ScriptBlock {
-                    $script:localizedData.Server_SetupArguments
+                    $script:localizedData.Invoke_SetupAction_SetupArguments
                 }
 
                 Should -Invoke -CommandName Write-Verbose -ParameterFilter {
@@ -2320,7 +2320,7 @@ Describe 'Install-SqlDscServer' -Tag 'Public' {
                     Install-SqlDscServer @installSqlDscServerParameters -Verbose 4> $null
 
                     $mockVerboseMessage = InModuleScope -ScriptBlock {
-                        $script:localizedData.Server_SetupArguments
+                        $script:localizedData.Invoke_SetupAction_SetupArguments
                     }
 
                     Should -Invoke -CommandName Write-Verbose -ParameterFilter {

--- a/tests/Unit/Public/Save-SqlDscSqlServerMediaFile.Tests.ps1
+++ b/tests/Unit/Public/Save-SqlDscSqlServerMediaFile.Tests.ps1
@@ -101,7 +101,7 @@ Describe 'Save-SqlDscSqlServerMediaFile' -Tag 'Public' {
 
         # Define parameters for the function
         $Url = 'http://example.com/media.iso'
-        $DestinationPath = 'C:\Temp'
+        $DestinationPath = $TestDrive
     }
 
     Context 'When the URL does not end with .exe' {
@@ -161,7 +161,7 @@ Describe 'Save-SqlDscSqlServerMediaFile' -Tag 'Public' {
             Mock -CommandName Invoke-WebRequest
             Mock -CommandName Remove-Item
 
-            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.iso' -DestinationPath 'C:\Temp' -Force
+            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.iso' -DestinationPath $TestDrive -Force
 
             Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Remove-Item -Exactly -Times 1 -Scope It
@@ -172,7 +172,7 @@ Describe 'Save-SqlDscSqlServerMediaFile' -Tag 'Public' {
         It 'Should force the download of the media file' {
             Mock -CommandName Invoke-WebRequest
 
-            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.iso' -DestinationPath 'C:\Temp' -Force
+            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.iso' -DestinationPath $TestDrive -Force
 
             Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 1 -Scope It
         }
@@ -182,7 +182,7 @@ Describe 'Save-SqlDscSqlServerMediaFile' -Tag 'Public' {
         It 'Should download the media file silently' {
             Mock -CommandName Invoke-WebRequest
 
-            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.iso' -DestinationPath 'C:\Temp' -Quiet  -Confirm:$false
+            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.iso' -DestinationPath $TestDrive -Quiet  -Confirm:$false
 
             Should -Invoke -CommandName Invoke-WebRequest -Exactly -Times 1 -Scope It
         }
@@ -193,7 +193,7 @@ Describe 'Save-SqlDscSqlServerMediaFile' -Tag 'Public' {
             Mock -CommandName Invoke-WebRequest
             Mock -CommandName Start-Process
 
-            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.exe' -DestinationPath 'C:\Temp' -Language 'fr-FR'  -Confirm:$false
+            Save-SqlDscSqlServerMediaFile -Url 'https://example.com/media.exe' -DestinationPath $TestDrive -Language 'fr-FR'  -Confirm:$false
 
             Should -Invoke -CommandName Invoke-WebRequest -Times 1 -Exactly
             Should -Invoke -CommandName Start-Process -Times 1 -Exactly


### PR DESCRIPTION

#### Pull Request (PR) description
- Private function:
  - `Invoke-ReportServerSetupAction`
- `Save-SqlDscSqlServerMediaFile`
  - Fix unit tests so the work cross-platform.
- `Install-SqlDscServer` and private function `Invoke-SetupAction`
  - Fix localization string keys naming.
  - Fix unit tests to use correct localization string names.
 
#### This Pull Request (PR) fixes the following issues
Ground work fo issue #2010.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2066)
<!-- Reviewable:end -->
