### PR TITLE
SqlServerDsc: Remove `Test-PendingRestart` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Revert workaround in GitHub Actions workflows as new version of ModuleBuilder
     was released.
 - SqlServerDsc.Common
-  - Removed the function `Get-RegistryPropertyValue` and `Format-Path` in
-    favor of the commands with the same names in the module _DscResource.Common_.
+  - Removed the function `Get-RegistryPropertyValue`, `Format-Path` and
+    `Test-PendingRestart` in favor of the commands with the same names in
+    the module _DscResource.Common_.
 
 ### Added
 

--- a/source/DSCResources/DSC_SqlRSSetup/DSC_SqlRSSetup.psm1
+++ b/source/DSCResources/DSC_SqlRSSetup/DSC_SqlRSSetup.psm1
@@ -527,7 +527,7 @@ function Set-TargetResource
 
         Write-Verbose -Message $script:localizedData.SuppressRestart
     }
-    elseif (-not $SuppressRestart -and (Test-PendingRestart))
+    elseif (-not $SuppressRestart -and (Test-PendingRestart -Check 'PendingFileRename'))
     {
         $global:DSCMachineStatus = 1
     }

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -1707,7 +1707,7 @@ function Set-TargetResource
             Write-Verbose -Message $setupExitMessageSuccessful
         }
 
-        if ($ForceReboot -or (Test-PendingRestart))
+        if ($ForceReboot -or (Test-PendingRestart -Check 'PendingFileRename'))
         {
             if (-not ($SuppressReboot))
             {

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psd1
@@ -26,7 +26,6 @@
         'Invoke-InstallationMediaCopy'
         'Connect-UncPath'
         'Disconnect-UncPath'
-        'Test-PendingRestart'
         'Start-SqlSetupProcess'
         'Connect-SQL'
         'Connect-SQLAnalysis'

--- a/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
+++ b/source/Modules/SqlServerDsc.Common/SqlServerDsc.Common.psm1
@@ -251,31 +251,6 @@ function Disconnect-UncPath
 
 <#
     .SYNOPSIS
-        Queries the registry and returns $true if there is a pending reboot.
-
-    .OUTPUTS
-        Returns $true if there is a pending reboot, otherwise it returns $false.
-#>
-function Test-PendingRestart
-{
-    [CmdletBinding()]
-    [OutputType([System.Boolean])]
-    param ()
-
-    $getRegistryPropertyValueParameters = @{
-        Path = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'
-        Name = 'PendingFileRenameOperations'
-    }
-
-    <#
-        If the key 'PendingFileRenameOperations' does not exist then if should
-        return $false, otherwise it should return $true.
-    #>
-    return $null -ne (Get-RegistryPropertyValue @getRegistryPropertyValueParameters)
-}
-
-<#
-    .SYNOPSIS
         Starts the SQL setup process.
 
     .PARAMETER FilePath

--- a/tests/Unit/DSC_SqlRSSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlRSSetup.Tests.ps1
@@ -958,7 +958,7 @@ Describe "DSC_SqlRSSetup\Set-TargetResource" -Tag 'Set' {
                     Edition = 'Dev'
                 }
 
-                Mock -CommandName Test-PendingRestart
+                Mock -CommandName Test-PendingRestart -RemoveParameterType 'Check'
                 Mock -CommandName Start-SqlSetupProcess -MockWith {
                     Test-SetupArgument -Argument $ArgumentList -ExpectedArgument $mockStartSqlSetupProcess_ExpectedArgumentList
 
@@ -996,7 +996,7 @@ Describe "DSC_SqlRSSetup\Set-TargetResource" -Tag 'Set' {
 
                 Mock -CommandName Test-PendingRestart -MockWith {
                     return $true
-                }
+                } -RemoveParameterType 'Check'
 
                 Mock -CommandName Start-SqlSetupProcess -MockWith {
                     Test-SetupArgument -Argument $ArgumentList -ExpectedArgument $mockStartSqlSetupProcess_ExpectedArgumentList

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -2283,7 +2283,7 @@ Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {
 
         Mock -CommandName Test-PendingRestart -MockWith {
             return $false
-        }
+        } -RemoveParameterType 'Check'
 
         InModuleScope -ScriptBlock {
             # Mock PsDscRunAsCredential context.

--- a/tests/Unit/SqlServerDsc.Common.Tests.ps1
+++ b/tests/Unit/SqlServerDsc.Common.Tests.ps1
@@ -707,36 +707,6 @@ Describe 'SqlServerDsc.Common\Disconnect-UncPath' -Tag 'DisconnectUncPath' {
     }
 }
 
-Describe 'SqlServerDsc.Common\Test-PendingRestart' -Tag 'TestPendingRestart' {
-    Context 'When there is a pending reboot' {
-        BeforeAll {
-            Mock -CommandName Get-RegistryPropertyValue -MockWith {
-                return 'AnyValue'
-            }
-        }
-
-        It 'Should return $true' {
-            $testPendingRestartResult = Test-PendingRestart
-            $testPendingRestartResult | Should -BeTrue
-
-            Should -Invoke -CommandName Get-RegistryPropertyValue -Exactly -Times 1 -Scope It
-        }
-    }
-
-    Context 'When there are no pending reboot' {
-        BeforeAll {
-            Mock -CommandName Get-RegistryPropertyValue
-        }
-
-        It 'Should return $true' {
-            $testPendingRestartResult = Test-PendingRestart
-            $testPendingRestartResult | Should -BeFalse
-
-            Should -Invoke -CommandName Get-RegistryPropertyValue -Exactly -Times 1 -Scope It
-        }
-    }
-}
-
 Describe 'SqlServerDsc.Common\Start-SqlSetupProcess' -Tag 'StartSqlSetupProcess' {
     BeforeAll {
         $mockPowerShellExecutable = if ($IsLinux -or $IsMacOS)


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc.Common
  - Removed the function `Test-PendingRestart` in favor of the commands with the same names in
    the module _DscResource.Common_.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2098)
<!-- Reviewable:end -->
