### PR TITLE
`Get-SqlDscServerPermission`: Check for both login and role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,18 +36,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed environment variable persistence by using $GITHUB_ENV instead of
     job-level env declaration.
 - `Grant-SqlDscServerPermission`
-  - Added new public command to grant server permissions to a principal (Login or ServerRole) on a SQL Server Database Engine instance.
+  - Added new public command to grant server permissions to a principal
+    (Login or ServerRole) on a SQL Server Database Engine instance.
 - `Deny-SqlDscServerPermission`
-  - Added new public command to deny server permissions to a principal (Login or ServerRole).
+  - Added new public command to deny server permissions to a principal
+    (Login or ServerRole).
 - `Revoke-SqlDscServerPermission`
-  - Added new public command to revoke server permissions from a principal (Login or ServerRole).
+  - Added new public command to revoke server permissions from a principal
+    (Login or ServerRole).
 - `Test-SqlDscServerPermission`
-  - Added new public command with Grant/Deny parameter sets (and `-WithGrant`) to test server permissions for a principal.
+  - Added new public command with Grant/Deny parameter sets (and `-WithGrant`)
+    to test server permissions for a principal.
 - `Assert-SqlDscLogin`
   - Added new public command to validate that a specified SQL Server principal
     is a login.
 - `Enable-SqlDscLogin`
   - Added new public command to enable a SQL Server login.
+- `Get-SqlDscServerPermission`
+  - Enhanced command to support pipeline input for Login and ServerRole
+    objects while maintaining backward compatibility with the original
+    parameter set.
 - `Disable-SqlDscLogin`
   - Added new public command to disable a SQL Server login.
 - `Test-SqlDscIsLoginEnabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added documentation for `SqlIntegrationTest` user and
     `IntegrationTestSqlLogin` login.
   - Added run order information for `New-SqlDscLogin` integration test.
+- `Get-SqlDscServerPermission`
+  - Enhanced the command to support server roles in addition to logins by utilizing
+    `Test-SqlDscIsRole` alongside the existing `Test-SqlDscIsLogin` check.
+  - The function now accepts both login principals and server role principals
+    as the `Name` parameter.
 - `azure-pipelines.yml`
   - Remove `windows-2019` images fixes [#2106](https://github.com/dsccommunity/SqlServerDsc/issues/2106).
   - Move individual tasks to `windows-latest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced the command to support server roles in addition to logins by
     utilizing `Test-SqlDscIsRole` alongside the existing `Test-SqlDscIsLogin`
     check.
