### PR TITLE
Remove `Get-RegistryPropertyValue` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- SqlServerDsc.Common
+  - Removed the function `Get-RegistryPropertyValue` in favor of the command
+    with the same name in the module _DscResource.Common_.
+
 ### Added
 
 - Public commands:

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
@@ -21,7 +21,6 @@
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
-        'Get-RegistryPropertyValue'
         'Format-Path'
         'Copy-ItemWithRobocopy'
         'Invoke-InstallationMediaCopy'

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -6,53 +6,6 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
 <#
     .SYNOPSIS
-        Returns the value of the provided Name parameter at the registry
-        location provided in the Path parameter.
-
-    .PARAMETER Path
-        Specifies the path in the registry to the property name.
-
-    .PARAMETER PropertyName
-        Specifies the the name of the property to return the value for.
-#>
-function Get-RegistryPropertyValue
-{
-    [CmdletBinding()]
-    [OutputType([System.String])]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $Path,
-
-        [Parameter(Mandatory = $true)]
-        [System.String]
-        $Name
-    )
-
-    $getItemPropertyParameters = @{
-        Path = $Path
-        Name = $Name
-    }
-
-    <#
-        Using a try/catch block instead of 'SilentlyContinue' to be
-        able to unit test a failing registry path.
-    #>
-    try
-    {
-        $getItemPropertyResult = (Get-ItemProperty @getItemPropertyParameters -ErrorAction 'Stop').$Name
-    }
-    catch
-    {
-        $getItemPropertyResult = $null
-    }
-
-    return $getItemPropertyResult
-}
-
-<#
-    .SYNOPSIS
         Returns the value of the provided in the Name parameter, at the registry
         location provided in the Path parameter.
 

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -83,68 +83,6 @@ AfterAll {
     Get-Module -Name 'CommonTestHelper' -All | Remove-Module -Force
 }
 
-Describe 'SqlServerDsc.Common\Get-RegistryPropertyValue' -Tag 'GetRegistryPropertyValue' {
-    BeforeAll {
-        $mockWrongRegistryPath = 'HKLM:\SOFTWARE\AnyPath'
-        $mockPropertyName = 'InstanceName'
-        $mockPropertyValue = 'AnyValue'
-    }
-
-    Context 'When there are no property in the registry' {
-        BeforeAll {
-            Mock -CommandName Get-ItemProperty -MockWith {
-                return @{
-                    'UnknownProperty' = $mockPropertyValue
-                }
-            }
-        }
-
-        It 'Should return $null' {
-            $result = Get-RegistryPropertyValue -Path $mockWrongRegistryPath -Name $mockPropertyName
-            $result | Should -BeNullOrEmpty
-
-            Should -Invoke -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It -Module $script:subModuleName
-        }
-    }
-
-    Context 'When the call to Get-ItemProperty throws an error (i.e. when the path does not exist)' {
-        BeforeAll {
-            Mock -CommandName Get-ItemProperty -MockWith {
-                throw 'mocked error'
-            }
-        }
-
-        It 'Should not throw an error, but return $null' {
-            $result = Get-RegistryPropertyValue -Path $mockWrongRegistryPath -Name $mockPropertyName
-            $result | Should -BeNullOrEmpty
-
-            Should -Invoke -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It
-        }
-    }
-
-    Context 'When there are a property in the registry' {
-        BeforeAll {
-            $mockCorrectRegistryPath = 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\RS'
-
-            Mock -CommandName Get-ItemProperty -MockWith {
-                return @{
-                    $mockPropertyName = $mockPropertyValue
-                }
-            } -ParameterFilter {
-                $Path -eq $mockCorrectRegistryPath `
-                -and $Name -eq $mockPropertyName
-            }
-        }
-
-        It 'Should return the correct value' {
-            $result = Get-RegistryPropertyValue -Path $mockCorrectRegistryPath -Name $mockPropertyName
-            $result | Should -Be $mockPropertyValue
-
-            Should -Invoke -CommandName Get-ItemProperty -Exactly -Times 1 -Scope It
-        }
-    }
-}
-
 Describe 'SqlServerDsc.Common\Format-Path' -Tag 'FormatPath' {
     BeforeAll {
         $mockCorrectPath = 'C:\Correct\Path'


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc.Common
  - Removed the function `Get-RegistryPropertyValue` in favor of the command
    with the same name in the module _DscResource.Common_.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2076)
<!-- Reviewable:end -->
