### PR TITLE
SqlAGReplica: fix SeedingMode check in Test-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     that they always are higher than what we expect.
 - `SqlRS`
   - Re-enable integration tests.
+- `SqlAG`
+  - Fix SeedingMode existence condition.
+- `SqlAGReplica`
+  - Fix SeedingMode existence condition.
 
 ## [17.0.0] - 2024-09-30
 

--- a/source/DSCResources/DSC_SqlAG/DSC_SqlAG.psm1
+++ b/source/DSCResources/DSC_SqlAG/DSC_SqlAG.psm1
@@ -759,7 +759,7 @@ function Test-TargetResource
                 $parametersToCheck += 'BasicAvailabilityGroup'
                 $parametersToCheck += 'DatabaseHealthTrigger'
                 $parametersToCheck += 'DtcSupportEnabled'
-                if ( $getTargetResourceResult.SeedingMode )
+                if ( $null -ne $getTargetResourceResult.SeedingMode )
                 {
                     $parametersToCheck += 'SeedingMode'
                 }

--- a/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
+++ b/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
@@ -739,7 +739,7 @@ function Test-TargetResource
                 'ReadOnlyRoutingConnectionUrl',
                 'ReadOnlyRoutingList'
             )
-            if ( $getTargetResourceResult.SeedingMode)
+            if ( $null -ne $getTargetResourceResult.SeedingMode )
             {
                 $parametersToCheck += 'SeedingMode'
             }

--- a/tests/Unit/DSC_SqlAG.Tests.ps1
+++ b/tests/Unit/DSC_SqlAG.Tests.ps1
@@ -99,7 +99,7 @@ Describe 'SqlAG\Get-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -111,7 +111,7 @@ Describe 'SqlAG\Get-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -123,7 +123,7 @@ Describe 'SqlAG\Get-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
@@ -188,7 +188,7 @@ Describe 'SqlAG\Get-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -200,7 +200,7 @@ Describe 'SqlAG\Get-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
@@ -369,7 +369,7 @@ Describe 'SqlAG\Set-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -381,7 +381,7 @@ Describe 'SqlAG\Set-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -393,7 +393,7 @@ Describe 'SqlAG\Set-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
@@ -446,7 +446,7 @@ Describe 'SqlAG\Set-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -458,7 +458,7 @@ Describe 'SqlAG\Set-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -470,7 +470,7 @@ Describe 'SqlAG\Set-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
@@ -693,7 +693,7 @@ Describe 'SqlAG\Set-TargetResource' {
             $mockReplicaObject.EndpointUrl = 'TCP://Server1:5022'
             $mockReplicaObject.FailoverMode = 'Manual'
             $mockReplicaObject.Name = 'Server1'
-            $mockReplicaObject.SeedingMode = 'Manual'
+            $mockReplicaObject.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             Mock -CommandName New-SqlAvailabilityReplica -MockWith {
                 return $mockReplicaObject
@@ -1215,7 +1215,7 @@ Describe 'SqlAG\Test-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -1227,7 +1227,7 @@ Describe 'SqlAG\Test-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -1239,7 +1239,7 @@ Describe 'SqlAG\Test-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
@@ -1303,7 +1303,7 @@ Describe 'SqlAG\Test-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -1315,7 +1315,7 @@ Describe 'SqlAG\Test-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup

--- a/tests/Unit/DSC_SqlAGReplica.Tests.ps1
+++ b/tests/Unit/DSC_SqlAGReplica.Tests.ps1
@@ -99,7 +99,7 @@ Describe 'SqlAGReplica\Get-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -111,7 +111,7 @@ Describe 'SqlAGReplica\Get-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -123,7 +123,7 @@ Describe 'SqlAGReplica\Get-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
@@ -214,7 +214,7 @@ Describe 'SqlAGReplica\Get-TargetResource' {
                 $getTargetResourceResult.ServerName | Should -Be 'Server1'
                 $getTargetResourceResult.InstanceName | Should -Be 'MSSQLSERVER'
                 $getTargetResourceResult.EndpointHostName | Should -Be 'Server1'
-                $getTargetResourceResult.SeedingMode | Should -Be 'Manual'
+                $getTargetResourceResult.SeedingMode | Should -Be ([Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual)
             }
 
             Should -Invoke -CommandName Connect-SQL -Exactly -Times 1 -Scope It
@@ -246,7 +246,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -258,7 +258,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -270,7 +270,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             # Mock the availability groups
             $mockAvailabilityGroup1 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityGroup
@@ -317,7 +317,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -329,7 +329,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -341,7 +341,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
             #endregion Mock the availability group replicas
 
             # Mock the availability groups
@@ -405,7 +405,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica1.Name = 'Server1'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingConnectionUrl = 'TCP://Server1.domain.com:1433'
             $mockAvailabilityGroupReplica1.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica1.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica1.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica2 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica2.AvailabilityMode = 'AsynchronousCommit'
@@ -417,7 +417,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica2.Name = 'Server2'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingConnectionUrl = 'TCP://Server2.domain.com:1433'
             $mockAvailabilityGroupReplica2.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica2.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica2.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
 
             $mockAvailabilityGroupReplica3 = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AvailabilityReplica
             $mockAvailabilityGroupReplica3.AvailabilityMode = 'AsynchronousCommit'
@@ -429,7 +429,7 @@ Describe 'SqlAGReplica\Set-TargetResource' {
             $mockAvailabilityGroupReplica3.Name = 'Server3'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingConnectionUrl = 'TCP://Server3.domain.com:1433'
             $mockAvailabilityGroupReplica3.ReadOnlyRoutingList = @('Server1', 'Server2')
-            $mockAvailabilityGroupReplica3.SeedingMode = 'Manual'
+            $mockAvailabilityGroupReplica3.SeedingMode = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Manual
             #endregion Mock the availability group replicas
 
             # Mock the availability groups
@@ -1645,7 +1645,7 @@ Describe 'SqlAGReplica\Test-TargetResource' {
             }
             @{
                 MockPropertyName  = 'SeedingMode'
-                MockPropertyValue = 'Automatic'
+                MockPropertyValue = 'Manual'
             }
         ) {
             BeforeAll {
@@ -1666,7 +1666,7 @@ Describe 'SqlAGReplica\Test-TargetResource' {
                         FailoverMode                  = 'Manual'
                         ReadOnlyRoutingConnectionUrl  = 'TCP://Server1.domain.com:1433'
                         ReadOnlyRoutingList           = @('Server1', 'Server2')
-                        SeedingMode                   = 'Manual'
+                        SeedingMode                   = [Microsoft.SqlServer.Management.Smo.AvailabilityReplicaSeedingMode]::Automatic
 
                         # Read properties
                         EndpointPort                  = '5022'


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description

- `SqlAG`
  - Fix SeedingMode existence condition as AvailabilityReplicaSeedingMode is an enum.
- `SqlAGReplica`
  - Fix SeedingMode existence condition as AvailabilityReplicaSeedingMode is an enum.
 
#### This Pull Request (PR) fixes the following issues
None
#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