-  - The function now accepts both login principals and server role principals
+  - The command now accepts both login principals and server role principals
     as the `Name` parameter (issue [#2063](https://github.com/dsccommunity/SqlServerDsc/issues/2063)).
 - `azure-pipelines.yml`
   - Remove `windows-2019` images fixes [#2106](https://github.com/dsccommunity/SqlServerDsc/issues/2106).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `IntegrationTestSqlLogin` login.
   - Added run order information for `New-SqlDscLogin` integration test.
 - `Get-SqlDscServerPermission`
-  - Enhanced the command to support server roles in addition to logins by utilizing
-    `Test-SqlDscIsRole` alongside the existing `Test-SqlDscIsLogin` check.
+  - Enhanced the command to support server roles in addition to logins by
+    utilizing `Test-SqlDscIsRole` alongside the existing `Test-SqlDscIsLogin`
+    check.
   - The function now accepts both login principals and server role principals
     as the `Name` parameter (issue [#2063](https://github.com/dsccommunity/SqlServerDsc/issues/2063)).
 - `azure-pipelines.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced the command to support server roles in addition to logins by utilizing
     `Test-SqlDscIsRole` alongside the existing `Test-SqlDscIsLogin` check.
   - The function now accepts both login principals and server role principals
-    as the `Name` parameter.
+    as the `Name` parameter (issue [#2063](https://github.com/dsccommunity/SqlServerDsc/issues/2063)).
 - `azure-pipelines.yml`
   - Remove `windows-2019` images fixes [#2106](https://github.com/dsccommunity/SqlServerDsc/issues/2106).
   - Move individual tasks to `windows-latest`.

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -28,7 +28,7 @@
     Sampler                        = 'latest'
     'Sampler.GitHubTasks'          = 'latest'
     MarkdownLinkCheck              = 'latest'
-    'DscResource.Test'             = 'latest'
+    'DscResource.Test'             = '0.17.2'
     xDscResourceDesigner           = 'latest'
 
     # Build dependencies needed for using the module

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -303,7 +303,6 @@ stages:
                   'tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1'
-                  'tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Get-SqlDscDatabase.Integration.Tests.ps1'
                   'tests/Integration/Commands/New-SqlDscDatabase.Integration.Tests.ps1'
                   'tests/Integration/Commands/Set-SqlDscDatabase.Integration.Tests.ps1'
@@ -315,6 +314,7 @@ stages:
                   # Group 8
                   'tests/Integration/Commands/Remove-SqlDscAgentAlert.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscDatabase.Integration.Tests.ps1'
+                  'tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscRole.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1'
                   # Group 9

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -303,6 +303,7 @@ stages:
                   'tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1'
+                  'tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Get-SqlDscDatabase.Integration.Tests.ps1'
                   'tests/Integration/Commands/New-SqlDscDatabase.Integration.Tests.ps1'
                   'tests/Integration/Commands/Set-SqlDscDatabase.Integration.Tests.ps1'
@@ -314,7 +315,6 @@ stages:
                   # Group 8
                   'tests/Integration/Commands/Remove-SqlDscAgentAlert.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscDatabase.Integration.Tests.ps1'
-                  'tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscRole.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1'
                   # Group 9

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -317,7 +317,6 @@ stages:
                   'tests/Integration/Commands/Remove-SqlDscDatabase.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscRole.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1'
-
                   # Group 9
                   'tests/Integration/Commands/Uninstall-SqlDscServer.Integration.Tests.ps1'
               )

--- a/source/Public/Deny-SqlDscServerPermission.ps1
+++ b/source/Public/Deny-SqlDscServerPermission.ps1
@@ -118,11 +118,13 @@ function Deny-SqlDscServerPermission
             }
             catch
             {
-                $errorMessage = $script:localizedData.ServerPermission_Deny_FailedToDenyPermission -f $principalName, $serverObject.InstanceName
+                $errorMessage = $script:localizedData.ServerPermission_Deny_FailedToDenyPermission -f $principalName, $serverObject.InstanceName, ($Permission -join ',')
+
+                $exception = [System.InvalidOperationException]::new($errorMessage, $_.Exception)
 
                 $PSCmdlet.ThrowTerminatingError(
                     [System.Management.Automation.ErrorRecord]::new(
-                        $errorMessage,
+                        $exception,
                         'DSDSP0001', # cSpell: disable-line
                         [System.Management.Automation.ErrorCategory]::InvalidOperation,
                         $principalName

--- a/source/Public/Deny-SqlDscServerPermission.ps1
+++ b/source/Public/Deny-SqlDscServerPermission.ps1
@@ -104,14 +104,6 @@ function Deny-SqlDscServerPermission
                 $permissionSet.$permissionName = $true
             }
 
-            # Get the permissions names that are set to $true in the ServerPermissionSet.
-            $permissionName = $permissionSet |
-                Get-Member -MemberType 'Property' |
-                Select-Object -ExpandProperty 'Name' |
-                Where-Object -FilterScript {
-                    $permissionSet.$_
-                }
-
             try
             {
                 $serverObject.Deny($permissionSet, $principalName)

--- a/source/Public/Get-SqlDscServerPermission.ps1
+++ b/source/Public/Get-SqlDscServerPermission.ps1
@@ -105,7 +105,7 @@ function Get-SqlDscServerPermission
             $false
         }
 
-        $isRole = if ($checkRole -and -not $isLogin)
+        $isRole = if ($checkRole)
         {
             Test-SqlDscIsRole @testSqlDscIsPrincipalParameters
         }

--- a/source/Public/Get-SqlDscServerPermission.ps1
+++ b/source/Public/Get-SqlDscServerPermission.ps1
@@ -50,14 +50,15 @@ function Get-SqlDscServerPermission
     {
         $getSqlDscServerPermissionResult = $null
 
-        $testSqlDscIsLoginParameters = @{
+        $testSqlDscIsPrincipalParameters = @{
             ServerObject = $ServerObject
             Name         = $Name
         }
 
-        $isLogin = Test-SqlDscIsLogin @testSqlDscIsLoginParameters
+        $isLogin = Test-SqlDscIsLogin @testSqlDscIsPrincipalParameters
+        $isRole = Test-SqlDscIsRole @testSqlDscIsPrincipalParameters
 
-        if ($isLogin)
+        if ($isLogin -or $isRole)
         {
             $getSqlDscServerPermissionResult = $ServerObject.EnumServerPermissions($Name)
         }

--- a/source/Public/Get-SqlDscServerPermission.ps1
+++ b/source/Public/Get-SqlDscServerPermission.ps1
@@ -7,17 +7,32 @@
         The command can retrieve permissions for both user-defined and built-in
         server principals including SQL Server logins and server roles.
 
+        The command supports two modes of operation:
+        1. By name: Specify ServerObject, Name, and optionally PrincipalType
+        2. By object: Pass Login or ServerRole objects via pipeline
+
     .PARAMETER ServerObject
-        Specifies current server connection object.
+        Specifies current server connection object. This parameter is used in the
+        default parameter set for backward compatibility.
 
     .PARAMETER Name
         Specifies the name of the SQL Server login or server role for which
-        the permissions are returned.
+        the permissions are returned. This parameter is used in the default
+        parameter set for backward compatibility.
 
     .PARAMETER PrincipalType
         Specifies the type(s) of principal to check. Valid values are 'Login'
         and 'Role'. If not specified, both login and role checks will be performed.
-        If specified, only the specified type(s) will be checked.
+        If specified, only the specified type(s) will be checked. This parameter
+        is used in the default parameter set for backward compatibility.
+
+    .PARAMETER Login
+        Specifies the Login object for which the permissions are returned.
+        This parameter accepts pipeline input.
+
+    .PARAMETER ServerRole
+        Specifies the ServerRole object for which the permissions are returned.
+        This parameter accepts pipeline input.
 
     .OUTPUTS
         [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]]
@@ -46,33 +61,67 @@
 
         Get the permissions for the server role 'MyRole', only checking if it exists as a role.
 
+    .EXAMPLE
+        $serverInstance = Connect-SqlDscDatabaseEngine
+        $login = $serverInstance | Get-SqlDscLogin -Name 'MyLogin'
+
+        Get-SqlDscServerPermission -Login $login
+
+        Get the permissions for the login 'MyLogin' using a Login object.
+
+    .EXAMPLE
+        $serverInstance = Connect-SqlDscDatabaseEngine
+        $role = $serverInstance | Get-SqlDscRole -Name 'MyRole'
+
+        $role | Get-SqlDscServerPermission
+
+        Get the permissions for the server role 'MyRole' using a ServerRole object from the pipeline.
+
+    .EXAMPLE
+        $serverInstance = Connect-SqlDscDatabaseEngine
+
+        $serverInstance | Get-SqlDscLogin | Get-SqlDscServerPermission
+
+        Get the permissions for all logins from the pipeline.
+
     .NOTES
         If specifying `-ErrorAction 'SilentlyContinue'` then the command will silently
         ignore if the principal (parameter **Name**) is not present. In such case the
         command will return `$null`. If specifying `-ErrorAction 'Stop'` the command
         will throw an error if the principal is missing.
+
+        The Login or ServerRole object must come from the same SQL Server instance
+        where the permissions will be retrieved.
 #>
 function Get-SqlDscServerPermission
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('AvoidThrowOutsideOfTry', '', Justification = 'Because the code throws based on an prior expression')]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ByName')]
     [OutputType([Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]])]
     param
     (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'ByName')]
         [Microsoft.SqlServer.Management.Smo.Server]
         $ServerObject,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName')]
         [System.String]
         $Name,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ByName')]
         [ValidateSet('Login', 'Role')]
         [System.String[]]
-        $PrincipalType
+        $PrincipalType,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'Login')]
+        [Microsoft.SqlServer.Management.Smo.Login]
+        $Login,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'ServerRole')]
+        [Microsoft.SqlServer.Management.Smo.ServerRole]
+        $ServerRole
     )
 
     # cSpell: ignore GSDSP
@@ -80,49 +129,71 @@ function Get-SqlDscServerPermission
     {
         $getSqlDscServerPermissionResult = $null
 
-        $testSqlDscIsPrincipalParameters = @{
-            ServerObject = $ServerObject
-            Name         = $Name
-        }
-
-        # Determine which checks to perform based on PrincipalType parameter
-        $checkLogin = $true
-        $checkRole = $true
-
-        if ($PSBoundParameters.ContainsKey('PrincipalType'))
+        # Determine which parameter set we're using and set up variables accordingly
+        if ($PSCmdlet.ParameterSetName -eq 'Login')
         {
-            $checkLogin = $PrincipalType -contains 'Login'
-            $checkRole = $PrincipalType -contains 'Role'
+            $principalName = $Login.Name
+            $serverObject = $Login.Parent
+            $isLogin = $true
+            $isRole = $false
         }
-
-        # Perform the appropriate checks
-        $isLogin = if ($checkLogin)
+        elseif ($PSCmdlet.ParameterSetName -eq 'ServerRole')
         {
-            Test-SqlDscIsLogin @testSqlDscIsPrincipalParameters
+            $principalName = $ServerRole.Name
+            $serverObject = $ServerRole.Parent
+            $isLogin = $false
+            $isRole = $true
         }
         else
         {
-            $false
-        }
+            # ByName parameter set (default for backward compatibility)
+            $principalName = $Name
+            $serverObject = $ServerObject
 
-        $isRole = if ($checkRole)
-        {
-            Test-SqlDscIsRole @testSqlDscIsPrincipalParameters
-        }
-        else
-        {
-            $false
+            $testSqlDscIsPrincipalParameters = @{
+                ServerObject = $serverObject
+                Name         = $principalName
+            }
+
+            # Determine which checks to perform based on PrincipalType parameter
+            $checkLogin = $true
+            $checkRole = $true
+
+            if ($PSBoundParameters.ContainsKey('PrincipalType'))
+            {
+                $checkLogin = $PrincipalType -contains 'Login'
+                $checkRole = $PrincipalType -contains 'Role'
+            }
+
+            # Perform the appropriate checks
+            $isLogin = if ($checkLogin)
+            {
+                Test-SqlDscIsLogin @testSqlDscIsPrincipalParameters
+            }
+            else
+            {
+                $false
+            }
+
+            $isRole = if ($checkRole)
+            {
+                Test-SqlDscIsRole @testSqlDscIsPrincipalParameters
+            }
+            else
+            {
+                $false
+            }
         }
 
         if ($isLogin -or $isRole)
         {
-            $getSqlDscServerPermissionResult = $ServerObject.EnumServerPermissions($Name)
+            $getSqlDscServerPermissionResult = $serverObject.EnumServerPermissions($principalName)
         }
         else
         {
-            $missingPrincipalMessage = $script:localizedData.ServerPermission_MissingPrincipal -f $Name, $ServerObject.InstanceName
+            $missingPrincipalMessage = $script:localizedData.ServerPermission_MissingPrincipal -f $principalName, $serverObject.InstanceName
 
-            Write-Error -Message $missingPrincipalMessage -Category 'InvalidOperation' -ErrorId 'GSDSP0001' -TargetObject $Name
+            Write-Error -Message $missingPrincipalMessage -Category 'InvalidOperation' -ErrorId 'GSDSP0001' -TargetObject $principalName
         }
 
         return , [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]] $getSqlDscServerPermissionResult

--- a/source/Public/Get-SqlDscServerPermission.ps1
+++ b/source/Public/Get-SqlDscServerPermission.ps1
@@ -1,16 +1,18 @@
 <#
     .SYNOPSIS
-        Returns the current permissions for the principal.
+        Returns the current permissions for a SQL Server login or server role.
 
     .DESCRIPTION
-        Returns the current permissions for the principal.
+        Returns the current permissions for a SQL Server login or server role.
+        The command can retrieve permissions for both user-defined and built-in
+        server principals including SQL Server logins and server roles.
 
     .PARAMETER ServerObject
         Specifies current server connection object.
 
     .PARAMETER Name
-        Specifies the name of the principal for which the permissions are
-        returned.
+        Specifies the name of the SQL Server login or server role for which
+        the permissions are returned.
 
     .OUTPUTS
         [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]]
@@ -20,6 +22,12 @@
         Get-SqlDscServerPermission -ServerObject $serverInstance -Name 'MyPrincipal'
 
         Get the permissions for the principal 'MyPrincipal'.
+
+    .EXAMPLE
+        $serverInstance = Connect-SqlDscDatabaseEngine
+        Get-SqlDscServerPermission -ServerObject $serverInstance -Name 'sysadmin'
+
+        Get the permissions for the server role 'sysadmin'.
 
     .NOTES
         If specifying `-ErrorAction 'SilentlyContinue'` then the command will silently

--- a/source/Public/Grant-SqlDscServerPermission.ps1
+++ b/source/Public/Grant-SqlDscServerPermission.ps1
@@ -140,11 +140,13 @@ function Grant-SqlDscServerPermission
             }
             catch
             {
-                $errorMessage = $script:localizedData.ServerPermission_Grant_FailedToGrantPermission -f $principalName, $serverObject.InstanceName
+                $errorMessage = $script:localizedData.ServerPermission_Grant_FailedToGrantPermission -f $principalName, $serverObject.InstanceName, ($Permission -join ', ')
+
+                $exception = [System.InvalidOperationException]::new($errorMessage, $_.Exception)
 
                 $PSCmdlet.ThrowTerminatingError(
                     [System.Management.Automation.ErrorRecord]::new(
-                        $errorMessage,
+                        $exception,
                         'GSDSP0001', # cSpell: disable-line
                         [System.Management.Automation.ErrorCategory]::InvalidOperation,
                         $principalName

--- a/source/Public/Grant-SqlDscServerPermission.ps1
+++ b/source/Public/Grant-SqlDscServerPermission.ps1
@@ -119,14 +119,6 @@ function Grant-SqlDscServerPermission
                 $permissionSet.$permissionName = $true
             }
 
-            # Get the permissions names that are set to $true in the ServerPermissionSet.
-            $permissionName = $permissionSet |
-                Get-Member -MemberType 'Property' |
-                Select-Object -ExpandProperty 'Name' |
-                Where-Object -FilterScript {
-                    $permissionSet.$_
-                }
-
             try
             {
                 if ($WithGrant.IsPresent)

--- a/source/Public/Revoke-SqlDscServerPermission.ps1
+++ b/source/Public/Revoke-SqlDscServerPermission.ps1
@@ -138,11 +138,13 @@ function Revoke-SqlDscServerPermission
             }
             catch
             {
-                $errorMessage = $script:localizedData.ServerPermission_Revoke_FailedToRevokePermission -f $principalName, $serverObject.InstanceName
+                $errorMessage = $script:localizedData.ServerPermission_Revoke_FailedToRevokePermission -f $principalName, $serverObject.InstanceName, ($Permission -join ',')
+
+                $exception = [System.InvalidOperationException]::new($errorMessage, $_.Exception)
 
                 $PSCmdlet.ThrowTerminatingError(
                     [System.Management.Automation.ErrorRecord]::new(
-                        $errorMessage,
+                        $exception,
                         'RSDSP0001', # cSpell: disable-line
                         [System.Management.Automation.ErrorCategory]::InvalidOperation,
                         $principalName

--- a/source/Public/Revoke-SqlDscServerPermission.ps1
+++ b/source/Public/Revoke-SqlDscServerPermission.ps1
@@ -117,14 +117,6 @@ function Revoke-SqlDscServerPermission
                 $permissionSet.$permissionName = $true
             }
 
-            # Get the permissions names that are set to $true in the ServerPermissionSet.
-            $permissionName = $permissionSet |
-                Get-Member -MemberType 'Property' |
-                Select-Object -ExpandProperty 'Name' |
-                Where-Object -FilterScript {
-                    $permissionSet.$_
-                }
-
             try
             {
                 if ($WithGrant.IsPresent)

--- a/source/Public/Test-SqlDscIsRole.ps1
+++ b/source/Public/Test-SqlDscIsRole.ps1
@@ -1,15 +1,15 @@
 <#
     .SYNOPSIS
-        Returns whether the database principal exists and is a database role.
+        Returns whether the server principal exists and is a server role.
 
     .DESCRIPTION
-        Returns whether the database principal exist and is a database role.
+        Returns whether the server principal exist and is a server role.
 
     .PARAMETER ServerObject
         Specifies current server connection object.
 
     .PARAMETER Name
-        Specifies the name of the database principal.
+        Specifies the name of the server principal.
 
     .OUTPUTS
         [System.Boolean]
@@ -18,7 +18,7 @@
         $serverInstance = Connect-SqlDscDatabaseEngine
         Test-SqlDscIsRole -ServerObject $serverInstance -Name 'MyPrincipal'
 
-        Returns $true if the principal exist as role, if not $false is returned.
+        Returns $true if the principal exist as a server role, if not $false is returned.
 #>
 function Test-SqlDscIsRole
 {

--- a/source/Public/Test-SqlDscServerPermission.ps1
+++ b/source/Public/Test-SqlDscServerPermission.ps1
@@ -173,8 +173,7 @@ function Test-SqlDscServerPermission
 
             if (-not $serverPermissionInfo)
             {
-                # TODO: Make this a debug message
-                Write-Verbose -Message (
+                Write-Debug -Message (
                     $script:localizedData.ServerPermission_Test_NoPermissionsFound -f $principalName
                 )
 
@@ -194,8 +193,8 @@ function Test-SqlDscServerPermission
 
             # Output verbose information about current permissions as compressed JSON
             $currentPermissionsJson = $currentPermissions | ConvertTo-Json -Compress
-            # TODO: Make this a debug message
-            Write-Verbose -Message (
+
+            Write-Debug -Message (
                 $script:localizedData.ServerPermission_Test_CurrentPermissions -f $principalName, $currentPermissionsJson
             )
 

--- a/source/Public/Test-SqlDscServerPermission.ps1
+++ b/source/Public/Test-SqlDscServerPermission.ps1
@@ -173,6 +173,11 @@ function Test-SqlDscServerPermission
 
             if (-not $serverPermissionInfo)
             {
+                # TODO: Make this a debug message
+                Write-Verbose -Message (
+                    $script:localizedData.ServerPermission_Test_NoPermissionsFound -f $principalName
+                )
+
                 # If no permissions exist and none are desired, that's the desired state
                 if ($Permission.Count -eq 0)
                 {
@@ -186,6 +191,13 @@ function Test-SqlDscServerPermission
 
             # Convert current permissions to ServerPermission objects
             $currentPermissions = $serverPermissionInfo | ConvertTo-SqlDscServerPermission
+
+            # Output verbose information about current permissions as compressed JSON
+            $currentPermissionsJson = $currentPermissions | ConvertTo-Json -Compress
+            # TODO: Make this a debug message
+            Write-Verbose -Message (
+                $script:localizedData.ServerPermission_Test_CurrentPermissions -f $principalName, $currentPermissionsJson
+            )
 
             # Handle empty Permission collection - check that no permissions are set
             if ($Permission.Count -eq 0)

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -60,7 +60,7 @@ ConvertFrom-StringData @'
     ServerPermission_Revoke_ShouldProcessVerboseWarning = Are you sure you want to revoke server permissions for the principal '{0}'?
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
     ServerPermission_Revoke_ShouldProcessCaption = Revoke server permissions
-    ServerPermission_Revoke_FailedToRevokePermission = Failed to revoke server permissions for principal '{0}' on instance '{1}'.
+    ServerPermission_Revoke_FailedToRevokePermission = Failed to revoke server permissions '{2}' for principal '{0}' on instance '{1}'.
 
     ## Class DatabasePermission
     InvalidTypeForCompare = Invalid type in comparison. Expected type [{0}], but the type was [{1}]. (DP0001)

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -42,14 +42,14 @@ ConvertFrom-StringData @'
     ServerPermission_Grant_ShouldProcessVerboseWarning = Are you sure you want to grant server permissions for the principal '{0}'?
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
     ServerPermission_Grant_ShouldProcessCaption = Grant server permissions
-    ServerPermission_Grant_FailedToGrantPermission = Failed to grant server permissions for principal '{0}' on instance '{1}'.
+    ServerPermission_Grant_FailedToGrantPermission = Failed to grant server permissions '{2}' for principal '{0}' on instance '{1}'.
 
     ## Deny-SqlDscServerPermission
     ServerPermission_Deny_ShouldProcessVerboseDescription = Denying server permissions '{2}' for the principal '{0}' on the instance '{1}'.
     ServerPermission_Deny_ShouldProcessVerboseWarning = Are you sure you want to deny server permissions for the principal '{0}'?
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
     ServerPermission_Deny_ShouldProcessCaption = Deny server permissions
-    ServerPermission_Deny_FailedToDenyPermission = Failed to deny server permissions for principal '{0}' on instance '{1}'.
+    ServerPermission_Deny_FailedToDenyPermission = Failed to deny server permissions '{2}' for principal '{0}' on instance '{1}'.
 
     ## Test-SqlDscServerPermission
     ServerPermission_TestingDesiredState = Testing desired state for server permissions for principal '{0}' on instance '{1}'.

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -54,6 +54,8 @@ ConvertFrom-StringData @'
     ## Test-SqlDscServerPermission
     ServerPermission_TestingDesiredState = Testing desired state for server permissions for principal '{0}' on instance '{1}'.
     ServerPermission_Test_TestFailed = Failed to test server permissions for principal '{0}': {1}
+    ServerPermission_Test_CurrentPermissions = Current server permissions for principal '{0}': {1}
+    ServerPermission_Test_NoPermissionsFound = No server permissions found for principal '{0}'.
 
     ## Revoke-SqlDscServerPermission
     ServerPermission_Revoke_ShouldProcessVerboseDescription = Revoking server permissions '{2}' for the principal '{0}' on the instance '{1}'.

--- a/tests/Integration/Commands/Assert-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Assert-SqlDscLogin.Integration.Tests.ps1
@@ -53,6 +53,10 @@ Describe 'Assert-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
             $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:instanceName -Credential $script:sqlAdminCredential
         }
 
+        AfterAll {
+            Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject
+        }
+
         Context 'When a login exists' {
             It 'Should not throw an error for sa login' {
                 { Assert-SqlDscLogin -ServerObject $script:serverObject -Name 'sa' } | Should -Not -Throw

--- a/tests/Integration/Commands/Assert-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Assert-SqlDscLogin.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Assert-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Assert-SqlDscLogin' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Connect-SqlDscDatabaseEngine.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Connect-SqlDscDatabaseEngine.Integration.Tests.ps1
@@ -23,8 +23,14 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 # cSpell: ignore DSCSQLTEST
-Describe 'Connect-SqlDscDatabaseEngine' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Connect-SqlDscDatabaseEngine' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose
 

--- a/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
@@ -75,7 +75,7 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $null = Deny-SqlDscServerPermission -Login $loginObject -Permission @('ViewAnyDatabase') -Force -ErrorAction 'Stop'
 
             # Then test if it's denied
-            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @([SqlServerPermission]::ViewAnyDatabase) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @('ViewAnyDatabase') -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -86,7 +86,7 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $null = $loginObject | Deny-SqlDscServerPermission -Permission @('ViewAnyDefinition') -Force -ErrorAction 'Stop'
 
             # Verify the permission was denied
-            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @([SqlServerPermission]::ViewAnyDefinition) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @('ViewAnyDefinition') -ErrorAction 'Stop'
             $result | Should -BeTrue
         }
     }
@@ -103,7 +103,7 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $null = Deny-SqlDscServerPermission -ServerRole $roleObject -Permission @('ViewServerState') -Force -ErrorAction 'Stop'
 
             # Verify the permission was denied
-            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Deny -Permission @([SqlServerPermission]::ViewServerState) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Deny -Permission @('ViewServerState') -ErrorAction 'Stop'
             $result | Should -BeTrue
         }
 
@@ -113,7 +113,7 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $null = Deny-SqlDscServerPermission -Login $loginObject -Permission @('AlterTrace') -Force -ErrorAction 'Stop'
 
             # Verify the permission was denied - this denial will remain persistent for other integration tests
-            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @([SqlServerPermission]::AlterTrace) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @('AlterTrace') -ErrorAction 'Stop'
             $result | Should -BeTrue
         }
     }

--- a/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
@@ -31,41 +31,28 @@ BeforeAll {
 
 Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
-        # Check if there is a CI database instance to use for testing
-        $script:sqlServerInstanceName = $env:SqlServerInstanceName
+        # Starting the named instance SQL Server service prior to running tests.
+        Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 
-        if (-not $script:sqlServerInstanceName)
-        {
-            $script:sqlServerInstanceName = 'DSCSQLTEST'
-        }
+        $script:mockInstanceName = 'DSCSQLTEST'
 
-        # Get a computer name that will work in the CI environment
-        $script:computerName = Get-ComputerName
+        $mockSqlAdministratorUserName = 'SqlAdmin' # Using computer name as NetBIOS name throw exception.
+        $mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
 
-        Write-Verbose -Message ('Integration tests will run using computer name ''{0}'' and instance name ''{1}''.' -f $script:computerName, $script:sqlServerInstanceName) -Verbose
+        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
 
-        $script:serverObject = Connect-SqlDscDatabaseEngine -ServerName $script:computerName -InstanceName $script:sqlServerInstanceName -Force
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
 
         # Use persistent test login and role created by earlier integration tests
         $script:testLoginName = 'IntegrationTestSqlLogin'
         $script:testRoleName = 'SqlDscIntegrationTestRole_Persistent'
-
-        # Verify the persistent principals exist (should be created by New-SqlDscLogin and New-SqlDscRole integration tests)
-        $existingLogin = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'SilentlyContinue'
-        if (-not $existingLogin)
-        {
-            throw ('Test login {0} does not exist. Please run New-SqlDscLogin integration tests first to create persistent test principals.' -f $script:testLoginName)
-        }
-
-        $existingRole = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'SilentlyContinue'
-        if (-not $existingRole)
-        {
-            throw ('Test role {0} does not exist. Please run New-SqlDscRole integration tests first to create persistent test principals.' -f $script:testRoleName)
-        }
     }
 
     AfterAll {
         Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject
+
+        # Stop the named instance SQL Server service to save memory on the build worker.
+        Stop-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
     }
 
     Context 'When denying server permissions to login' {

--- a/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
@@ -29,12 +29,7 @@ BeforeAll {
     Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:moduleName -All | Remove-Module -Force
-}
-
-Describe 'Deny-SqlDscServerPermission' -Tag 'IntegrationTest' {
+Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Check if there is a CI database instance to use for testing
         $script:sqlServerInstanceName = $env:SqlServerInstanceName

--- a/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
 
         $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
 
-        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential -ErrorAction 'Stop'
 
         # Use persistent test login and role created by earlier integration tests
         $script:testLoginName = 'IntegrationTestSqlLogin'

--- a/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
@@ -76,8 +76,8 @@ Describe 'Deny-SqlDscServerPermission' -Tag 'IntegrationTest' {
     Context 'When denying server permissions to login' {
         BeforeEach {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
-            Revoke-SqlDscServerPermission -Login $loginObject -Permission ViewServerState -Force -ErrorAction 'SilentlyContinue'
-            Revoke-SqlDscServerPermission -Login $loginObject -Permission ViewAnyDefinition -Force -ErrorAction 'SilentlyContinue'
+            Revoke-SqlDscServerPermission -Login $loginObject -Permission 'ViewServerState' -Force -ErrorAction 'SilentlyContinue'
+            Revoke-SqlDscServerPermission -Login $loginObject -Permission 'ViewAnyDefinition' -Force -ErrorAction 'SilentlyContinue'
         }
 
         It 'Should deny ViewServerState permission' {

--- a/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Deny-SqlDscServerPermission.Integration.Tests.ps1
@@ -58,6 +58,7 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
     Context 'When denying server permissions to login' {
         BeforeEach {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
+
             Revoke-SqlDscServerPermission -Login $loginObject -Permission 'ViewServerState' -Force -ErrorAction 'SilentlyContinue'
             Revoke-SqlDscServerPermission -Login $loginObject -Permission 'ViewAnyDefinition' -Force -ErrorAction 'SilentlyContinue'
         }
@@ -94,6 +95,7 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
     Context 'When denying server permissions to role' {
         BeforeEach {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
+
             Revoke-SqlDscServerPermission -ServerRole $roleObject -Permission 'ViewServerState' -Force -ErrorAction 'SilentlyContinue'
         }
 
@@ -114,6 +116,15 @@ Describe 'Deny-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
 
             # Verify the permission was denied - this denial will remain persistent for other integration tests
             $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @('AlterTrace') -ErrorAction 'Stop'
+            $result | Should -BeTrue
+        }
+
+        It 'Should accept ServerRole from pipeline' {
+            $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
+
+            $null = $roleObject | Deny-SqlDscServerPermission -Permission @('ViewServerState') -Force -ErrorAction 'Stop'
+
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Deny -Permission @('ViewServerState') -ErrorAction 'Stop'
             $result | Should -BeTrue
         }
     }

--- a/tests/Integration/Commands/Disable-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Disable-SqlDscLogin.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Disable-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Disable-SqlDscLogin' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Enable-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Enable-SqlDscLogin.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Enable-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Enable-SqlDscLogin' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Get-SqlDscAgentAlert.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscAgentAlert.Integration.Tests.ps1
@@ -24,25 +24,16 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
-
-    $env:SqlServerDscCI = $true
-
-    # Integration tests are run on the DSCSQLTEST instance
-    $script:sqlServerInstance = 'DSCSQLTEST'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    $env:SqlServerDscCI = $null
-
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
-}
-
-Describe 'Get-SqlDscAgentAlert' -Tag 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022' {
+Describe 'Get-SqlDscAgentAlert' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
+        # Integration tests are run on the DSCSQLTEST instance
+        $script:sqlServerInstance = 'DSCSQLTEST'
+
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 

--- a/tests/Integration/Commands/Get-SqlDscDatabase.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscDatabase.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Get-SqlDscDatabase' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Integration/Commands/Get-SqlDscInstalledInstance.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscInstalledInstance.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Get-SqlDscInstalledInstance' {
     Context 'When getting all SQL Server instances' -Tag @('Integration_PowerBI') {
         It 'Should not throw an exception' {

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Get-SqlDscRSSetupConfiguration.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscRSSetupConfiguration.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Get-SqlDscRSSetupConfiguration' {
     Context 'When getting the configuration for SQL Server Reporting Services instance' -Tag @('Integration_SQL2017_RS') {
         It 'Should return the correct configuration for SSRS instance' {

--- a/tests/Integration/Commands/Get-SqlDscRole.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscRole.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Get-SqlDscRole' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Get-SqlDscRole' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
@@ -103,7 +103,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
 
                 $result | Should -Not -BeNullOrEmpty
                 $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
-                
+
                 # Verify that the CreateEndpoint permission granted by Grant-SqlDscServerPermission test is present
                 $createEndpointPermission = $result | Where-Object { $_.PermissionType.CreateEndpoint -eq $true }
                 $createEndpointPermission | Should -Not -BeNullOrEmpty -Because 'CreateEndpoint permission should have been granted by Grant-SqlDscServerPermission integration test'
@@ -114,7 +114,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
         Context 'When getting permissions for invalid principals' {
             It 'Should throw error for non-existent login with ErrorAction Stop' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentLogin123' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*is not a login nor role*"
+                    Should -Throw
             }
 
             It 'Should return null for non-existent login with ErrorAction SilentlyContinue' {
@@ -125,7 +125,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
 
             It 'Should throw error for non-existent server role with ErrorAction Stop' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentRole123' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*is not a login nor role*"
+                    Should -Throw
             }
 
             It 'Should return null for non-existent server role with ErrorAction SilentlyContinue' {
@@ -183,12 +183,12 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
 
             It 'Should throw error when looking for login as role' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sa' -PrincipalType 'Role' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*is not a login nor role*"
+                    Should -Throw
             }
 
             It 'Should throw error when looking for role as login' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent' -PrincipalType 'Login' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*is not a login nor role*"
+                    Should -Throw
             }
 
             It 'Should return null when looking for login as role with SilentlyContinue' {

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
         Context 'When getting permissions for invalid principals' {
             It 'Should throw error for non-existent login with ErrorAction Stop' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentLogin123' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*does not exist*"
+                    Should -Throw -ExpectedMessage "*is not a login nor role*"
             }
 
             It 'Should return null for non-existent login with ErrorAction SilentlyContinue' {
@@ -134,7 +134,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
 
             It 'Should throw error for non-existent server role with ErrorAction Stop' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentRole123' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*does not exist*"
+                    Should -Throw -ExpectedMessage "*is not a login nor role*"
             }
 
             It 'Should return null for non-existent server role with ErrorAction SilentlyContinue' {
@@ -192,12 +192,12 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
 
             It 'Should throw error when looking for login as role' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sa' -PrincipalType 'Role' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*does not exist*"
+                    Should -Throw -ExpectedMessage "*is not a login nor role*"
             }
 
             It 'Should throw error when looking for role as login' {
                 { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin' -PrincipalType 'Login' -ErrorAction 'Stop' } |
-                    Should -Throw -ExpectedMessage "*does not exist*"
+                    Should -Throw -ExpectedMessage "*is not a login nor role*"
             }
 
             It 'Should return null when looking for login as role with SilentlyContinue' {

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -70,7 +70,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration
 
         Context 'When getting permissions for valid Windows logins' {
             It 'Should return permissions for SqlAdmin Windows login' {
-                $windowsLogin = '{0}\SqlAdmin' -f $script:computerName
+                $windowsLogin = '{0}\SqlAdmin' -f (Get-ComputerName)
                 $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $windowsLogin
 
                 $result | Should -Not -BeNullOrEmpty
@@ -217,7 +217,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration
             }
 
             It 'Should return permissions for Windows login using Login object' {
-                $windowsLogin = '{0}\SqlAdmin' -f $script:computerName
+                $windowsLogin = '{0}\SqlAdmin' -f (Get-ComputerName)
                 $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $windowsLogin
                 $result = Get-SqlDscServerPermission -Login $loginObject
 
@@ -233,7 +233,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration
                 $result = $loginObjects | Get-SqlDscServerPermission
 
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]]
                 $result.Count | Should -BeGreaterThan 1
             }
         }
@@ -271,7 +271,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration
                 $result = $roleObjects | Get-SqlDscServerPermission
 
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]]
                 $result.Count | Should -BeGreaterThan 1
             }
         }

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -6,14 +6,14 @@ BeforeDiscovery {
     {
         if (-not (Get-Module -Name 'DscResource.Test'))
         {
-            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
                 & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
-            # If the dependencies has not been resolved, this will throw an error.
+            # If the dependencies have not been resolved, this will throw an error.
             Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
         }
     }
@@ -29,7 +29,7 @@ BeforeAll {
     Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -167,5 +167,50 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
                 }
             }
         }
+
+        Context 'When using PrincipalType parameter' {
+            It 'Should return permissions for sa login when PrincipalType is Login' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sa' -PrincipalType 'Login'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should return permissions for sysadmin role when PrincipalType is Role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin' -PrincipalType 'Role'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should return permissions for sa login when PrincipalType is both Login and Role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sa' -PrincipalType 'Login', 'Role'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should throw error when looking for login as role' {
+                { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sa' -PrincipalType 'Role' -ErrorAction 'Stop' } |
+                    Should -Throw -ExpectedMessage "*does not exist*"
+            }
+
+            It 'Should throw error when looking for role as login' {
+                { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin' -PrincipalType 'Login' -ErrorAction 'Stop' } |
+                    Should -Throw -ExpectedMessage "*does not exist*"
+            }
+
+            It 'Should return null when looking for login as role with SilentlyContinue' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sa' -PrincipalType 'Role' -ErrorAction 'SilentlyContinue'
+
+                $result | Should -BeNullOrEmpty
+            }
+
+            It 'Should return null when looking for role as login with SilentlyContinue' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin' -PrincipalType 'Login' -ErrorAction 'SilentlyContinue'
+
+                $result | Should -BeNullOrEmpty
+            }
+        }
     }
 }

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -1,0 +1,171 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Suppressing this rule because Script Analyzer does not understand Pester syntax.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:dscModuleName
+}
+
+Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+    BeforeAll {
+        # Starting the named instance SQL Server service prior to running tests.
+        Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
+
+        $script:instanceName = 'DSCSQLTEST'
+        $script:computerName = Get-ComputerName
+    }
+
+    AfterAll {
+        # Stop the named instance SQL Server service to save memory on the build worker.
+        Stop-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
+    }
+
+    Context 'When connecting to SQL Server instance' {
+        BeforeAll {
+            $sqlAdministratorUserName = 'SqlAdmin' # Using computer name as NetBIOS name throw exception.
+            $sqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+
+            $script:sqlAdminCredential = [System.Management.Automation.PSCredential]::new($sqlAdministratorUserName, $sqlAdministratorPassword)
+
+            $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:instanceName -Credential $script:sqlAdminCredential
+        }
+
+        AfterAll {
+            Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject
+        }
+
+        Context 'When getting permissions for valid SQL logins' {
+            It 'Should return permissions for sa login' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sa'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should return permissions for sa login using pipeline' {
+                $result = $script:serverObject | Get-SqlDscServerPermission -Name 'sa'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+        }
+
+        Context 'When getting permissions for valid Windows logins' {
+            It 'Should return permissions for SqlAdmin Windows login' {
+                $windowsLogin = '{0}\SqlAdmin' -f $script:computerName
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $windowsLogin
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should return permissions for NT AUTHORITY\SYSTEM login' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NT AUTHORITY\SYSTEM'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+        }
+
+        Context 'When getting permissions for valid server roles' {
+            It 'Should return permissions for sysadmin server role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should return permissions for public server role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'public'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should return permissions for serveradmin server role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'serveradmin'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+
+            It 'Should return permissions for securityadmin server role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'securityadmin'
+
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+            }
+        }
+
+        Context 'When getting permissions for invalid principals' {
+            It 'Should throw error for non-existent login with ErrorAction Stop' {
+                { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentLogin123' -ErrorAction 'Stop' } |
+                    Should -Throw -ExpectedMessage "*does not exist*"
+            }
+
+            It 'Should return null for non-existent login with ErrorAction SilentlyContinue' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentLogin123' -ErrorAction 'SilentlyContinue'
+
+                $result | Should -BeNullOrEmpty
+            }
+
+            It 'Should throw error for non-existent server role with ErrorAction Stop' {
+                { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentRole123' -ErrorAction 'Stop' } |
+                    Should -Throw -ExpectedMessage "*does not exist*"
+            }
+
+            It 'Should return null for non-existent server role with ErrorAction SilentlyContinue' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'NonExistentRole123' -ErrorAction 'SilentlyContinue'
+
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        Context 'When verifying permission properties' {
+            BeforeAll {
+                # Get permissions for a known principal that should have permissions
+                $script:testPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin'
+            }
+
+            It 'Should return ServerPermissionInfo objects with PermissionState property' {
+                $script:testPermissions | Should -Not -BeNullOrEmpty
+
+                foreach ($permission in $script:testPermissions) {
+                    $permission.PermissionState | Should -BeIn @('Grant', 'Deny', 'GrantWithGrant')
+                }
+            }
+
+            It 'Should return ServerPermissionInfo objects with PermissionType property' {
+                $script:testPermissions | Should -Not -BeNullOrEmpty
+
+                foreach ($permission in $script:testPermissions) {
+                    $permission.PermissionType | Should -Not -BeNullOrEmpty
+                    $permission.PermissionType | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionSet]
+                }
+            }
+        }
+    }
+}

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -103,6 +103,11 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
 
                 $result | Should -Not -BeNullOrEmpty
                 $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
+                
+                # Verify that the CreateEndpoint permission granted by Grant-SqlDscServerPermission test is present
+                $createEndpointPermission = $result | Where-Object { $_.PermissionType.CreateEndpoint -eq $true }
+                $createEndpointPermission | Should -Not -BeNullOrEmpty -Because 'CreateEndpoint permission should have been granted by Grant-SqlDscServerPermission integration test'
+                $createEndpointPermission.PermissionState | Should -Be 'Grant'
             }
         }
 

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -91,13 +91,6 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
         }
 
         Context 'When getting permissions for valid server roles' {
-            It 'Should return permissions for sysadmin server role' {
-                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin'
-
-                $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
-            }
-
             It 'Should return permissions for public server role' {
                 $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'public'
 
@@ -105,15 +98,8 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
                 $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
             }
 
-            It 'Should return permissions for serveradmin server role' {
-                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'serveradmin'
-
-                $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
-            }
-
-            It 'Should return permissions for securityadmin server role' {
-                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'securityadmin'
+            It 'Should return permissions for SqlDscIntegrationTestRole_Persistent server role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent'
 
                 $result | Should -Not -BeNullOrEmpty
                 $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
@@ -147,7 +133,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
         Context 'When verifying permission properties' {
             BeforeAll {
                 # Get permissions for a known principal that should have permissions
-                $script:testPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin'
+                $script:testPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent'
             }
 
             It 'Should return ServerPermissionInfo objects with PermissionState property' {
@@ -176,8 +162,8 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
                 $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
             }
 
-            It 'Should return permissions for sysadmin role when PrincipalType is Role' {
-                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin' -PrincipalType 'Role'
+            It 'Should return permissions for SqlDscIntegrationTestRole_Persistent role when PrincipalType is Role' {
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent' -PrincipalType 'Role'
 
                 $result | Should -Not -BeNullOrEmpty
                 $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
@@ -196,7 +182,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
             }
 
             It 'Should throw error when looking for role as login' {
-                { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin' -PrincipalType 'Login' -ErrorAction 'Stop' } |
+                { Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent' -PrincipalType 'Login' -ErrorAction 'Stop' } |
                     Should -Throw -ExpectedMessage "*is not a login nor role*"
             }
 
@@ -207,7 +193,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
             }
 
             It 'Should return null when looking for role as login with SilentlyContinue' {
-                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin' -PrincipalType 'Login' -ErrorAction 'SilentlyContinue'
+                $result = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent' -PrincipalType 'Login' -ErrorAction 'SilentlyContinue'
 
                 $result | Should -BeNullOrEmpty
             }
@@ -253,16 +239,16 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
         }
 
         Context 'When using ServerRole parameter set' {
-            It 'Should return permissions for sysadmin role using ServerRole object' {
-                $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name 'sysadmin'
+            It 'Should return permissions for SqlDscIntegrationTestRole_Persistent role using ServerRole object' {
+                $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent'
                 $result = Get-SqlDscServerPermission -ServerRole $roleObject
 
                 $result | Should -Not -BeNullOrEmpty
                 $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
             }
 
-            It 'Should return permissions for sysadmin role using ServerRole object from pipeline' {
-                $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name 'sysadmin'
+            It 'Should return permissions for SqlDscIntegrationTestRole_Persistent role using ServerRole object from pipeline' {
+                $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent'
                 $result = $roleObject | Get-SqlDscServerPermission
 
                 $result | Should -Not -BeNullOrEmpty
@@ -279,9 +265,8 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
 
             It 'Should return permissions for multiple server roles using pipeline' {
                 $roleObjects = @(
-                    Get-SqlDscRole -ServerObject $script:serverObject -Name 'sysadmin'
+                    Get-SqlDscRole -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent'
                     Get-SqlDscRole -ServerObject $script:serverObject -Name 'public'
-                    Get-SqlDscRole -ServerObject $script:serverObject -Name 'serveradmin'
                 )
                 $result = $roleObjects | Get-SqlDscServerPermission
 
@@ -310,12 +295,12 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2016', 'Integration
                 }
             }
 
-            It 'Should return same permissions for sysadmin role using different parameter sets' {
+            It 'Should return same permissions for SqlDscIntegrationTestRole_Persistent role using different parameter sets' {
                 # Get permissions using ByName parameter set
-                $resultByName = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'sysadmin'
+                $resultByName = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent'
 
                 # Get permissions using ServerRole parameter set
-                $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name 'sysadmin'
+                $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name 'SqlDscIntegrationTestRole_Persistent'
                 $resultByRole = Get-SqlDscServerPermission -ServerRole $roleObject
 
                 # Compare results

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
 
         Write-Verbose -Message ('Integration tests will run using computer name ''{0}'' and instance name ''{1}''.' -f $script:computerName, $script:sqlServerInstanceName) -Verbose
 
-        $script:serverObject = Connect-SqlDscDatabaseEngine -ServerName $script:computerName -InstanceName $script:sqlServerInstanceName -Force
+        $script:serverObject = Connect-SqlDscDatabaseEngine -ServerName $script:computerName -InstanceName $script:sqlServerInstanceName -ErrorAction 'Stop'
 
         # Use existing persistent principals created by earlier integration tests
         $script:testLoginName = 'IntegrationTestSqlLogin'

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -69,41 +69,60 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             $null = Grant-SqlDscServerPermission -Login $script:loginObject -Permission @('ViewServerState') -Force -ErrorAction 'Stop'
 
             # Verify the permission was granted
-            $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
-            $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
-            $grantPermission.PermissionType.ViewServerState | Should -BeTrue
+            $permission = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
+
+            $permission | Should -Not -BeNullOrEmpty
+            $grantedPermissions = $permission | Where-Object { $_.PermissionState -eq 'Grant' }
+
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.ViewServerState -eq $true }
+            $expectedPermission | Should -HaveCount 1
+            $expectedPermission.PermissionType.ViewServerState | Should -BeTrue
         }
 
         It 'Should grant multiple permissions successfully' {
             $null = Grant-SqlDscServerPermission -Login $script:loginObject -Permission @('ViewServerState', 'ViewAnyDatabase') -Force -ErrorAction 'Stop'
 
             # Verify the permissions were granted
-            $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
-            $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
-            $grantPermission.PermissionType.ViewServerState | Should -BeTrue
-            $grantPermission.PermissionType.ViewAnyDatabase | Should -BeTrue
+            $permission = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
+
+            $permission | Should -Not -BeNullOrEmpty
+            $grantedPermissions = $permission | Where-Object { $_.PermissionState -eq 'Grant' }
+
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.ViewServerState -eq $true }
+            $expectedPermission | Should -HaveCount 1
+            $expectedPermission.PermissionType.ViewServerState | Should -BeTrue
+
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.ViewAnyDatabase -eq $true }
+            $expectedPermission | Should -HaveCount 1
+            $expectedPermission.PermissionType.ViewAnyDatabase | Should -BeTrue
         }
 
         It 'Should grant permissions with WithGrant option' {
             $null = Grant-SqlDscServerPermission -Login $script:loginObject -Permission @('ViewServerState') -WithGrant -Force -ErrorAction 'Stop'
 
             # Verify the permission was granted with grant option
-            $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
-            $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantWithGrantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'GrantWithGrant' }
-            $grantWithGrantPermission.PermissionType.ViewServerState | Should -BeTrue
+            $permission = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
+
+            $permission | Should -Not -BeNullOrEmpty
+            $grantedPermissions = $permission | Where-Object { $_.PermissionState -eq 'GrantWithGrant' }
+
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.ViewServerState -eq $true }
+            $expectedPermission | Should -HaveCount 1
+            $expectedPermission.PermissionType.ViewServerState | Should -BeTrue
         }
 
         It 'Should accept Login from pipeline' {
             $null = $script:loginObject | Grant-SqlDscServerPermission -Permission @('ViewAnyDefinition') -Force -ErrorAction 'Stop'
 
             # Verify the permission was granted
-            $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
-            $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
-            $grantPermission.PermissionType.ViewAnyDefinition | Should -BeTrue
+            $permission = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
+
+            $permission | Should -Not -BeNullOrEmpty
+            $grantedPermissions = $permission | Where-Object { $_.PermissionState -eq 'Grant' }
+
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.ViewAnyDefinition -eq $true }
+            $expectedPermission | Should -HaveCount 1
+            $expectedPermission.PermissionType.ViewAnyDefinition | Should -BeTrue
         }
     }
 
@@ -121,10 +140,14 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             $null = Grant-SqlDscServerPermission -ServerRole $roleObject -Permission @('ViewServerState') -Force -ErrorAction 'Stop'
 
             # Verify the permission was granted
-            $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
-            $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
-            $grantPermission.PermissionType.ViewServerState | Should -BeTrue
+            $permission = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
+
+            $permission | Should -Not -BeNullOrEmpty
+            $grantedPermissions = $permission | Where-Object { $_.PermissionState -eq 'Grant' }
+
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.ViewServerState -eq $true }
+            $expectedPermission | Should -HaveCount 1
+            $expectedPermission.PermissionType.ViewServerState | Should -BeTrue
         }
 
         It 'Should grant persistent CreateEndpoint permission to role for other tests' {
@@ -133,10 +156,14 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             $null = Grant-SqlDscServerPermission -ServerRole $roleObject -Permission @('CreateEndpoint') -Force -ErrorAction 'Stop'
 
             # Verify the permission was granted - this permission will remain persistent for other integration tests
-            $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
-            $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
-            $grantPermission.PermissionType.CreateEndpoint | Should -BeTrue
+            $permission = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
+
+            $permission | Should -Not -BeNullOrEmpty
+            $grantedPermissions = $permission | Where-Object { $_.PermissionState -eq 'Grant' }
+
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.CreateEndpoint -eq $true }
+            $expectedPermission | Should -HaveCount 1
+            $expectedPermission.PermissionType.CreateEndpoint | Should -BeTrue
         }
     }
 }

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -71,7 +71,8 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             # Verify the permission was granted
             $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
             $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantedPermissions.PermissionType.ViewServerState | Should -BeTrue
+            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
+            $grantPermission.PermissionType.ViewServerState | Should -BeTrue
         }
 
         It 'Should grant multiple permissions successfully' {
@@ -80,8 +81,9 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             # Verify the permissions were granted
             $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
             $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantedPermissions.PermissionType.ViewServerState | Should -BeTrue
-            $grantedPermissions.PermissionType.ViewAnyDatabase | Should -BeTrue
+            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
+            $grantPermission.PermissionType.ViewServerState | Should -BeTrue
+            $grantPermission.PermissionType.ViewAnyDatabase | Should -BeTrue
         }
 
         It 'Should grant permissions with WithGrant option' {
@@ -100,7 +102,8 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             # Verify the permission was granted
             $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
             $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantedPermissions.PermissionType.ViewAnyDefinition | Should -BeTrue
+            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
+            $grantPermission.PermissionType.ViewAnyDefinition | Should -BeTrue
         }
     }
 
@@ -120,7 +123,8 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             # Verify the permission was granted
             $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
             $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantedPermissions.PermissionType.ViewServerState | Should -BeTrue
+            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
+            $grantPermission.PermissionType.ViewServerState | Should -BeTrue
         }
 
         It 'Should grant persistent CreateEndpoint permission to role for other tests' {
@@ -131,8 +135,8 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             # Verify the permission was granted - this permission will remain persistent for other integration tests
             $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
             $grantedPermissions | Should -Not -BeNullOrEmpty
-            $grantedPermissions.PermissionType.PermissionState | Should -Be 'Grant'
-            $grantedPermissions.PermissionType.CreateEndpoint | Should -BeTrue
+            $grantPermission = $grantedPermissions | Where-Object { $_.PermissionState -eq 'Grant' }
+            $grantPermission.PermissionType.CreateEndpoint | Should -BeTrue
         }
     }
 }

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -63,6 +63,7 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             Revoke-SqlDscServerPermission -Login $script:loginObject -Permission 'ViewServerState' -Force -ErrorAction 'SilentlyContinue'
             Revoke-SqlDscServerPermission -Login $script:loginObject -Permission 'ViewAnyDatabase' -Force -ErrorAction 'SilentlyContinue'
             Revoke-SqlDscServerPermission -Login $script:loginObject -Permission 'ViewAnyDefinition' -Force -ErrorAction 'SilentlyContinue'
+            Revoke-SqlDscServerPermission -Login $script:loginObject -Permission 'CreateAnyDatabase' -WithGrant -Force -ErrorAction 'SilentlyContinue'
         }
 
         It 'Should grant ViewServerState permission successfully' {
@@ -98,7 +99,7 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
         }
 
         It 'Should grant permissions with WithGrant option' {
-            $null = Grant-SqlDscServerPermission -Login $script:loginObject -Permission @('ViewServerState') -WithGrant -Force -ErrorAction 'Stop'
+            $null = Grant-SqlDscServerPermission -Login $script:loginObject -Permission @('CreateAnyDatabase') -WithGrant -Force -ErrorAction 'Stop'
 
             # Verify the permission was granted with grant option
             $permission = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
@@ -106,9 +107,9 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
             $permission | Should -Not -BeNullOrEmpty
             $grantedPermissions = $permission | Where-Object { $_.PermissionState -eq 'GrantWithGrant' }
 
-            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.ViewServerState -eq $true }
+            $expectedPermission = $grantedPermissions | Where-Object { $_.PermissionType.CreateAnyDatabase -eq $true }
             $expectedPermission | Should -HaveCount 1
-            $expectedPermission.PermissionType.ViewServerState | Should -BeTrue
+            $expectedPermission.PermissionType.CreateAnyDatabase | Should -BeTrue
         }
 
         It 'Should accept Login from pipeline' {

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -29,12 +29,7 @@ BeforeAll {
     Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:moduleName -All | Remove-Module -Force
-}
-
-Describe 'Grant-SqlDscServerPermission Integration Tests' -Tag 'Integration' {
+Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Check if there is a CI database instance to use for testing
         $script:sqlServerInstanceName = $env:SqlServerInstanceName

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -31,44 +31,28 @@ BeforeAll {
 
 Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
-        # Check if there is a CI database instance to use for testing
-        $script:sqlServerInstanceName = $env:SqlServerInstanceName
+        # Starting the named instance SQL Server service prior to running tests.
+        Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 
-        if (-not $script:sqlServerInstanceName)
-        {
-            $script:sqlServerInstanceName = 'DSCSQLTEST'
-        }
+        $script:mockInstanceName = 'DSCSQLTEST'
 
-        # Get a computer name that will work in the CI environment
-        $script:computerName = Get-ComputerName
+        $mockSqlAdministratorUserName = 'SqlAdmin' # Using computer name as NetBIOS name throw exception.
+        $mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
 
-        Write-Verbose -Message ('Integration tests will run using computer name ''{0}'' and instance name ''{1}''.' -f $script:computerName, $script:sqlServerInstanceName) -Verbose
+        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
 
-        $script:serverObject = Connect-SqlDscDatabaseEngine -ServerName $script:computerName -InstanceName $script:sqlServerInstanceName -ErrorAction 'Stop'
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
 
         # Use existing persistent principals created by earlier integration tests
         $script:testLoginName = 'IntegrationTestSqlLogin'
         $script:testRoleName = 'SqlDscIntegrationTestRole_Persistent'
-
-        # Verify the persistent principals exist (should be created by New-SqlDscLogin and New-SqlDscRole integration tests)
-        $existingLogin = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'SilentlyContinue'
-        if (-not $existingLogin)
-        {
-            throw ('Test login {0} does not exist. Please run New-SqlDscLogin integration tests first to create persistent test principals.' -f $script:testLoginName)
-        }
-
-        $existingRole = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'SilentlyContinue'
-        if (-not $existingRole)
-        {
-            throw ('Test role {0} does not exist. Please run New-SqlDscRole integration tests first to create persistent test principals.' -f $script:testRoleName)
-        }
     }
 
     AfterAll {
-        # Keep the persistent principals for other tests to use
-        # Do not remove $script:testLoginName and $script:testRoleName as they are managed by New-SqlDscLogin and New-SqlDscRole tests
-
         Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject
+
+        # Stop the named instance SQL Server service to save memory on the build worker.
+        Stop-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
     }
 
     Context 'When granting server permissions to login' {

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -152,6 +152,7 @@ Describe 'Grant-SqlDscServerPermission Integration Tests' -Tag 'Integration' {
             # Verify the permission was granted - this permission will remain persistent for other integration tests
             $grantedPermissions = Get-SqlDscServerPermission -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
             $grantedPermissions | Should -Not -BeNullOrEmpty
+            $grantedPermissions.PermissionType.PermissionState | Should -Be 'Grant'
             $grantedPermissions.PermissionType.CreateEndpoint | Should -BeTrue
         }
     }

--- a/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Grant-SqlDscServerPermission.Integration.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'Grant-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrati
 
         $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
 
-        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential -ErrorAction 'Stop'
 
         # Use existing persistent principals created by earlier integration tests
         $script:testLoginName = 'IntegrationTestSqlLogin'

--- a/tests/Integration/Commands/Install-SqlDscBIReportServer.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Install-SqlDscBIReportServer.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Install-SqlDscBIReportServer' -Tag @('Integration_PowerBI') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose

--- a/tests/Integration/Commands/Install-SqlDscReportingService.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Install-SqlDscReportingService.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Install-SqlDscReportingService' -Tag @('Integration_SQL2017_RS', 'Integration_SQL2019_RS', 'Integration_SQL2022_RS') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose

--- a/tests/Integration/Commands/Install-SqlDscServer.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Install-SqlDscServer.Integration.Tests.ps1
@@ -23,8 +23,14 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 # cSpell: ignore SQLSERVERAGENT, DSCSQLTEST
-Describe 'Install-SqlDscServer' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Install-SqlDscServer' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose
 

--- a/tests/Integration/Commands/New-SqlDscAgentAlert.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscAgentAlert.Integration.Tests.ps1
@@ -24,25 +24,16 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
-
-    $env:SqlServerDscCI = $true
-
-    # Integration tests are run on the DSCSQLTEST instance
-    $script:sqlServerInstance = 'DSCSQLTEST'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    $env:SqlServerDscCI = $null
-
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
-}
-
-Describe 'New-SqlDscAgentAlert' -Tag 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022' {
+Describe 'New-SqlDscAgentAlert' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
+        # Integration tests are run on the DSCSQLTEST instance
+        $script:sqlServerInstance = 'DSCSQLTEST'
+
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 

--- a/tests/Integration/Commands/New-SqlDscDatabase.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscDatabase.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName  -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'New-SqlDscDatabase' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/New-SqlDscRole.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscRole.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'New-SqlDscRole' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'New-SqlDscRole' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Prerequisites.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Prerequisites.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 # CSpell: ignore Remoting
 Describe 'Prerequisites' {
     Context 'Create required local Windows users' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022', 'Integration_PowerBI') {

--- a/tests/Integration/Commands/README.md
+++ b/tests/Integration/Commands/README.md
@@ -51,7 +51,7 @@ Enable-SqlDscLogin | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTES
 Test-SqlDscIsLoginEnabled | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 New-SqlDscRole | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | SqlDscIntegrationTestRole_Persistent role
 Get-SqlDscRole | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
-Grant-SqlDscServerPermission | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | Grants ConnectSql permissions to existing persistent principals, CreateEndpoint to role
+Grant-SqlDscServerPermission | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | Grants CreateEndpoint permission to role
 Get-SqlDscServerPermission | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 Test-SqlDscServerPermission | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 Deny-SqlDscServerPermission | 2 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | Denies AlterTrace permission to login (persistent)
@@ -104,8 +104,7 @@ with sa owner that remains on the instance for other tests to use.
 
 ### `Grant-SqlDscServerPermission`
 
-Grants `ConnectSql` permission to persistent login `IntegrationTestSqlLogin`
-and `CreateEndpoint` permission to the role `SqlDscIntegrationTestRole_Persistent`
+Grants `CreateEndpoint` permission to the role `SqlDscIntegrationTestRole_Persistent`
 
 ### `Deny-SqlDscServerPermission`
 
@@ -181,14 +180,14 @@ Group | Description
 Login | Password | Permission | Description
 --- | --- | --- | ---
 sa | P@ssw0rd1 | sysadmin | Administrator of all the Database Engine instances.
-IntegrationTestSqlLogin | P@ssw0rd123! | ConnectSql (Grant), AlterTrace (Deny) | SQL Server login created by New-SqlDscLogin integration tests. ConnectSql permission granted by Grant-SqlDscServerPermission, AlterTrace permission denied by Deny-SqlDscServerPermission integration tests for server permission testing.
+IntegrationTestSqlLogin | P@ssw0rd123! | AlterTrace (Deny) | SQL Server login created by New-SqlDscLogin integration tests. AlterTrace permission denied by Deny-SqlDscServerPermission integration tests for server permission testing.
 .\SqlIntegrationTestGroup | - | - | Windows group login created by New-SqlDscLogin integration tests for testing purposes.
 
 ### SQL Server Roles
 
 Role | Owner | Permission | Description
 --- | --- | --- | ---
-SqlDscIntegrationTestRole_Persistent | sa | ConnectSql, CreateEndpoint | Server role created by New-SqlDscRole integration tests. ConnectSql and CreateEndpoint permissions granted by Grant-SqlDscServerPermission integration tests for server permission testing.
+SqlDscIntegrationTestRole_Persistent | sa | CreateEndpoint | Server role created by New-SqlDscRole integration tests. CreateEndpoint permission granted by Grant-SqlDscServerPermission integration tests for server permission testing.
 <!-- markdownlint-enable MD013 -->
 
 ### Image media (ISO)

--- a/tests/Integration/Commands/Remove-SqlDscAgentAlert.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscAgentAlert.Integration.Tests.ps1
@@ -24,25 +24,16 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
-
-    $env:SqlServerDscCI = $true
-
-    # Integration tests are run on the DSCSQLTEST instance
-    $script:sqlServerInstance = 'DSCSQLTEST'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    $env:SqlServerDscCI = $null
-
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
-}
-
-Describe 'Remove-SqlDscAgentAlert' -Tag 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022' {
+Describe 'Remove-SqlDscAgentAlert' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
+        # Integration tests are run on the DSCSQLTEST instance
+        $script:sqlServerInstance = 'DSCSQLTEST'
+
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 

--- a/tests/Integration/Commands/Remove-SqlDscDatabase.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscDatabase.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Remove-SqlDscDatabase' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Remove-SqlDscRole.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscRole.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Remove-SqlDscRole' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Remove-SqlDscRole' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Repair-SqlDscBIReportServer.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Repair-SqlDscBIReportServer.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Repair-SqlDscBIReportServer' -Tag @('Integration_PowerBI') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose

--- a/tests/Integration/Commands/Repair-SqlDscReportingService.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Repair-SqlDscReportingService.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Repair-SqlDscReportingService' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose

--- a/tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1
@@ -29,12 +29,7 @@ BeforeAll {
     Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:moduleName -All | Remove-Module -Force
-}
-
-Describe 'Revoke-SqlDscServerPermission' -Tag 'IntegrationTest' {
+Describe 'Revoke-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Check if there is a CI database instance to use for testing
         $script:sqlServerInstanceName = $env:SqlServerInstanceName

--- a/tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrat
             $null = Revoke-SqlDscServerPermission -Login $loginObject -Permission @('ViewAnyDatabase') -Force -ErrorAction 'Stop'
 
             # Test that it's no longer granted
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::ViewAnyDatabase) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ViewAnyDatabase') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -92,7 +92,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrat
             $null = $loginObject | Revoke-SqlDscServerPermission -Permission @('ViewAnyDefinition') -Force -ErrorAction 'Stop'
 
             # Verify the permission was revoked
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::ViewAnyDefinition) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ViewAnyDefinition') -ErrorAction 'Stop'
             $result | Should -BeFalse
         }
     }
@@ -110,7 +110,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integrat
             $null = Revoke-SqlDscServerPermission -ServerRole $roleObject -Permission @('ViewServerState') -Force -ErrorAction 'Stop'
 
             # Test that it's no longer granted
-            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @([SqlServerPermission]::ViewServerState) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('ViewServerState') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }

--- a/tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Revoke-SqlDscServerPermission.Integration.Tests.ps1
@@ -31,41 +31,28 @@ BeforeAll {
 
 Describe 'Revoke-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
-        # Check if there is a CI database instance to use for testing
-        $script:sqlServerInstanceName = $env:SqlServerInstanceName
+        # Starting the named instance SQL Server service prior to running tests.
+        Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 
-        if (-not $script:sqlServerInstanceName)
-        {
-            $script:sqlServerInstanceName = 'DSCSQLTEST'
-        }
+        $script:mockInstanceName = 'DSCSQLTEST'
 
-        # Get a computer name that will work in the CI environment
-        $script:computerName = Get-ComputerName
+        $mockSqlAdministratorUserName = 'SqlAdmin' # Using computer name as NetBIOS name throw exception.
+        $mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
 
-        Write-Verbose -Message ('Integration tests will run using computer name ''{0}'' and instance name ''{1}''.' -f $script:computerName, $script:sqlServerInstanceName) -Verbose
+        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
 
-        $script:serverObject = Connect-SqlDscDatabaseEngine -ServerName $script:computerName -InstanceName $script:sqlServerInstanceName -Force
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
 
         # Use persistent test login and role created by earlier integration tests
         $script:testLoginName = 'IntegrationTestSqlLogin'
         $script:testRoleName = 'SqlDscIntegrationTestRole_Persistent'
-
-        # Verify the persistent principals exist (should be created by New-SqlDscLogin and New-SqlDscRole integration tests)
-        $existingLogin = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'SilentlyContinue'
-        if (-not $existingLogin)
-        {
-            throw ('Test login {0} does not exist. Please run New-SqlDscLogin integration tests first to create persistent test principals.' -f $script:testLoginName)
-        }
-
-        $existingRole = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'SilentlyContinue'
-        if (-not $existingRole)
-        {
-            throw ('Test role {0} does not exist. Please run New-SqlDscRole integration tests first to create persistent test principals.' -f $script:testRoleName)
-        }
     }
 
     AfterAll {
         Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject
+
+        # Stop the named instance SQL Server service to save memory on the build worker.
+        Stop-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
     }
 
     Context 'When revoking server permissions from login' {

--- a/tests/Integration/Commands/Set-SqlDscAgentAlert.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Set-SqlDscAgentAlert.Integration.Tests.ps1
@@ -24,25 +24,16 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
-
-    $env:SqlServerDscCI = $true
-
-    # Integration tests are run on the DSCSQLTEST instance
-    $script:sqlServerInstance = 'DSCSQLTEST'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    $env:SqlServerDscCI = $null
-
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
-}
-
-Describe 'Set-SqlDscAgentAlert' -Tag 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022' {
+Describe 'Set-SqlDscAgentAlert' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
+        # Integration tests are run on the DSCSQLTEST instance
+        $script:sqlServerInstance = 'DSCSQLTEST'
+
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 

--- a/tests/Integration/Commands/Set-SqlDscDatabase.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Set-SqlDscDatabase.Integration.Tests.ps1
@@ -24,9 +24,9 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'Set-SqlDscDatabase' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Integration/Commands/Test-SqlDscAgentAlert.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscAgentAlert.Integration.Tests.ps1
@@ -24,25 +24,16 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
-
-    $env:SqlServerDscCI = $true
-
-    # Integration tests are run on the DSCSQLTEST instance
-    $script:sqlServerInstance = 'DSCSQLTEST'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    $env:SqlServerDscCI = $null
-
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
-}
-
-Describe 'Test-SqlDscAgentAlert' -Tag 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022' {
+Describe 'Test-SqlDscAgentAlert' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022'){
     BeforeAll {
+        # Integration tests are run on the DSCSQLTEST instance
+        $script:sqlServerInstance = 'DSCSQLTEST'
+
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
 

--- a/tests/Integration/Commands/Test-SqlDscDatabase.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscDatabase.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName  -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Test-SqlDscDatabase' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Test-SqlDscDatabase' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Test-SqlDscIsLoginEnabled.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscIsLoginEnabled.Integration.Tests.ps1
@@ -24,12 +24,12 @@ BeforeDiscovery {
 }
 
 BeforeAll {
-    $script:dscModuleName = 'SqlServerDsc'
+    $script:moduleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-Describe 'Test-SqlDscIsLoginEnabled' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Test-SqlDscIsLoginEnabled' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Starting the named instance SQL Server service prior to running tests.
         Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Test-SqlDscRSInstalled.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscRSInstalled.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Test-SqlDscRSInstalled' {
     Context 'When testing if a specific Reporting Services instance exists' -Tag @('Integration_SQL2017_RS', 'Integration_SQL2019_RS', 'Integration_SQL2022_RS', 'Integration_PowerBI') {
         It 'Should return $false for a non-existing instance' {

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -107,23 +107,15 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $result | Should -BeFalse
         }
 
+        # cSpell:ignore securityadmin
         It 'Should return true when testing for empty permission collection on principal with no additional permissions' {
-            # Create a temporary login for this test to ensure it has no additional permissions
-            $tempLoginName = 'TempTestLogin_' + (Get-Random)
-            $tempLoginObject = New-SqlDscLogin -ServerObject $script:serverObject -Name $tempLoginName -SqlLogin -SecurePassword (ConvertTo-SecureString -String 'TempPassword123!' -AsPlainText -Force) -Force -PassThru -ErrorAction 'Stop'
+            # Get the built-in securityadmin server role which should have no explicit permissions
+            $securityAdminRole = Get-SqlDscRole -ServerObject $script:serverObject -Name 'securityadmin' -ErrorAction 'Stop'
 
-            try
-            {
-                # Test that empty permission collection returns true when no permissions are set
-                $result = Test-SqlDscServerPermission -Login $tempLoginObject -Grant -Permission @() -ErrorAction 'Stop'
+            # Test that empty permission collection returns true when no permissions are set
+            $result = Test-SqlDscServerPermission -ServerRole $securityAdminRole -Grant -Permission @() -ErrorAction 'Stop'
 
-                $result | Should -BeTrue
-            }
-            finally
-            {
-                # Clean up temporary login
-                Remove-SqlDscLogin -Login $tempLoginObject -Force -ErrorAction 'SilentlyContinue'
-            }
+            $result | Should -BeTrue
         }
 
         It 'Should return false when using ExactMatch and additional permissions exist' {

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -194,12 +194,12 @@ Describe 'Test-SqlDscServerPermission Integration Tests' -Tag 'Integration' {
         BeforeAll {
             # Set up denied permissions for testing
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
-            Deny-SqlDscServerPermission -Login $loginObject -Permission @('ViewAnyDefinition') -Force -ErrorAction 'Stop'
+            $null = Deny-SqlDscServerPermission -Login $loginObject -Permission @('ViewAnyDefinition') -Force -ErrorAction 'Stop'
         }
 
         AfterAll {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
-            Revoke-SqlDscServerPermission -Login $loginObject -Permission @('ViewAnyDefinition') -Force -ErrorAction 'SilentlyContinue'
+            $null = Revoke-SqlDscServerPermission -Login $loginObject -Permission @('ViewAnyDefinition') -Force -ErrorAction 'SilentlyContinue'
         }
 
         It 'Should return true when testing for denied permission that exists' {

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -180,6 +180,14 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
 
             $result | Should -BeFalse
         }
+
+        It 'Should accept ServerRole object from pipeline' {
+            $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
+
+            $result = $roleObject | Test-SqlDscServerPermission -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
+
+            $result | Should -BeTrue
+        }
     }
 
     Context 'When testing deny permissions' {

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -29,12 +29,7 @@ BeforeAll {
     Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
 }
 
-AfterAll {
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:moduleName -All | Remove-Module -Force
-}
-
-Describe 'Test-SqlDscServerPermission Integration Tests' -Tag 'Integration' {
+Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         # Check if there is a CI database instance to use for testing
         $script:sqlServerInstanceName = $env:SqlServerInstanceName

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -121,7 +121,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when using ExactMatch and additional permissions exist' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            # Test with ExactMatch - should fail because ViewServerState is also granted
+            # Test with ExactMatch - should fail because ViewServerState and ViewAnyDefinition is also granted
             $result = Test-SqlDscServerPermission -Verbose -Login $loginObject -Grant -Permission @('ConnectSql') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeFalse
@@ -131,7 +131,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
             # Test with ExactMatch - should pass because both ConnectSql and ViewServerState are granted
-            $result = Test-SqlDscServerPermission -Verbose -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Verbose -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'ViewAnyDefinition') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -157,10 +157,10 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $result | Should -BeTrue
         }
 
-                It 'Should return true when role permissions match desired state' {
+        It 'Should return true when role permissions exact match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'CreateAnyDatabase') -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'CreateEndpoint', 'CreateAnyDatabase') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -168,7 +168,15 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when role permissions do not match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Verbose-ServerRole $roleObject -Grant -Permission @('CreateAnyDatabase') -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('AlterAnyEndpoint') -ErrorAction 'Stop'
+
+            $result | Should -BeFalse
+        }
+
+        It 'Should return false when role permissions do not exact match desired state' {
+            $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
+
+            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ViewServerState') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -122,7 +122,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
             # Test with ExactMatch - should fail because ViewServerState and ViewAnyDefinition is also granted
-            $result = Test-SqlDscServerPermission -Verbose -Login $loginObject -Grant -Permission @('ConnectSql') -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -130,8 +130,8 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when using ExactMatch and permissions exactly match' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            # Test with ExactMatch - should pass because both ConnectSql and ViewServerState are granted
-            $result = Test-SqlDscServerPermission -Verbose -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'ViewAnyDefinition') -ExactMatch -ErrorAction 'Stop'
+            # Test with ExactMatch - should pass because both ConnectSql, ViewAnyDefinition and ViewServerState are granted
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'ViewAnyDefinition') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -152,7 +152,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when role permissions match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -160,7 +160,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when role permissions exact match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'CreateEndpoint', 'CreateAnyDatabase') -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'CreateEndpoint', 'CreateAnyDatabase') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -168,7 +168,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when role permissions do not match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('AlterAnyEndpoint') -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('AlterAnyEndpoint') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -176,7 +176,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when role permissions do not exact match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ViewServerState') -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('ViewServerState') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -70,7 +70,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when permissions match desired state' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::ConnectSql, [SqlServerPermission]::ViewServerState) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -78,7 +78,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when permissions do not match desired state' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::AlterAnyDatabase) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('AlterAnyDatabase') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -86,7 +86,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should accept Login object from pipeline' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = $loginObject | Test-SqlDscServerPermission -Grant -Permission @([SqlServerPermission]::ConnectSql, [SqlServerPermission]::ViewServerState) -ErrorAction 'Stop'
+            $result = $loginObject | Test-SqlDscServerPermission -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -94,7 +94,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when only testing specific grant permission that exists' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::ConnectSql) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql') -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -102,7 +102,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when testing for permission that does not exist' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::AlterAnyCredential) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('AlterAnyCredential') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -128,7 +128,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
             # Test with ExactMatch - should fail because ViewServerState is also granted
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::ConnectSql) -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -137,7 +137,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
             # Test with ExactMatch - should pass because both ConnectSql and ViewServerState are granted
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::ConnectSql, [SqlServerPermission]::ViewServerState) -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -158,7 +158,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when role permissions match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @([SqlServerPermission]::ConnectSql, [SqlServerPermission]::ViewServerState) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -166,7 +166,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when role permissions do not match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @([SqlServerPermission]::CreateAnyDatabase) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('CreateAnyDatabase') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -187,7 +187,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when testing for denied permission that exists' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @([SqlServerPermission]::ViewAnyDefinition) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @('ViewAnyDefinition') -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -195,7 +195,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when testing for denied permission that does not exist' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @([SqlServerPermission]::AlterServerState) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Deny -Permission @('AlterServerState') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -216,7 +216,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when testing for grant with grant permission that exists' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::ViewAnyDatabase) -WithGrant -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ViewAnyDatabase') -WithGrant -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -224,7 +224,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when testing for grant with grant permission that does not exist' {
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @([SqlServerPermission]::CreateEndpoint) -WithGrant -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('CreateEndpoint') -WithGrant -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -236,7 +236,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             # We need to use a real server object but with a non-existent login name
             $mockLogin = [Microsoft.SqlServer.Management.Smo.Login]::new($script:serverObject, 'NonExistentLogin')
 
-            $result = Test-SqlDscServerPermission -Login $mockLogin -Grant -Permission @([SqlServerPermission]::ConnectSql) -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Login $mockLogin -Grant -Permission @('ConnectSql') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -122,7 +122,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
             # Test with ExactMatch - should fail because ViewServerState is also granted
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql') -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Verbose -Login $loginObject -Grant -Permission @('ConnectSql') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }
@@ -131,7 +131,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName -ErrorAction 'Stop'
 
             # Test with ExactMatch - should pass because both ConnectSql and ViewServerState are granted
-            $result = Test-SqlDscServerPermission -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ExactMatch -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Verbose -Login $loginObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -141,18 +141,26 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         BeforeAll {
             # Set up known permissions for testing
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
-            $null = Grant-SqlDscServerPermission -ServerRole $roleObject -Permission @('ViewServerState') -Force -ErrorAction 'Stop'
+            $null = Grant-SqlDscServerPermission -ServerRole $roleObject -Permission @('ConnectSql', 'ViewServerState', 'CreateAnyDatabase') -Force -ErrorAction 'Stop'
         }
 
         AfterAll {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
-            $null = Revoke-SqlDscServerPermission -ServerRole $roleObject -Permission @('ViewServerState') -Force -ErrorAction 'SilentlyContinue'
+            $null = Revoke-SqlDscServerPermission -ServerRole $roleObject -Permission @('ConnectSql', 'ViewServerState', 'CreateAnyDatabase') -Force -ErrorAction 'SilentlyContinue'
         }
 
         It 'Should return true when role permissions match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState') -ErrorAction 'Stop'
+
+            $result | Should -BeTrue
+        }
+
+                It 'Should return true when role permissions match desired state' {
+            $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
+
+            $result = Test-SqlDscServerPermission -Verbose -ServerRole $roleObject -Grant -Permission @('ConnectSql', 'ViewServerState', 'CreateAnyDatabase') -ExactMatch -ErrorAction 'Stop'
 
             $result | Should -BeTrue
         }
@@ -160,7 +168,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return false when role permissions do not match desired state' {
             $roleObject = Get-SqlDscRole -ServerObject $script:serverObject -Name $script:testRoleName -ErrorAction 'Stop'
 
-            $result = Test-SqlDscServerPermission -ServerRole $roleObject -Grant -Permission @('CreateAnyDatabase') -ErrorAction 'Stop'
+            $result = Test-SqlDscServerPermission -Verbose-ServerRole $roleObject -Grant -Permission @('CreateAnyDatabase') -ErrorAction 'Stop'
 
             $result | Should -BeFalse
         }

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -110,7 +110,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when testing for empty permission collection on principal with no additional permissions' {
             # Create a temporary login for this test to ensure it has no additional permissions
             $tempLoginName = 'TempTestLogin_' + (Get-Random)
-            $tempLoginObject = New-SqlDscLogin -ServerObject $script:serverObject -Name $tempLoginName -SqlLogin -SecurePassword (ConvertTo-SecureString -String 'TempPassword123!' -AsPlainText -Force) -Force -ErrorAction 'Stop'
+            $tempLoginObject = New-SqlDscLogin -ServerObject $script:serverObject -Name $tempLoginName -SqlLogin -SecurePassword (ConvertTo-SecureString -String 'TempPassword123!' -AsPlainText -Force) -Force -PassThru -ErrorAction 'Stop'
 
             try
             {

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -110,15 +110,17 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
         It 'Should return true when testing for empty permission collection on principal with no additional permissions' {
             # Create a temporary login for this test to ensure it has no additional permissions
             $tempLoginName = 'TempTestLogin_' + (Get-Random)
-            $tempLoginObject = New-SqlDscLogin -ServerObject $script:serverObject -Name $tempLoginName -LoginType SqlLogin -SecureString (ConvertTo-SecureString -String 'TempPassword123!' -AsPlainText -Force) -Force -ErrorAction 'Stop'
+            $tempLoginObject = New-SqlDscLogin -ServerObject $script:serverObject -Name $tempLoginName -SqlLogin -SecurePassword (ConvertTo-SecureString -String 'TempPassword123!' -AsPlainText -Force) -Force -ErrorAction 'Stop'
 
-            try {
+            try
+            {
                 # Test that empty permission collection returns true when no permissions are set
                 $result = Test-SqlDscServerPermission -Login $tempLoginObject -Grant -Permission @() -ErrorAction 'Stop'
 
                 $result | Should -BeTrue
             }
-            finally {
+            finally
+            {
                 # Clean up temporary login
                 Remove-SqlDscLogin -Login $tempLoginObject -Force -ErrorAction 'SilentlyContinue'
             }

--- a/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Test-SqlDscServerPermission.Integration.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'Test-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integratio
 
         $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
 
-        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential -ErrorAction 'Stop'
 
         # Use persistent test login and role created by earlier integration tests
         $script:testLoginName = 'IntegrationTestSqlLogin'

--- a/tests/Integration/Commands/Uninstall-SqlDscBIReportServer.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Uninstall-SqlDscBIReportServer.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Uninstall-SqlDscBIReportServer' -Tag @('Integration_PowerBI') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose

--- a/tests/Integration/Commands/Uninstall-SqlDscReportingService.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Uninstall-SqlDscReportingService.Integration.Tests.ps1
@@ -23,6 +23,12 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 Describe 'Uninstall-SqlDscReportingService' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose

--- a/tests/Integration/Commands/Uninstall-SqlDscServer.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Uninstall-SqlDscServer.Integration.Tests.ps1
@@ -23,8 +23,14 @@ BeforeDiscovery {
     }
 }
 
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
 # cSpell: ignore DSCSQLTEST
-Describe 'Uninstall-SqlDscServer' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+Describe 'Uninstall-SqlDscServer' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
         Write-Verbose -Message ('Running integration test as user ''{0}''.' -f $env:UserName) -Verbose
 

--- a/tests/Unit/Public/Get-SqlDscServerPermission.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscServerPermission.Tests.ps1
@@ -244,14 +244,16 @@ Describe 'Get-SqlDscServerPermission' -Tag 'Public' {
                 }
             }
 
-            It 'Should call Test-SqlDscIsLogin but not Test-SqlDscIsRole when login is found' {
+            It 'Should call both Test-SqlDscIsLogin and Test-SqlDscIsRole' {
                 $null = Get-SqlDscServerPermission -ServerObject $mockServerObject -Name 'TestPrincipal' -ErrorAction 'SilentlyContinue'
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter {
                     $ServerObject.Equals($mockServerObject) -and $Name -eq 'TestPrincipal'
                 } -Exactly -Times 1
 
-                Should -Invoke -CommandName Test-SqlDscIsRole -Exactly -Times 0
+                Should -Invoke -CommandName Test-SqlDscIsRole -ParameterFilter {
+                    $ServerObject.Equals($mockServerObject) -and $Name -eq 'TestPrincipal'
+                } -Exactly -Times 1
             }
         }
 
@@ -266,7 +268,7 @@ Describe 'Get-SqlDscServerPermission' -Tag 'Public' {
                 }
             }
 
-            It 'Should call both Test-SqlDscIsLogin and Test-SqlDscIsRole when login is not found' {
+            It 'Should call both Test-SqlDscIsLogin and Test-SqlDscIsRole' {
                 $null = Get-SqlDscServerPermission -ServerObject $mockServerObject -Name 'TestPrincipal' -ErrorAction 'SilentlyContinue'
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter {
@@ -334,14 +336,16 @@ Describe 'Get-SqlDscServerPermission' -Tag 'Public' {
                 }
             }
 
-            It 'Should call Test-SqlDscIsLogin but not Test-SqlDscIsRole when login is found' {
+            It 'Should call both Test-SqlDscIsLogin and Test-SqlDscIsRole when both types are specified' {
                 $null = Get-SqlDscServerPermission -ServerObject $mockServerObject -Name 'TestPrincipal' -PrincipalType 'Login', 'Role' -ErrorAction 'SilentlyContinue'
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter {
                     $ServerObject.Equals($mockServerObject) -and $Name -eq 'TestPrincipal'
                 } -Exactly -Times 1
 
-                Should -Invoke -CommandName Test-SqlDscIsRole -Exactly -Times 0
+                Should -Invoke -CommandName Test-SqlDscIsRole -ParameterFilter {
+                    $ServerObject.Equals($mockServerObject) -and $Name -eq 'TestPrincipal'
+                } -Exactly -Times 1
             }
         }
     }

--- a/tests/Unit/Public/Get-SqlDscServerPermission.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscServerPermission.Tests.ps1
@@ -242,7 +242,7 @@ Describe 'Get-SqlDscServerPermission' -Tag 'Public' {
         }
 
         It 'Should call both Test-SqlDscIsLogin and Test-SqlDscIsRole' {
-            Get-SqlDscServerPermission -ServerObject $mockServerObject -Name 'TestPrincipal' -ErrorAction 'SilentlyContinue'
+            $null = Get-SqlDscServerPermission -ServerObject $mockServerObject -Name 'TestPrincipal' -ErrorAction 'SilentlyContinue'
 
             Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter {
                 $ServerObject.Equals($mockServerObject) -and $Name -eq 'TestPrincipal'

--- a/tests/Unit/Public/Revoke-SqlDscServerPermission.Tests.ps1
+++ b/tests/Unit/Public/Revoke-SqlDscServerPermission.Tests.ps1
@@ -115,27 +115,15 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
         }
 
         It 'Should revoke permissions from a login' {
-            InModuleScope -Parameters @{
-                mockLogin = $mockLogin
-            } -ScriptBlock {
-                $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force
-            }
+            $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force
         }
 
         It 'Should revoke permissions from a server role' {
-            InModuleScope -Parameters @{
-                mockServerRole = $mockServerRole
-            } -ScriptBlock {
-                $null = Revoke-SqlDscServerPermission -ServerRole $mockServerRole -Permission 'ConnectSql' -Force
-            }
+            $null = Revoke-SqlDscServerPermission -ServerRole $mockServerRole -Permission 'ConnectSql' -Force
         }
 
         It 'Should handle WithGrant parameter correctly' {
-            InModuleScope -Parameters @{
-                mockLogin = $mockLogin
-            } -ScriptBlock {
-                $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -WithGrant -Force
-            }
+            $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -WithGrant -Force
         }
     }
 
@@ -154,12 +142,8 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
         }
 
         It 'Should throw a descriptive error when operation fails' {
-            InModuleScope -Parameters @{
-                mockLogin = $mockLogin
-            } -ScriptBlock {
-                { Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force } |
-                    Should -Throw -ExpectedMessage '*Failed to revoke server permissions*'
-            }
+            { Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force } |
+                Should -Throw -ExpectedMessage '*Failed to revoke server permissions*'
         }
     }
 
@@ -179,19 +163,11 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
         }
 
         It 'Should accept Login from pipeline' {
-            InModuleScope -Parameters @{
-                mockLogin = $mockLogin
-            } -ScriptBlock {
-                $null = $mockLogin | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
-            }
+            $null = $mockLogin | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
         }
 
         It 'Should accept ServerRole from pipeline' {
-            InModuleScope -Parameters @{
-                mockServerRole = $mockServerRole
-            } -ScriptBlock {
-                $null = $mockServerRole | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
-            }
+            $null = $mockServerRole | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
         }
     }
 }

--- a/tests/Unit/Public/Revoke-SqlDscServerPermission.Tests.ps1
+++ b/tests/Unit/Public/Revoke-SqlDscServerPermission.Tests.ps1
@@ -104,8 +104,8 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
             $mockServerObject.InstanceName = 'MockInstance'
 
-            $mockLogin = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList $mockServerObject, 'TestUser'
-            $mockServerRole = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.ServerRole' -ArgumentList $mockServerObject, 'TestRole'
+            $script:mockLogin = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList $mockServerObject, 'TestUser'
+            $script:mockServerRole = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.ServerRole' -ArgumentList $mockServerObject, 'TestRole'
 
             # Mock the Revoke method on the server object
             $mockServerObject | Add-Member -MemberType ScriptMethod -Name 'Revoke' -Value {
@@ -115,15 +115,15 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
         }
 
         It 'Should revoke permissions from a login' {
-            $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force
+            $null = Revoke-SqlDscServerPermission -Login $script:mockLogin -Permission 'ConnectSql' -Force
         }
 
         It 'Should revoke permissions from a server role' {
-            $null = Revoke-SqlDscServerPermission -ServerRole $mockServerRole -Permission 'ConnectSql' -Force
+            $null = Revoke-SqlDscServerPermission -ServerRole $script:mockServerRole -Permission 'ConnectSql' -Force
         }
 
         It 'Should handle WithGrant parameter correctly' {
-            $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -WithGrant -Force
+            $null = Revoke-SqlDscServerPermission -Login $script:mockLogin -Permission 'ConnectSql' -WithGrant -Force
         }
     }
 
@@ -132,7 +132,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
             $mockServerObject.InstanceName = 'MockInstance'
 
-            $mockLogin = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList $mockServerObject, 'TestUser'
+            $script:mockLogin = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList $mockServerObject, 'TestUser'
 
             # Mock the Revoke method to throw an error
             $mockServerObject | Add-Member -MemberType ScriptMethod -Name 'Revoke' -Value {
@@ -142,7 +142,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
         }
 
         It 'Should throw a descriptive error when operation fails' {
-            { Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force } |
+            { Revoke-SqlDscServerPermission -Login $script:mockLogin -Permission 'ConnectSql' -Force } |
                 Should -Throw -ExpectedMessage '*Failed to revoke server permissions*'
         }
     }
@@ -152,8 +152,8 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
             $mockServerObject.InstanceName = 'MockInstance'
 
-            $mockLogin = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList $mockServerObject, 'TestUser'
-            $mockServerRole = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.ServerRole' -ArgumentList $mockServerObject, 'TestRole'
+            $script:mockLogin = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList $mockServerObject, 'TestUser'
+            $script:mockServerRole = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.ServerRole' -ArgumentList $mockServerObject, 'TestRole'
 
             # Mock the Revoke method on the server object
             $mockServerObject | Add-Member -MemberType ScriptMethod -Name 'Revoke' -Value {
@@ -163,11 +163,11 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
         }
 
         It 'Should accept Login from pipeline' {
-            $null = $mockLogin | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
+            $null = $script:mockLogin | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
         }
 
         It 'Should accept ServerRole from pipeline' {
-            $null = $mockServerRole | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
+            $null = $script:mockServerRole | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
         }
     }
 }

--- a/tests/Unit/Public/Revoke-SqlDscServerPermission.Tests.ps1
+++ b/tests/Unit/Public/Revoke-SqlDscServerPermission.Tests.ps1
@@ -118,7 +118,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             InModuleScope -Parameters @{
                 mockLogin = $mockLogin
             } -ScriptBlock {
-                $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission ConnectSql -Force
+                $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force
             }
         }
 
@@ -126,7 +126,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             InModuleScope -Parameters @{
                 mockServerRole = $mockServerRole
             } -ScriptBlock {
-                $null = Revoke-SqlDscServerPermission -ServerRole $mockServerRole -Permission ConnectSql -Force
+                $null = Revoke-SqlDscServerPermission -ServerRole $mockServerRole -Permission 'ConnectSql' -Force
             }
         }
 
@@ -134,7 +134,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             InModuleScope -Parameters @{
                 mockLogin = $mockLogin
             } -ScriptBlock {
-                $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission ConnectSql -WithGrant -Force
+                $null = Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -WithGrant -Force
             }
         }
     }
@@ -157,7 +157,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             InModuleScope -Parameters @{
                 mockLogin = $mockLogin
             } -ScriptBlock {
-                { Revoke-SqlDscServerPermission -Login $mockLogin -Permission ConnectSql -Force } |
+                { Revoke-SqlDscServerPermission -Login $mockLogin -Permission 'ConnectSql' -Force } |
                     Should -Throw -ExpectedMessage '*Failed to revoke server permissions*'
             }
         }
@@ -182,7 +182,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             InModuleScope -Parameters @{
                 mockLogin = $mockLogin
             } -ScriptBlock {
-                $null = $mockLogin | Revoke-SqlDscServerPermission -Permission ConnectSql -Force
+                $null = $mockLogin | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
             }
         }
 
@@ -190,7 +190,7 @@ Describe 'Revoke-SqlDscServerPermission' -Tag 'Public' {
             InModuleScope -Parameters @{
                 mockServerRole = $mockServerRole
             } -ScriptBlock {
-                $null = $mockServerRole | Revoke-SqlDscServerPermission -Permission ConnectSql -Force
+                $null = $mockServerRole | Revoke-SqlDscServerPermission -Permission 'ConnectSql' -Force
             }
         }
     }


### PR DESCRIPTION

#### Pull Request (PR) description
- `Get-SqlDscServerPermission`
  - Enhanced the command to support server roles in addition to logins by utilizing
    `Test-SqlDscIsRole` alongside the existing `Test-SqlDscIsLogin` check.
  - The function now accepts both login principals and server role principals
    as the `Name` parameter.

#### This Pull Request (PR) fixes the following issues

- Fixes #2063 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2131)
<!-- Reviewable:end -->
