### PR TITLE
`New-SqlDscLogin`: command to create SQL Server logins

### DIFF
--- a/.build/Test-ShouldRunDscResourceIntegrationTests.ps1
+++ b/.build/Test-ShouldRunDscResourceIntegrationTests.ps1
@@ -413,7 +413,7 @@ function Test-ShouldRunDscResourceIntegrationTests
     }
 
     # Check if any public commands used by DSC resources are changed
-    $changedPublicCommands = $changedFiles | Where-Object -FilterScript { $_ -match '^source/Public/(.+)\.ps1$' } | 
+    $changedPublicCommands = $changedFiles | Where-Object -FilterScript { $_ -match '^source/Public/(.+)\.ps1$' } |
         ForEach-Object -Process { [System.IO.Path]::GetFileNameWithoutExtension((Split-Path -Path $_ -Leaf)) }
 
     $affectedCommands = $changedPublicCommands | Where-Object -FilterScript { $_ -in $PublicCommandsUsedByDscResources }
@@ -428,7 +428,7 @@ function Test-ShouldRunDscResourceIntegrationTests
     }
 
     # Check if any private functions used by the affected public commands or class-based DSC resources are changed
-    $changedPrivateFunctions = $changedFiles | Where-Object -FilterScript { $_ -match '^source/Private/(.+)\.ps1$' } | 
+    $changedPrivateFunctions = $changedFiles | Where-Object -FilterScript { $_ -match '^source/Private/(.+)\.ps1$' } |
         ForEach-Object -Process { [System.IO.Path]::GetFileNameWithoutExtension((Split-Path -Path $_ -Leaf)) }
 
     $affectedPrivateFunctions = @()
@@ -489,10 +489,6 @@ if ($MyInvocation.InvocationName -ne '.')
     {
         Write-Host "RESULT: DSC resource integration tests will be SKIPPED"
     }
-
-    # Output the result for the calling script to capture
-    Write-Output -InputObject ""
-    Write-Output -InputObject "ShouldRunDscResourceIntegrationTests: $shouldRun"
 
     # Return the boolean value for pipeline script to use
     return $shouldRun

--- a/.github/instructions/dsc-community-style-guidelines-markdown.instructions.md
+++ b/.github/instructions/dsc-community-style-guidelines-markdown.instructions.md
@@ -5,7 +5,7 @@ applyTo: "**/*.md"
 
 # Markdown Style Guidelines
 
-- Wrap lines after word when over 80 characters
+- Wrap lines at word boundaries when over 80 characters
 - Use 2 spaces for indentation
 - Use '1.' for all items in ordered lists (1/1/1 numbering style)
 - Surround fenced code blocks with blank lines

--- a/.github/instructions/dsc-community-style-guidelines-markdown.instructions.md
+++ b/.github/instructions/dsc-community-style-guidelines-markdown.instructions.md
@@ -5,7 +5,7 @@ applyTo: "**/*.md"
 
 # Markdown Style Guidelines
 
-- Wrap lines at 80 characters
+- Wrap lines after word when over 80 characters
 - Use 2 spaces for indentation
 - Use '1.' for all items in ordered lists (1/1/1 numbering style)
 - Surround fenced code blocks with blank lines

--- a/.github/instructions/dsc-community-style-guidelines-powershell.instructions.md
+++ b/.github/instructions/dsc-community-style-guidelines-powershell.instructions.md
@@ -134,6 +134,7 @@ function Get-Something
 - Parameter type on line above parameter name
 - Parameters separated by blank line
 - Parameters should use full type name.
+- Pipeline parameters (`ValueFromPipeline = $true`) must be declared in ALL parameter sets
 
 ## Best Practices
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 .vs
 output/
+coverage.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,7 +81,7 @@
         "DSCSQLTEST",
         "unshallow",
         "pullrequest",
-        "targetbranch"
+        "targetbranch",
         "hqrm",
         "sqlps"
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,7 +83,8 @@
         "pullrequest",
         "targetbranch",
         "hqrm",
-        "sqlps"
+        "sqlps",
+        "securestring"
     ],
     "cSpell.ignorePaths": [
         ".git"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,7 +79,11 @@
         "PBIRS",
         "SSRS",
         "DSCSQLTEST",
-        "unshallow"
+        "unshallow",
+        "pullrequest",
+        "targetbranch"
+        "hqrm",
+        "sqlps"
     ],
     "cSpell.ignorePaths": [
         ".git"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,7 +84,9 @@
         "targetbranch",
         "hqrm",
         "sqlps",
-        "securestring"
+        "securestring",
+        "encryptorname",
+        "wsfc"
     ],
     "cSpell.ignorePaths": [
         ".git"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -129,6 +129,54 @@
                     ]
                 }
             ]
+        },
+        {
+            "label": "hqrmtest",
+            "type": "shell",
+            "command": "&${cwd}/build.ps1",
+            "args": [
+                "-AutoRestore",
+                "-UseModuleFast",
+                "-Tasks",
+                "hqrmtest",
+                "-CodeCoverageThreshold",
+                "0"
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "dedicated",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "problemMatcher": [
+                {
+                    "owner": "powershell",
+                    "fileLocation": [
+                        "absolute"
+                    ],
+                    "severity": "error",
+                    "pattern": [
+                        {
+                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
+                            "message": 1
+                        },
+                        {
+                            "regexp": "(.*)",
+                            "code": 1
+                        },
+                        {
+                            "regexp": ""
+                        },
+                        {
+                            "regexp": "^.*,\\s*(.*):\\s*line\\s*(\\d+).*",
+                            "file": 1,
+                            "line": 2
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -84,7 +84,16 @@
             "label": "test",
             "type": "shell",
             "command": "&${cwd}/build.ps1",
-            "args": ["-AutoRestore", "-UseModuleFast", "-Tasks", "test"],
+            "args": [
+                "-AutoRestore",
+                "-UseModuleFast",
+                "-Tasks",
+                "test",
+                "-PesterPath",
+                "./tests/Unit/Classes,./tests/Unit/Private,./tests/Unit/Public,./tests/QA",
+                "-CodeCoverageThreshold",
+                "0"
+            ],
             "presentation": {
                 "echo": true,
                 "reveal": "always",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Includes a `-Refresh` parameter to refresh the server's login collection
     before attempting removal.
   - Provides detailed error messages with localization support.
+- `New-SqlDscLogin`
+  - Added new public command to create a new login on a SQL Server Database
+    Engine instance.
+  - Supports creating SQL Server logins, Windows user logins, Windows group
+    logins, certificate-based logins, and asymmetric key-based logins.
 
 ### Changed
 
 - Module now outputs a verbose message instead of a warning when the SMO
   dependency module is missing during import to work around a DSC v3 issue.
 - VS Code tasks configuration was improved to support AI.
+- `Prerequisites` tests
+  - Added creation of `SqlIntegrationTest` local Windows user for integration testing.
+- `tests/Integration/Commands/README.md`
+  - Added documentation for `SqlIntegrationTest` user and
+    `IntegrationTestSqlLogin` login.
+  - Added run order information for `New-SqlDscLogin` integration test.
 - `azure-pipelines.yml`
   - Remove `windows-2019` images fixes [#2106](https://github.com/dsccommunity/SqlServerDsc/issues/2106).
   - Move individual tasks to `windows-latest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make sure tests forcibly imports the module being tested to avoid AI failing
   when testing changes.
+- Fixed Azure DevOps pipeline conditions that were preventing DSC resource
+  integration tests from running when they should by removing incorrect quotes
+  around boolean values.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Engine instance.
   - Supports creating SQL Server logins, Windows user logins, Windows group
     logins, certificate-based logins, and asymmetric key-based logins.
+  - Implements proper parameter sets to prevent combining hashed passwords
+    with password policy options, following SQL Server restrictions.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,7 +296,7 @@ be compiled to a .mof file. If the tests find any errors the build will fail.
 
 A terminating error is an error that prevents the resource to continue further.
 If a DSC resource shall throw an terminating error the commands of the module
-**DscResource.Common** shall be used primarily; [`New-InvalidArgumentException`](https://github.com/dsccommunity/DscResource.Common#new-invalidargumentexception),
+**DscResource.Common** shall be used primarily; [`New-ArgumentException`](https://github.com/dsccommunity/DscResource.Common#new-invalidargumentexception),
 [`New-InvalidDataExcpetion`](https://github.com/dsccommunity/DscResource.Common#new-invaliddataexception),
 [`New-InvalidOperationException`](https://github.com/dsccommunity/DscResource.Common#new-invalidoperationexception),
 [`New-InvalidResultException`](https://github.com/dsccommunity/DscResource.Common#new-invalidresultexception),

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,9 +104,34 @@ stages:
                 # Run the script to determine if DSC resource integration tests should run
                 $shouldRun = ./.build/Test-ShouldRunDscResourceIntegrationTests.ps1 -BaseBranch $targetBranch -CurrentBranch HEAD
 
+                # Debug: print computed value before exporting as output
+                Write-Host "Computed ShouldRunDscResourceIntegrationTests: $shouldRun"
+
                 # Set Azure DevOps output variable for pipeline conditions
                 Write-Host "##vso[task.setvariable variable=ShouldRunDscResourceIntegrationTests;isOutput=true]$shouldRun"
               pwsh: true
+
+      - job: Debug_DSC_Resource_Test_Flag
+        displayName: 'Debug: DSC Resource Test Flag'
+        dependsOn: Determine_DSC_Resource_Test_Requirements
+        pool:
+          vmImage: 'windows-latest'
+        variables:
+          # Read the job output from the previous job via dependencies
+          ShouldRun: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
+        steps:
+          - pwsh: |
+              $val = '$(ShouldRun)'
+              Write-Host "Dependency output ShouldRunDscResourceIntegrationTests = '$val'"
+              $lower = $val.ToLower()
+              Write-Host "Lowercased = '$lower'"
+              if ($lower -eq 'true') {
+                  Write-Host "Stage condition eq(toLower(...), 'true') would be TRUE"
+              }
+              else {
+                  Write-Host "Stage condition eq(toLower(...), 'true') would be FALSE"
+              }
+            displayName: 'Echo dependency output variable'
 
       - job: Test_HQRM
         displayName: 'HQRM'
@@ -440,7 +465,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
+        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
       )
     jobs:
       - job: Test_Integration
@@ -538,7 +563,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
+        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
       )
     jobs:
       - job: Test_Integration
@@ -633,7 +658,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
+        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
       )
     jobs:
       - job: Test_Integration
@@ -709,7 +734,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
+        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
       )
     jobs:
       - job: Test_Integration
@@ -776,7 +801,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
+        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,27 +115,6 @@ stages:
                 Write-Host "##vso[task.setvariable variable=ShouldRunDscResourceIntegrationTests;isOutput=true]$shouldRunNormalized"
               pwsh: true
 
-      - job: Debug_DSC_Resource_Test_Flag
-        displayName: 'Debug: DSC Resource Test Flag'
-        dependsOn: Determine_DSC_Resource_Test_Requirements
-        pool:
-          vmImage: 'windows-latest'
-        variables:
-          # Use the correct output format: step_name.variable_name (both lowercase)
-          ShouldRun: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
-        steps:
-          - pwsh: |
-              Write-Host "Main output: '$(ShouldRun)'"
-
-              # Test which one has a clean value
-              if ('$(ShouldRun)' -eq 'true') {
-                Write-Host "SUCCESS: Output eq 'true' - Stage conditions should work"
-              } else {
-                Write-Host "PROBLEM: Output does not equal 'true'"
-                Write-Host "Output: [$(ShouldRun)]"
-              }
-            displayName: 'Echo dependency output variable'
-
       - job: Test_HQRM
         displayName: 'HQRM'
         pool:
@@ -468,7 +447,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -566,7 +545,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -661,7 +640,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -737,7 +716,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -804,7 +783,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,6 +113,8 @@ stages:
 
                 # Set Azure DevOps output variable for pipeline conditions
                 Write-Host "##vso[task.setvariable variable=ShouldRunDscResourceIntegrationTests;isOutput=true]$shouldRunNormalized"
+                # Also set a short alias for easier referencing (lowercase name)
+                Write-Host "##vso[task.setvariable variable=runDscResIT;isOutput=true]$shouldRunNormalized"
               pwsh: true
 
       - job: Debug_DSC_Resource_Test_Flag
@@ -121,16 +123,19 @@ stages:
         pool:
           vmImage: 'windows-latest'
         variables:
-          # Read the job output from the previous job via dependencies
-          ShouldRun: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
+          # Read the job output from the previous job via dependencies (both casings)
+          ShouldRunUpper: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
+          ShouldRunLower: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.shouldrundscresourceintegrationtests'] ]
+          ShouldRunShort: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'] ]
         steps:
           - pwsh: |
-              $val = '$(ShouldRun)'
-              Write-Host "Dependency output ShouldRunDscResourceIntegrationTests = '$val'"
-              if ($val -eq 'true') {
+              Write-Host "dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] = '$(ShouldRunUpper)'"
+              Write-Host "dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.shouldrundscresourceintegrationtests'] = '$(ShouldRunLower)'"
+              Write-Host "dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'] = '$(ShouldRunShort)'"
+
+              if ('$(ShouldRunLower)' -eq 'true' -or '$(ShouldRunShort)' -eq 'true') {
                 Write-Host "Stage condition eq(..., 'true') would be TRUE"
-              }
-              else {
+              } else {
                 Write-Host "Stage condition eq(..., 'true') would be FALSE"
               }
             displayName: 'Echo dependency output variable'
@@ -467,7 +472,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -565,7 +570,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -660,7 +665,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -736,7 +741,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -803,7 +808,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,8 +92,9 @@ stages:
               targetType: 'inline'
               script: |
                 # Set the target branch for comparison
-                $targetBranch = "origin/$(System.PullRequest.TargetBranch)"
-                if (-not $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+                if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+                    $targetBranch = "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
+                } else {
                     $targetBranch = "origin/main"
                 }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -447,7 +447,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true'))
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,8 +107,12 @@ stages:
                 # Debug: print computed value before exporting as output
                 Write-Host "Computed ShouldRunDscResourceIntegrationTests: $shouldRun"
 
+                # Normalize to lowercase string so conditions can use a simple string comparison
+                $shouldRunNormalized = ([string] $shouldRun).ToLower()
+                Write-Host "Normalized ShouldRunDscResourceIntegrationTests: $shouldRunNormalized"
+
                 # Set Azure DevOps output variable for pipeline conditions
-                Write-Host "##vso[task.setvariable variable=ShouldRunDscResourceIntegrationTests;isOutput=true]$shouldRun"
+                Write-Host "##vso[task.setvariable variable=ShouldRunDscResourceIntegrationTests;isOutput=true]$shouldRunNormalized"
               pwsh: true
 
       - job: Debug_DSC_Resource_Test_Flag
@@ -123,13 +127,11 @@ stages:
           - pwsh: |
               $val = '$(ShouldRun)'
               Write-Host "Dependency output ShouldRunDscResourceIntegrationTests = '$val'"
-              $lower = $val.ToLower()
-              Write-Host "Lowercased = '$lower'"
-              if ($lower -eq 'true') {
-                  Write-Host "Stage condition eq(toLower(...), 'true') would be TRUE"
+              if ($val -eq 'true') {
+                Write-Host "Stage condition eq(..., 'true') would be TRUE"
               }
               else {
-                  Write-Host "Stage condition eq(toLower(...), 'true') would be FALSE"
+                Write-Host "Stage condition eq(..., 'true') would be FALSE"
               }
             displayName: 'Echo dependency output variable'
 
@@ -465,7 +467,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -563,7 +565,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -658,7 +660,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -734,7 +736,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -801,7 +803,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(toLower(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests']), 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -447,7 +447,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true'))
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -545,7 +545,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -640,7 +640,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -716,7 +716,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -783,7 +783,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'true')
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,8 +113,6 @@ stages:
 
                 # Set Azure DevOps output variable for pipeline conditions
                 Write-Host "##vso[task.setvariable variable=ShouldRunDscResourceIntegrationTests;isOutput=true]$shouldRunNormalized"
-                # Also set a short alias for easier referencing (lowercase name)
-                Write-Host "##vso[task.setvariable variable=runDscResIT;isOutput=true]$shouldRunNormalized"
               pwsh: true
 
       - job: Debug_DSC_Resource_Test_Flag
@@ -124,22 +122,17 @@ stages:
           vmImage: 'windows-latest'
         variables:
           # Use the correct output format: step_name.variable_name (both lowercase)
-          ShouldRunMain: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
-          ShouldRunAlias: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'] ]
+          ShouldRun: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
         steps:
           - pwsh: |
-              Write-Host "Main output: '$(ShouldRunMain)'"
-              Write-Host "Alias output: '$(ShouldRunAlias)'"
+              Write-Host "Main output: '$(ShouldRun)'"
 
               # Test which one has a clean value
-              if ('$(ShouldRunAlias)' -eq 'true') {
-                Write-Host "SUCCESS: Alias output eq 'true' - Stage conditions should work"
-              } elseif ('$(ShouldRunMain)' -eq 'true') {
-                Write-Host "SUCCESS: Main output eq 'true' - Stage conditions should work"
+              if ('$(ShouldRun)' -eq 'true') {
+                Write-Host "SUCCESS: Output eq 'true' - Stage conditions should work"
               } else {
-                Write-Host "PROBLEM: Neither output equals 'true'"
-                Write-Host "Main: [$(ShouldRunMain)]"
-                Write-Host "Alias: [$(ShouldRunAlias)]"
+                Write-Host "PROBLEM: Output does not equal 'true'"
+                Write-Host "Output: [$(ShouldRun)]"
               }
             displayName: 'Echo dependency output variable'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -440,7 +440,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'True')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
       )
     jobs:
       - job: Test_Integration
@@ -538,7 +538,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'True')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
       )
     jobs:
       - job: Test_Integration
@@ -633,7 +633,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'True')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
       )
     jobs:
       - job: Test_Integration
@@ -709,7 +709,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'True')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
       )
     jobs:
       - job: Test_Integration
@@ -776,7 +776,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], 'True')
+        eq(dependencies.Quality_Test_and_Unit_Test.outputs['Determine_DSC_Resource_Test_Requirements.determineDscResourceTests.ShouldRunDscResourceIntegrationTests'], True)
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,20 +123,23 @@ stages:
         pool:
           vmImage: 'windows-latest'
         variables:
-          # Read the job output from the previous job via dependencies (both casings)
-          ShouldRunUpper: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
-          ShouldRunLower: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.shouldrundscresourceintegrationtests'] ]
-          ShouldRunShort: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'] ]
+          # Use the correct output format: step_name.variable_name (both lowercase)
+          ShouldRunMain: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] ]
+          ShouldRunAlias: $[ dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'] ]
         steps:
           - pwsh: |
-              Write-Host "dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.ShouldRunDscResourceIntegrationTests'] = '$(ShouldRunUpper)'"
-              Write-Host "dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.shouldrundscresourceintegrationtests'] = '$(ShouldRunLower)'"
-              Write-Host "dependencies.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'] = '$(ShouldRunShort)'"
+              Write-Host "Main output: '$(ShouldRunMain)'"
+              Write-Host "Alias output: '$(ShouldRunAlias)'"
 
-              if ('$(ShouldRunLower)' -eq 'true' -or '$(ShouldRunShort)' -eq 'true') {
-                Write-Host "Stage condition eq(..., 'true') would be TRUE"
+              # Test which one has a clean value
+              if ('$(ShouldRunAlias)' -eq 'true') {
+                Write-Host "SUCCESS: Alias output eq 'true' - Stage conditions should work"
+              } elseif ('$(ShouldRunMain)' -eq 'true') {
+                Write-Host "SUCCESS: Main output eq 'true' - Stage conditions should work"
               } else {
-                Write-Host "Stage condition eq(..., 'true') would be FALSE"
+                Write-Host "PROBLEM: Neither output equals 'true'"
+                Write-Host "Main: [$(ShouldRunMain)]"
+                Write-Host "Alias: [$(ShouldRunAlias)]"
               }
             displayName: 'Echo dependency output variable'
 
@@ -472,7 +475,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -570,7 +573,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -665,7 +668,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -741,7 +744,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
       )
     jobs:
       - job: Test_Integration
@@ -808,7 +811,7 @@ stages:
     condition: |
       and(
         succeeded(),
-        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determinedscresourcetests.rundscresit'], 'true')
+        eq(stageDependencies.Quality_Test_and_Unit_Test.Determine_DSC_Resource_Test_Requirements.outputs['determineDscResourceTests.runDscResIT'], 'true')
       )
     jobs:
       - job: Test_Integration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ stages:
                 if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
                     $targetBranch = "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
                 } else {
-                    $targetBranch = "origin/main"
+                    $targetBranch = "origin/$(defaultBranch)"
                 }
 
                 Write-Output "Target branch: $targetBranch"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -283,6 +283,7 @@ stages:
                   'tests/Integration/Commands/Connect-SqlDscDatabaseEngine.Integration.Tests.ps1'
                   # Group 2
                   'tests/Integration/Commands/Assert-SqlDscLogin.Integration.Tests.ps1'
+                  'tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1'
                   'tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1'
                   'tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1'
                   # Group 9

--- a/source/Classes/002.DatabasePermission.ps1
+++ b/source/Classes/002.DatabasePermission.ps1
@@ -260,7 +260,7 @@ class DatabasePermission : IComparable, System.IEquatable[Object]
                 $object.GetType().FullName
             )
 
-            New-InvalidArgumentException -ArgumentName 'Object' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'Object' -Message $errorMessage
         }
 
         return $returnValue

--- a/source/Classes/002.ServerPermission.ps1
+++ b/source/Classes/002.ServerPermission.ps1
@@ -197,7 +197,7 @@ class ServerPermission : IComparable, System.IEquatable[Object]
                 $object.GetType().FullName
             )
 
-            New-InvalidArgumentException -ArgumentName 'Object' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'Object' -Message $errorMessage
         }
 
         return $returnValue

--- a/source/Classes/020.SqlAudit.ps1
+++ b/source/Classes/020.SqlAudit.ps1
@@ -519,7 +519,7 @@ class SqlAudit : SqlResourceBase
         {
             $errorMessage = $this.localizedData.BothFileSizePropertiesMustBeSet
 
-            New-InvalidArgumentException -ArgumentName 'MaximumFileSize, MaximumFileSizeUnit' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'MaximumFileSize, MaximumFileSizeUnit' -Message $errorMessage
         }
 
         <#
@@ -530,7 +530,7 @@ class SqlAudit : SqlResourceBase
         {
             $errorMessage = $this.localizedData.MaximumFileSizeValueInvalid
 
-            New-InvalidArgumentException -ArgumentName 'MaximumFileSize' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'MaximumFileSize' -Message $errorMessage
         }
 
         <#
@@ -541,7 +541,7 @@ class SqlAudit : SqlResourceBase
         {
             $errorMessage = $this.localizedData.QueueDelayValueInvalid
 
-            New-InvalidArgumentException -ArgumentName 'QueueDelay' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'QueueDelay' -Message $errorMessage
         }
 
         # ReserveDiskSpace can only be used with MaximumFiles.
@@ -549,7 +549,7 @@ class SqlAudit : SqlResourceBase
         {
             $errorMessage = $this.localizedData.ReservDiskSpaceWithoutMaximumFiles
 
-            New-InvalidArgumentException -ArgumentName 'ReserveDiskSpace' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'ReserveDiskSpace' -Message $errorMessage
         }
 
         # Test so that the path exists.
@@ -557,7 +557,7 @@ class SqlAudit : SqlResourceBase
         {
             $errorMessage = $this.localizedData.PathInvalid -f $properties.Path
 
-            New-InvalidArgumentException -ArgumentName 'Path' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'Path' -Message $errorMessage
         }
     }
 

--- a/source/Classes/020.SqlDatabasePermission.ps1
+++ b/source/Classes/020.SqlDatabasePermission.ps1
@@ -574,7 +574,7 @@ class SqlDatabasePermission : SqlResourceBase
         {
             $errorMessage = $this.localizedData.MustAssignOnePermissionProperty
 
-            New-InvalidArgumentException -ArgumentName 'Permission, PermissionToInclude, PermissionToExclude' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'Permission, PermissionToInclude, PermissionToExclude' -Message $errorMessage
         }
 
         foreach ($currentAssignedPermissionProperty in $assignedPermissionProperty)
@@ -590,7 +590,7 @@ class SqlDatabasePermission : SqlResourceBase
             {
                 $errorMessage = $this.localizedData.DuplicatePermissionState
 
-                New-InvalidArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
+                New-ArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
             }
 
             # A specific permission must only exist in one permission state.
@@ -602,7 +602,7 @@ class SqlDatabasePermission : SqlResourceBase
             {
                 $errorMessage = $this.localizedData.DuplicatePermissionBetweenState
 
-                New-InvalidArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
+                New-ArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
             }
         }
 
@@ -619,7 +619,7 @@ class SqlDatabasePermission : SqlResourceBase
             {
                 $errorMessage = $this.localizedData.MissingPermissionState
 
-                New-InvalidArgumentException -ArgumentName 'Permission' -Message $errorMessage
+                New-ArgumentException -ArgumentName 'Permission' -Message $errorMessage
             }
         }
 
@@ -637,7 +637,7 @@ class SqlDatabasePermission : SqlResourceBase
                     {
                         $errorMessage = $this.localizedData.MustHaveMinimumOnePermissionInState -f $currentAssignedPermissionProperty
 
-                        New-InvalidArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
+                        New-ArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
                     }
                 }
             }

--- a/source/Classes/020.SqlPermission.ps1
+++ b/source/Classes/020.SqlPermission.ps1
@@ -567,7 +567,7 @@ class SqlPermission : SqlResourceBase
         {
             $errorMessage = $this.localizedData.MustAssignOnePermissionProperty
 
-            New-InvalidArgumentException -ArgumentName 'Permission, PermissionToInclude, PermissionToExclude' -Message $errorMessage
+            New-ArgumentException -ArgumentName 'Permission, PermissionToInclude, PermissionToExclude' -Message $errorMessage
         }
 
         foreach ($currentAssignedPermissionProperty in $assignedPermissionProperty)
@@ -583,7 +583,7 @@ class SqlPermission : SqlResourceBase
             {
                 $errorMessage = $this.localizedData.DuplicatePermissionState
 
-                New-InvalidArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
+                New-ArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
             }
 
             # A specific permission must only exist in one permission state.
@@ -595,7 +595,7 @@ class SqlPermission : SqlResourceBase
             {
                 $errorMessage = $this.localizedData.DuplicatePermissionBetweenState
 
-                New-InvalidArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
+                New-ArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
             }
         }
 
@@ -612,7 +612,7 @@ class SqlPermission : SqlResourceBase
             {
                 $errorMessage = $this.localizedData.MissingPermissionState
 
-                New-InvalidArgumentException -ArgumentName 'Permission' -Message $errorMessage
+                New-ArgumentException -ArgumentName 'Permission' -Message $errorMessage
             }
         }
 
@@ -630,7 +630,7 @@ class SqlPermission : SqlResourceBase
                     {
                         $errorMessage = $this.localizedData.MustHaveMinimumOnePermissionInState -f $currentAssignedPermissionProperty
 
-                        New-InvalidArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
+                        New-ArgumentException -ArgumentName $currentAssignedPermissionProperty -Message $errorMessage
                     }
                 }
             }

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -165,7 +165,12 @@ function New-SqlDscLogin
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium', DefaultParameterSetName = 'WindowsUser')]
     param
     (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'WindowsUser', Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'WindowsGroup', Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'SqlLogin', Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'SqlLoginHashed', Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'Certificate', Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'AsymmetricKey', Mandatory = $true, ValueFromPipeline = $true)]
         [Microsoft.SqlServer.Management.Smo.Server]
         $ServerObject,
 

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -281,7 +281,7 @@ function New-SqlDscLogin
         if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
         {
             # Create the login object
-            $loginObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $ServerObject, $Name
+            $loginObject = [Microsoft.SqlServer.Management.Smo.Login]::new($ServerObject, $Name)
 
             # Set login type
             switch ($loginType)

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -4,8 +4,8 @@
 
     .DESCRIPTION
         This command creates a new login on a SQL Server Database Engine instance.
-        The login can be a SQL Server login or a Windows login (user or group).
-
+        The login can be a SQL Server login, a Windows login (user or group),
+        a certificate-based login, or an asymmetric key-based login.
     .PARAMETER ServerObject
         Specifies current server connection object.
 

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -117,6 +117,38 @@
 
         Creates a new SQL Server login and returns the Login object.
 
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | New-SqlDscLogin -Name 'MyAsymKeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyAsymmetricKey'
+
+        Creates a new asymmetric key-based login using the specified asymmetric key.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | New-SqlDscLogin -Name 'MyAsymKeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyAsymmetricKey' -PassThru
+
+        Creates a new asymmetric key-based login and returns the Login object.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $securePassword = ConvertTo-SecureString -String 'NewPassword123!' -AsPlainText -Force
+        $serverObject | New-SqlDscLogin -Name 'ExistingLogin' -SqlLogin -SecurePassword $securePassword -Force
+
+        Replaces an existing SQL Server login named 'ExistingLogin' with a new login using the -Force parameter.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $securePassword = ConvertTo-SecureString -String 'MyPassword123!' -AsPlainText -Force
+        $serverObject | New-SqlDscLogin -Name 'DisabledLogin' -SqlLogin -SecurePassword $securePassword -Disabled
+
+        Creates a new SQL Server login in a disabled state.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | New-SqlDscLogin -Name 'DOMAIN\DisabledUser' -WindowsUser -Disabled -PassThru
+
+        Creates a new disabled Windows user login and returns the Login object.
+
     .OUTPUTS
         `[Microsoft.SqlServer.Management.Smo.Login]` when passing parameter **PassThru**,
          otherwise none.

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -119,13 +119,13 @@
 
     .EXAMPLE
         $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
-        $serverObject | New-SqlDscLogin -Name 'MyAsymKeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyAsymmetricKey'
+        $serverObject | New-SqlDscLogin -Name 'MyAsymmetricKeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyAsymmetricKey'
 
         Creates a new asymmetric key-based login using the specified asymmetric key.
 
     .EXAMPLE
         $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
-        $serverObject | New-SqlDscLogin -Name 'MyAsymKeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyAsymmetricKey' -PassThru
+        $serverObject | New-SqlDscLogin -Name 'MyAsymmetricKeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyAsymmetricKey' -PassThru
 
         Creates a new asymmetric key-based login and returns the Login object.
 
@@ -135,7 +135,7 @@
         $serverObject | New-SqlDscLogin -Name 'ExistingLogin' -SqlLogin -SecurePassword $securePassword -Force
 
         Creates a SQL Server login named 'ExistingLogin' without confirmation prompts.
-+        Note: If the login already exists, the command throws a terminating error.
+        Note: If the login already exists, the command throws a terminating error.
 
     .EXAMPLE
         $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
@@ -153,6 +153,10 @@
     .OUTPUTS
         `[Microsoft.SqlServer.Management.Smo.Login]` when passing parameter **PassThru**,
          otherwise none.
+
+    .INPUTS
+        `[Microsoft.SqlServer.Management.Smo.Server]` Accepted from the pipeline. This cmdlet accepts a SMO Server
+        object (for example, the output of `Connect-SqlDscDatabaseEngine`) via the pipeline.
 
     .NOTES
         This command has the confirm impact level set to medium since a login is

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -267,7 +267,7 @@ function New-SqlDscLogin
             $PSCmdlet.ThrowTerminatingError(
                 [System.Management.Automation.ErrorRecord]::new(
                     $errorMessage,
-                    'ASDL0001', # cspell: disable-line
+                    'NSDL0001', # cspell: disable-line
                     [System.Management.Automation.ErrorCategory]::ResourceExists,
                     $Name
                 )

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -134,7 +134,8 @@
         $securePassword = ConvertTo-SecureString -String 'NewPassword123!' -AsPlainText -Force
         $serverObject | New-SqlDscLogin -Name 'ExistingLogin' -SqlLogin -SecurePassword $securePassword -Force
 
-        Replaces an existing SQL Server login named 'ExistingLogin' with a new login using the -Force parameter.
+        Creates a SQL Server login named 'ExistingLogin' without confirmation prompts.
++        Note: If the login already exists, the command throws a terminating error.
 
     .EXAMPLE
         $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -1,0 +1,321 @@
+<#
+    .SYNOPSIS
+        Creates a new login on a SQL Server Database Engine instance.
+
+    .DESCRIPTION
+        This command creates a new login on a SQL Server Database Engine instance.
+        The login can be a SQL Server login or a Windows login (user or group).
+
+    .PARAMETER ServerObject
+        Specifies current server connection object.
+
+    .PARAMETER Name
+        Specifies the name of the login to be created.
+
+    .PARAMETER SqlLogin
+        Specifies that a SQL Server login should be created.
+
+    .PARAMETER WindowsUser
+        Specifies that a Windows user login should be created.
+
+    .PARAMETER WindowsGroup
+        Specifies that a Windows group login should be created.
+
+    .PARAMETER Certificate
+        Specifies that a certificate-based login should be created.
+
+    .PARAMETER AsymmetricKey
+        Specifies that an asymmetric key-based login should be created.
+
+    .PARAMETER SecurePassword
+        Specifies the password as a SecureString for SQL Server logins. This
+        parameter is required when creating a SQL Server login.
+
+    .PARAMETER CertificateName
+        Specifies the certificate name when creating a certificate-based login.
+
+    .PARAMETER AsymmetricKeyName
+        Specifies the asymmetric key name when creating an asymmetric key-based login.
+
+    .PARAMETER DefaultDatabase
+        Specifies the default database for the login. If not specified,
+        'master' will be used as the default database.
+
+    .PARAMETER DefaultLanguage
+        Specifies the default language for the login.
+
+    .PARAMETER PasswordExpirationEnabled
+        Specifies whether password expiration is enabled for SQL Server logins.
+        Only applies when creating a SQL Server login.
+
+    .PARAMETER PasswordPolicyEnforced
+        Specifies whether password policy is enforced for SQL Server logins.
+        Only applies when creating a SQL Server login.
+
+    .PARAMETER MustChangePassword
+        Specifies whether the user must change the password on next login.
+        Only applies when creating a SQL Server login.
+
+    .PARAMETER IsHashed
+        Specifies whether the provided password is already hashed.
+        Only applies when creating a SQL Server login.
+
+    .PARAMETER Disabled
+        Specifies whether the login should be created in a disabled state.
+
+    .PARAMETER Force
+        Specifies that the login should be created without any confirmation.
+
+    .PARAMETER PassThru
+        If specified, the created login object will be returned.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $securePassword = ConvertTo-SecureString -String 'MyPassword123!' -AsPlainText -Force
+        $serverObject | New-SqlDscLogin -Name 'MyLogin' -SqlLogin -SecurePassword $securePassword
+
+        Creates a new SQL Server login named 'MyLogin' with the specified password.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $securePassword = ConvertTo-SecureString -String 'MyPassword123!' -AsPlainText -Force
+        $serverObject | New-SqlDscLogin -Name 'MyLogin' -SqlLogin -SecurePassword $securePassword -MustChangePassword
+
+        Creates a new SQL Server login named 'MyLogin' with a SecureString password that must be changed on first login.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | New-SqlDscLogin -Name 'DOMAIN\MyUser' -WindowsUser
+
+        Creates a new Windows user login for 'DOMAIN\MyUser'.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | New-SqlDscLogin -Name 'DOMAIN\MyGroup' -WindowsGroup
+
+        Creates a new Windows group login for 'DOMAIN\MyGroup'.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | New-SqlDscLogin -Name 'MyCertLogin' -Certificate -CertificateName 'MyCertificate'
+
+        Creates a new certificate-based login using the specified certificate.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $securePassword = ConvertTo-SecureString -String 'MyPassword123!' -AsPlainText -Force
+        $loginObject = $serverObject | New-SqlDscLogin -Name 'MyLogin' -SqlLogin -SecurePassword $securePassword -PassThru
+
+        Creates a new SQL Server login and returns the Login object.
+
+    .OUTPUTS
+        `[Microsoft.SqlServer.Management.Smo.Login]` when passing parameter **PassThru**,
+         otherwise none.
+
+    .NOTES
+        This command has the confirm impact level set to medium since a login is
+        created but by default it does not have any special permissions.
+#>
+function New-SqlDscLogin
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
+    [OutputType([Microsoft.SqlServer.Management.Smo.Login])]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium', DefaultParameterSetName = 'WindowsUser')]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Microsoft.SqlServer.Management.Smo.Server]
+        $ServerObject,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(ParameterSetName = 'SqlLogin', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $SqlLogin,
+
+        [Parameter(ParameterSetName = 'WindowsUser', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $WindowsUser,
+
+        [Parameter(ParameterSetName = 'WindowsGroup', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $WindowsGroup,
+
+        [Parameter(ParameterSetName = 'Certificate', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $Certificate,
+
+        [Parameter(ParameterSetName = 'AsymmetricKey', Mandatory = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $AsymmetricKey,
+
+        [Parameter(ParameterSetName = 'SqlLogin', Mandatory = $true)]
+        [System.Security.SecureString]
+        $SecurePassword,
+
+        [Parameter(ParameterSetName = 'Certificate', Mandatory = $true)]
+        [System.String]
+        $CertificateName,
+
+        [Parameter(ParameterSetName = 'AsymmetricKey', Mandatory = $true)]
+        [System.String]
+        $AsymmetricKeyName,
+
+        [Parameter()]
+        [System.String]
+        $DefaultDatabase = 'master',
+
+        [Parameter()]
+        [System.String]
+        $DefaultLanguage,
+
+        [Parameter(ParameterSetName = 'SqlLogin')]
+        [System.Management.Automation.SwitchParameter]
+        $PasswordExpirationEnabled,
+
+        [Parameter(ParameterSetName = 'SqlLogin')]
+        [System.Management.Automation.SwitchParameter]
+        $PasswordPolicyEnforced,
+
+        [Parameter(ParameterSetName = 'SqlLogin')]
+        [System.Management.Automation.SwitchParameter]
+        $MustChangePassword,
+
+        [Parameter(ParameterSetName = 'SqlLogin')]
+        [System.Management.Automation.SwitchParameter]
+        $IsHashed,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Disabled,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Force,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru
+    )
+
+    process
+    {
+        if ($Force.IsPresent -and -not $Confirm)
+        {
+            $ConfirmPreference = 'None'
+        }
+
+        # Determine login type from parameter set
+        $loginType = $PSCmdlet.ParameterSetName
+
+        # Check if login already exists
+        if (Test-SqlDscIsLogin -ServerObject $ServerObject -Name $Name)
+        {
+            $errorMessage = $script:localizedData.Login_Add_LoginAlreadyExists -f $Name, $ServerObject.InstanceName
+
+            $PSCmdlet.ThrowTerminatingError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    $errorMessage,
+                    'ASDL0001', # cspell: disable-line
+                    [System.Management.Automation.ErrorCategory]::ResourceExists,
+                    $Name
+                )
+            )
+        }
+
+        $verboseDescriptionMessage = $script:localizedData.Login_Add_ShouldProcessVerboseDescription -f $Name, $ServerObject.InstanceName
+        $verboseWarningMessage = $script:localizedData.Login_Add_ShouldProcessVerboseWarning -f $Name
+        $captionMessage = $script:localizedData.Login_Add_ShouldProcessCaption
+
+        if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
+        {
+            Write-Verbose -Message ($script:localizedData.Login_Add_CreatingLogin -f $Name, $loginType)
+
+            # Create the login object
+            $loginObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $ServerObject, $Name
+
+            # Set login type
+            switch ($loginType)
+            {
+                'SqlLogin'
+                {
+                    $loginObject.LoginType = [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin
+                }
+
+                'WindowsUser'
+                {
+                    $loginObject.LoginType = [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser
+                }
+
+                'WindowsGroup'
+                {
+                    $loginObject.LoginType = [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsGroup
+                }
+
+                'Certificate'
+                {
+                    $loginObject.LoginType = [Microsoft.SqlServer.Management.Smo.LoginType]::Certificate
+                    $loginObject.Certificate = $CertificateName
+                }
+
+                'AsymmetricKey'
+                {
+                    $loginObject.LoginType = [Microsoft.SqlServer.Management.Smo.LoginType]::AsymmetricKey
+                    $loginObject.AsymmetricKey = $AsymmetricKeyName
+                }
+            }
+
+            # Set default database
+            $loginObject.DefaultDatabase = $DefaultDatabase
+
+            # Set default language if specified
+            if ($PSBoundParameters.ContainsKey('DefaultLanguage'))
+            {
+                $loginObject.Language = $DefaultLanguage
+            }
+
+            # Set SQL Server login specific properties
+            if ($loginType -eq 'SqlLogin')
+            {
+                $loginObject.PasswordExpirationEnabled = $PasswordExpirationEnabled.IsPresent
+                $loginObject.PasswordPolicyEnforced = $PasswordPolicyEnforced.IsPresent
+
+                # Prepare login creation options
+                $loginCreateOptions = [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::None
+
+                if ($MustChangePassword.IsPresent)
+                {
+                    $loginCreateOptions = $loginCreateOptions -bor [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::MustChange
+                }
+
+                if ($IsHashed.IsPresent)
+                {
+                    $loginCreateOptions = $loginCreateOptions -bor [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::IsHashed
+                }
+
+                # Create the login with password
+                $loginObject.Create($SecurePassword, $loginCreateOptions)
+            }
+            else
+            {
+                # Create login without password for Windows logins, Certificate, and AsymmetricKey
+                $loginObject.Create()
+            }
+
+            # Disable login if requested
+            if ($Disabled.IsPresent)
+            {
+                $loginObject.Disable()
+            }
+
+            Write-Verbose -Message ($script:localizedData.Login_Add_LoginCreated -f $Name, $ServerObject.InstanceName)
+
+            if ($PassThru.IsPresent)
+            {
+                return $loginObject
+            }
+        }
+    }
+}

--- a/source/Public/New-SqlDscLogin.ps1
+++ b/source/Public/New-SqlDscLogin.ps1
@@ -225,14 +225,12 @@ function New-SqlDscLogin
             )
         }
 
-        $verboseDescriptionMessage = $script:localizedData.Login_Add_ShouldProcessVerboseDescription -f $Name, $ServerObject.InstanceName
+        $verboseDescriptionMessage = $script:localizedData.Login_Add_ShouldProcessVerboseDescription -f $Name, $loginType, $ServerObject.InstanceName
         $verboseWarningMessage = $script:localizedData.Login_Add_ShouldProcessVerboseWarning -f $Name
         $captionMessage = $script:localizedData.Login_Add_ShouldProcessCaption
 
         if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
         {
-            Write-Verbose -Message ($script:localizedData.Login_Add_CreatingLogin -f $Name, $loginType)
-
             # Create the login object
             $loginObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $ServerObject, $Name
 

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -240,4 +240,13 @@ ConvertFrom-StringData @'
     Assert_Login_CheckingLogin = Checking if the principal '{0}' exists as a login on the instance '{1}'.
     Assert_Login_LoginMissing = The principal '{0}' does not exist as a login on the instance '{1}'.
     Assert_Login_LoginExists = The principal '{0}' exists as a login.
+
+    ## New-SqlDscLogin
+    Login_Add_ShouldProcessVerboseDescription = Adding the login '{0}' on the instance '{1}'.
+    Login_Add_ShouldProcessVerboseWarning = Are you sure you want to add the login '{0}'?
+    # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
+    Login_Add_ShouldProcessCaption = Add login on instance
+    Login_Add_CreatingLogin = Creating login '{0}' of type '{1}'.
+    Login_Add_LoginCreated = Successfully created login '{0}' on the instance '{1}'.
+    Login_Add_LoginAlreadyExists = The login '{0}' already exists on the instance '{1}'.
 '@

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -242,11 +242,10 @@ ConvertFrom-StringData @'
     Assert_Login_LoginExists = The principal '{0}' exists as a login.
 
     ## New-SqlDscLogin
-    Login_Add_ShouldProcessVerboseDescription = Adding the login '{0}' on the instance '{1}'.
-    Login_Add_ShouldProcessVerboseWarning = Are you sure you want to add the login '{0}'?
+    Login_Add_ShouldProcessVerboseDescription = Creating the login '{0}' of type '{1}' on the instance '{2}'.
+    Login_Add_ShouldProcessVerboseWarning = Are you sure you want to create the login '{0}'?
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
-    Login_Add_ShouldProcessCaption = Add login on instance
-    Login_Add_CreatingLogin = Creating login '{0}' of type '{1}'.
+    Login_Add_ShouldProcessCaption = Create login on instance
     Login_Add_LoginCreated = Successfully created login '{0}' on the instance '{1}'.
     Login_Add_LoginAlreadyExists = The login '{0}' already exists on the instance '{1}'.
 '@

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -248,5 +248,4 @@ ConvertFrom-StringData @'
     Login_Add_ShouldProcessCaption = Create login on instance
     Login_Add_LoginCreated = Successfully created login '{0}' on the instance '{1}'.
     Login_Add_LoginAlreadyExists = The login '{0}' already exists on the instance '{1}'.
-    Login_Add_HashedPasswordPolicyConflict = Hashed passwords cannot be used with password policy options (PasswordExpirationEnabled, PasswordPolicyEnforced, or MustChangePassword). (NSDL0001)
 '@

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -248,4 +248,5 @@ ConvertFrom-StringData @'
     Login_Add_ShouldProcessCaption = Create login on instance
     Login_Add_LoginCreated = Successfully created login '{0}' on the instance '{1}'.
     Login_Add_LoginAlreadyExists = The login '{0}' already exists on the instance '{1}'.
+    Login_Add_HashedPasswordPolicyConflict = Hashed passwords cannot be used with password policy options (PasswordExpirationEnabled, PasswordPolicyEnforced, or MustChangePassword). (NSDL0001)
 '@

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -210,8 +210,8 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             }
         }
 
-        Context 'When testing ShouldProcess functionality' {
-            It 'Should not create a login when using WhatIf' {
+        Context 'When running with WhatIf' {
+            It 'Should not create a login' {
                 $whatIfLoginName = 'IntegrationTestWhatIf'
 
                 $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $whatIfLoginName -SqlLogin -SecurePassword $script:testPassword -WhatIf

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -80,12 +80,12 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             }
 
             It 'Should verify the login type is SqlLogin' {
-                $loginObject = $script:serverObject.Logins[$script:testSqlLoginName]
+                $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName
                 $loginObject.LoginType | Should -Be 'SqlLogin'
             }
 
             It 'Should verify the default database is set correctly' {
-                $loginObject = $script:serverObject.Logins[$script:testSqlLoginName]
+                $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName
                 $loginObject.DefaultDatabase | Should -Be 'master'
             }
 
@@ -96,7 +96,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
                 {
                     { New-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName -SqlLogin -SecurePassword $script:testPassword -DefaultDatabase 'tempdb' -Confirm:$false } | Should -Not -Throw
 
-                    $loginObject = $script:serverObject.Logins[$customLoginName]
+                    $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName
                     $loginObject.DefaultDatabase | Should -Be 'tempdb'
                 }
                 finally
@@ -151,7 +151,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             }
 
             It 'Should throw an error when trying to create a login that already exists' {
-                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Throw -ExpectedMessage "*already exists*"
+                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Throw -ExpectedMessage "*The login '$script:testSqlLoginName' already exists on the instance '$($script:serverObject.InstanceName)'*"
             }
         }
 
@@ -167,7 +167,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                     Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName | Should -BeTrue
 
-                    $loginObject = $script:serverObject.Logins[$script:testWindowsUserName]
+                    $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName
                     $loginObject.LoginType | Should -Be 'WindowsUser'
                 }
                 finally
@@ -189,7 +189,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                     Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName | Should -BeTrue
 
-                    $loginObject = $script:serverObject.Logins[$script:testWindowsGroupName]
+                    $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName
                     $loginObject.LoginType | Should -Be 'WindowsGroup'
                 }
                 finally

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -1,0 +1,237 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Suppressing this rule because Script Analyzer does not understand Pester syntax.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:dscModuleName
+}
+
+Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+    BeforeAll {
+        # Starting the named instance SQL Server service prior to running tests.
+        Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
+
+        $script:instanceName = 'DSCSQLTEST'
+        $script:computerName = Get-ComputerName
+
+        # Test login names - prefixed to avoid conflicts
+        $script:testSqlLoginName = 'IntegrationTestSqlLogin'
+        $script:testWindowsUserName = '{0}\SqlIntegrationTest' -f $script:computerName
+        $script:testWindowsGroupName = 'NT AUTHORITY\SYSTEM'
+    }
+
+    AfterAll {
+        # Stop the named instance SQL Server service to save memory on the build worker.
+        Stop-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
+    }
+
+    Context 'When connecting to SQL Server instance' {
+        BeforeAll {
+            $sqlAdministratorUserName = 'SqlAdmin'
+            $sqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+
+            $script:sqlAdminCredential = [System.Management.Automation.PSCredential]::new($sqlAdministratorUserName, $sqlAdministratorPassword)
+
+            $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:instanceName -Credential $script:sqlAdminCredential
+        }
+
+        AfterAll {
+            # Disconnect from SQL Server
+            if ($script:serverObject)
+            {
+                Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject
+            }
+        }
+
+        Context 'When creating a SQL Server login' {
+            BeforeAll {
+                $script:testPassword = ConvertTo-SecureString -String 'P@ssw0rd123!' -AsPlainText -Force
+            }
+
+            It 'Should create a SQL Server login without error' {
+                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Not -Throw
+            }
+
+            It 'Should verify the SQL Server login was created' {
+                Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName | Should -BeTrue
+            }
+
+            It 'Should verify the login type is SqlLogin' {
+                $loginObject = $script:serverObject.Logins[$script:testSqlLoginName]
+                $loginObject.LoginType | Should -Be 'SqlLogin'
+            }
+
+            It 'Should verify the default database is set correctly' {
+                $loginObject = $script:serverObject.Logins[$script:testSqlLoginName]
+                $loginObject.DefaultDatabase | Should -Be 'master'
+            }
+
+            It 'Should create a SQL Server login with custom default database' {
+                $customLoginName = 'IntegrationTestCustomDb'
+
+                try
+                {
+                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName -SqlLogin -SecurePassword $script:testPassword -DefaultDatabase 'tempdb' -Confirm:$false } | Should -Not -Throw
+
+                    $loginObject = $script:serverObject.Logins[$customLoginName]
+                    $loginObject.DefaultDatabase | Should -Be 'tempdb'
+                }
+                finally
+                {
+                    # Clean up
+                    if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $customLoginName)
+                    {
+                        $script:serverObject.Logins[$customLoginName].Drop()
+                    }
+                }
+            }
+
+            It 'Should create a SQL Server login with PassThru parameter' {
+                $passthroughLoginName = 'IntegrationTestPassThru'
+
+                try
+                {
+                    $result = New-SqlDscLogin -ServerObject $script:serverObject -Name $passthroughLoginName -SqlLogin -SecurePassword $script:testPassword -PassThru -Confirm:$false
+
+                    $result | Should -Not -BeNullOrEmpty
+                    $result.Name | Should -Be $passthroughLoginName
+                    $result.LoginType | Should -Be 'SqlLogin'
+                }
+                finally
+                {
+                    # Clean up
+                    if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $passthroughLoginName)
+                    {
+                        $script:serverObject.Logins[$passthroughLoginName].Drop()
+                    }
+                }
+            }
+
+            It 'Should create a disabled SQL Server login' {
+                $disabledLoginName = 'IntegrationTestDisabled'
+
+                try
+                {
+                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $disabledLoginName -SqlLogin -SecurePassword $script:testPassword -Disabled -Confirm:$false } | Should -Not -Throw
+
+                    $loginObject = $script:serverObject.Logins[$disabledLoginName]
+                    $loginObject.IsDisabled | Should -BeTrue
+                }
+                finally
+                {
+                    # Clean up
+                    if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $disabledLoginName)
+                    {
+                        $script:serverObject.Logins[$disabledLoginName].Drop()
+                    }
+                }
+            }
+
+            It 'Should throw an error when trying to create a login that already exists' {
+                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Throw -ExpectedMessage "*already exists*"
+            }
+        }
+
+        Context 'When creating a Windows user login' {
+            It 'Should create a Windows user login without error' {
+                $windowsLoginName = 'IntegrationTestWindowsUser'
+                $fullWindowsLoginName = '{0}\{1}' -f $script:computerName, $windowsLoginName
+
+                try
+                {
+                    # Using the SqlIntegrationTest user created by Prerequisites integration test
+                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName -WindowsUser -Confirm:$false } | Should -Not -Throw
+
+                    Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName | Should -BeTrue
+
+                    $loginObject = $script:serverObject.Logins[$script:testWindowsUserName]
+                    $loginObject.LoginType | Should -Be 'WindowsUser'
+                }
+                finally
+                {
+                    # Clean up
+                    if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName)
+                    {
+                        $script:serverObject.Logins[$script:testWindowsUserName].Drop()
+                    }
+                }
+            }
+        }
+
+        Context 'When creating a Windows group login' {
+            It 'Should create a Windows group login without error' {
+                try
+                {
+                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName -WindowsGroup -Confirm:$false } | Should -Not -Throw
+
+                    Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName | Should -BeTrue
+
+                    $loginObject = $script:serverObject.Logins[$script:testWindowsGroupName]
+                    $loginObject.LoginType | Should -Be 'WindowsGroup'
+                }
+                finally
+                {
+                    # Clean up
+                    if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName)
+                    {
+                        $script:serverObject.Logins[$script:testWindowsGroupName].Drop()
+                    }
+                }
+            }
+        }
+
+        Context 'When using Force parameter' {
+            It 'Should create a login with Force parameter without confirmation prompt' {
+                $forceLoginName = 'IntegrationTestForce'
+
+                try
+                {
+                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $forceLoginName -SqlLogin -SecurePassword $script:testPassword -Force } | Should -Not -Throw
+
+                    Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $forceLoginName | Should -BeTrue
+                }
+                finally
+                {
+                    # Clean up
+                    if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $forceLoginName)
+                    {
+                        $script:serverObject.Logins[$forceLoginName].Drop()
+                    }
+                }
+            }
+        }
+
+        Context 'When testing ShouldProcess functionality' {
+            It 'Should not create a login when using WhatIf' {
+                $whatIfLoginName = 'IntegrationTestWhatIf'
+
+                { New-SqlDscLogin -ServerObject $script:serverObject -Name $whatIfLoginName -SqlLogin -SecurePassword $script:testPassword -WhatIf } | Should -Not -Throw
+
+                Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $whatIfLoginName | Should -BeFalse
+            }
+        }
+    }
+}

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -72,7 +72,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             }
 
             It 'Should create a SQL Server login without error' {
-                $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false
+                $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Force
             }
 
             It 'Should verify the SQL Server login was created' {
@@ -94,7 +94,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                 try
                 {
-                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName -SqlLogin -SecurePassword $script:testPassword -DefaultDatabase 'tempdb' -Confirm:$false
+                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName -SqlLogin -SecurePassword $script:testPassword -DefaultDatabase 'tempdb' -Force
 
                     $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName
                     $loginObject.DefaultDatabase | Should -Be 'tempdb'
@@ -114,7 +114,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                 try
                 {
-                    $result = New-SqlDscLogin -ServerObject $script:serverObject -Name $passthroughLoginName -SqlLogin -SecurePassword $script:testPassword -PassThru -Confirm:$false
+                    $result = New-SqlDscLogin -ServerObject $script:serverObject -Name $passthroughLoginName -SqlLogin -SecurePassword $script:testPassword -PassThru -Force
 
                     $result | Should -Not -BeNullOrEmpty
                     $result.Name | Should -Be $passthroughLoginName
@@ -135,7 +135,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                 try
                 {
-                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $disabledLoginName -SqlLogin -SecurePassword $script:testPassword -Disabled -Confirm:$false
+                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $disabledLoginName -SqlLogin -SecurePassword $script:testPassword -Disabled -Force
 
                     $loginObject = $script:serverObject.Logins[$disabledLoginName]
                     $loginObject.IsDisabled | Should -BeTrue
@@ -151,19 +151,16 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             }
 
             It 'Should throw an error when trying to create a login that already exists' {
-                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Throw
+                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Force } | Should -Throw
             }
         }
 
         Context 'When creating a Windows user login' {
             It 'Should create a Windows user login without error' {
-                $windowsLoginName = 'IntegrationTestWindowsUser'
-                $fullWindowsLoginName = '{0}\{1}' -f $script:computerName, $windowsLoginName
-
                 try
                 {
                     # Using the SqlIntegrationTest user created by Prerequisites integration test
-                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName -WindowsUser -Confirm:$false
+                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName -WindowsUser -Force
 
                     Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName | Should -BeTrue
 
@@ -183,7 +180,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
         Context 'When creating a Windows group login' {
             It 'Should create a Windows group login without error' {
-                $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName -WindowsGroup -Confirm:$false
+                $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName -WindowsGroup -Force
 
                 Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName | Should -BeTrue
 

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -6,14 +6,14 @@ BeforeDiscovery {
     {
         if (-not (Get-Module -Name 'DscResource.Test'))
         {
-            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
                 & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
-            # If the dependencies has not been resolved, this will throw an error.
+            # If the dependencies have not been resolved, this will throw an error.
             Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
         }
     }

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -40,7 +40,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
         # Test login names - prefixed to avoid conflicts
         $script:testSqlLoginName = 'IntegrationTestSqlLogin'
         $script:testWindowsUserName = '{0}\SqlIntegrationTest' -f $script:computerName
-        $script:testWindowsGroupName = 'NT AUTHORITY\SYSTEM'
+        $script:testWindowsGroupName = '{0}\SqlIntegrationTestGroup' -f $script:computerName
     }
 
     AfterAll {
@@ -72,7 +72,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             }
 
             It 'Should create a SQL Server login without error' {
-                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false
             }
 
             It 'Should verify the SQL Server login was created' {
@@ -94,7 +94,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                 try
                 {
-                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName -SqlLogin -SecurePassword $script:testPassword -DefaultDatabase 'tempdb' -Confirm:$false } | Should -Not -Throw
+                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName -SqlLogin -SecurePassword $script:testPassword -DefaultDatabase 'tempdb' -Confirm:$false
 
                     $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $customLoginName
                     $loginObject.DefaultDatabase | Should -Be 'tempdb'
@@ -135,7 +135,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                 try
                 {
-                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $disabledLoginName -SqlLogin -SecurePassword $script:testPassword -Disabled -Confirm:$false } | Should -Not -Throw
+                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $disabledLoginName -SqlLogin -SecurePassword $script:testPassword -Disabled -Confirm:$false
 
                     $loginObject = $script:serverObject.Logins[$disabledLoginName]
                     $loginObject.IsDisabled | Should -BeTrue
@@ -151,7 +151,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             }
 
             It 'Should throw an error when trying to create a login that already exists' {
-                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Throw -ExpectedMessage "*The login '$script:testSqlLoginName' already exists on the instance '$($script:serverObject.InstanceName)'*"
+                { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testSqlLoginName -SqlLogin -SecurePassword $script:testPassword -Confirm:$false } | Should -Throw
             }
         }
 
@@ -163,7 +163,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
                 try
                 {
                     # Using the SqlIntegrationTest user created by Prerequisites integration test
-                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName -WindowsUser -Confirm:$false } | Should -Not -Throw
+                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName -WindowsUser -Confirm:$false
 
                     Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsUserName | Should -BeTrue
 
@@ -183,23 +183,12 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
         Context 'When creating a Windows group login' {
             It 'Should create a Windows group login without error' {
-                try
-                {
-                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName -WindowsGroup -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName -WindowsGroup -Confirm:$false
 
-                    Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName | Should -BeTrue
+                Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName | Should -BeTrue
 
-                    $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName
-                    $loginObject.LoginType | Should -Be 'WindowsGroup'
-                }
-                finally
-                {
-                    # Clean up
-                    if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName)
-                    {
-                        $script:serverObject.Logins[$script:testWindowsGroupName].Drop()
-                    }
-                }
+                $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testWindowsGroupName
+                $loginObject.LoginType | Should -Be 'WindowsGroup'
             }
         }
 
@@ -209,7 +198,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
                 try
                 {
-                    { New-SqlDscLogin -ServerObject $script:serverObject -Name $forceLoginName -SqlLogin -SecurePassword $script:testPassword -Force } | Should -Not -Throw
+                    $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $forceLoginName -SqlLogin -SecurePassword $script:testPassword -Force
 
                     Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $forceLoginName | Should -BeTrue
                 }
@@ -228,7 +217,7 @@ Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             It 'Should not create a login when using WhatIf' {
                 $whatIfLoginName = 'IntegrationTestWhatIf'
 
-                { New-SqlDscLogin -ServerObject $script:serverObject -Name $whatIfLoginName -SqlLogin -SecurePassword $script:testPassword -WhatIf } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:serverObject -Name $whatIfLoginName -SqlLogin -SecurePassword $script:testPassword -WhatIf
 
                 Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $whatIfLoginName | Should -BeFalse
             }

--- a/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/New-SqlDscLogin.Integration.Tests.ps1
@@ -26,7 +26,7 @@ BeforeDiscovery {
 BeforeAll {
     $script:dscModuleName = 'SqlServerDsc'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
 }
 
 Describe 'New-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Integration/Commands/Prerequisites.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Prerequisites.Integration.Tests.ps1
@@ -86,6 +86,15 @@ Describe 'Prerequisites' {
         }
     }
 
+    Context 'Create required local Windows groups' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022', 'Integration_PowerBI') {
+        It 'Should create SqlIntegrationTestGroup group' {
+            $group = New-LocalGroup -Name 'SqlIntegrationTestGroup' -Description 'Local Windows group for SQL integration testing.'
+
+            $group.Name | Should -Be 'SqlIntegrationTestGroup'
+            (Get-LocalGroup -Name 'SqlIntegrationTestGroup').Name | Should -Be 'SqlIntegrationTestGroup'
+        }
+    }
+
     Context 'Add local Windows users to local groups' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022', 'Integration_PowerBI') {
         It 'Should add SqlInstall to local administrator group' {
             # Add user to local administrator group
@@ -95,6 +104,16 @@ Describe 'Prerequisites' {
             $adminGroup = Get-LocalGroup -Name 'Administrators'
             $adminGroupMembers = Get-LocalGroupMember -Group $adminGroup
             $adminGroupMembers.Name | Should -Contain ('{0}\SqlInstall' -f (Get-ComputerName))
+        }
+
+        It 'Should add SqlIntegrationTest to SqlIntegrationTestGroup group' {
+            # Add user to the local group
+            Add-LocalGroupMember -Group 'SqlIntegrationTestGroup' -Member 'SqlIntegrationTest'
+
+            # Verify if user is part of the local group
+            $testGroup = Get-LocalGroup -Name 'SqlIntegrationTestGroup'
+            $testGroupMembers = Get-LocalGroupMember -Group $testGroup
+            $testGroupMembers.Name | Should -Contain ('{0}\SqlIntegrationTest' -f (Get-ComputerName))
         }
     }
 

--- a/tests/Integration/Commands/Prerequisites.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Prerequisites.Integration.Tests.ps1
@@ -43,6 +43,13 @@ Describe 'Prerequisites' {
             $user.Name | Should -Be 'SqlAdmin'
             (Get-LocalUser -Name 'SqlAdmin').Name | Should -Be 'SqlAdmin'
         }
+
+        It 'Should create SqlIntegrationTest user' {
+            $user = New-LocalUser -Name 'SqlIntegrationTest' -Password $password -FullName 'SQL Integration Test User' -Description 'User for SQL integration testing.'
+
+            $user.Name | Should -Be 'SqlIntegrationTest'
+            (Get-LocalUser -Name 'SqlIntegrationTest').Name | Should -Be 'SqlIntegrationTest'
+        }
     }
 
     Context 'Should create required local Windows service accounts' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022', 'Integration_PowerBI') {

--- a/tests/Integration/Commands/README.md
+++ b/tests/Integration/Commands/README.md
@@ -40,6 +40,7 @@ to each other. Dependencies are made to speed up the testing.**
 Command | Run order # | Depends on # | Use instance
 --- | --- | --- | ---
 Install-SqlDscServer | 1 | - | -
+New-SqlDscLogin | 2 | 1 (Install-SqlDscServer) | DSCSQLTEST
 
 ## Integration Tests
 
@@ -51,6 +52,12 @@ first.
 ### `Install-SqlDscServer`
 
 Installs all the [instances](#instances).
+
+### `New-SqlDscLogin`
+
+Creates test logins on the DSCSQLTEST instance for use by other integration
+tests. The main test login `IntegrationTestSqlLogin` is left in place after
+the test completes so other tests can use it for validation purposes.
 
 ## Dependencies
 
@@ -102,6 +109,7 @@ User | Password | Permission | Description
 --- | --- | --- | ---
 .\SqlInstall | P@ssw0rd1 | Local Windows administrator and sysadmin | Runs Setup for all the instances.
 .\SqlAdmin | P@ssw0rd1 | Local Windows user and sysadmin | Administrator of all the SQL Server instances.
+.\SqlIntegrationTest | P@ssw0rd1 | Local Windows user | User for SQL integration testing.
 .\svc-SqlPrimary | yig-C^Equ3 | Local Windows user. | Runs the SQL Server service.
 .\svc-SqlAgentPri | yig-C^Equ3 | Local Windows user. | Runs the SQL Server Agent service.
 .\svc-SqlSecondary | yig-C^Equ3 | Local Windows user. | Runs the SQL Server service in multi node scenarios.
@@ -110,6 +118,7 @@ User | Password | Permission | Description
 Login | Password | Permission | Description
 --- | --- | --- | ---
 sa | P@ssw0rd1 | sysadmin | Administrator of all the Database Engine instances.
+IntegrationTestSqlLogin | P@ssw0rd123! | - | SQL Server login created by New-SqlDscLogin integration tests for testing purposes.
 <!-- markdownlint-enable MD013 -->
 
 ### Image media (ISO)

--- a/tests/Integration/Commands/README.md
+++ b/tests/Integration/Commands/README.md
@@ -60,8 +60,7 @@ integration tests. Tests SQL Server logins, Windows user logins,
 and Windows group logins (using the local SqlIntegrationTestGroup).
 The main test login `IntegrationTestSqlLogin` and the Windows group
 login for `.\SqlIntegrationTestGroup` are left in place after the
-test completes so other tests can use them for validation purposes.
-
+test completes so other tests can use them for validation.
 ## Dependencies
 
 ### SqlServer module

--- a/tests/Integration/Commands/README.md
+++ b/tests/Integration/Commands/README.md
@@ -55,12 +55,12 @@ Installs all the [instances](#instances).
 
 ### `New-SqlDscLogin`
 
-Creates test logins on the DSCSQLTEST instance for use by other integration
-tests. Tests SQL Server logins, Windows user logins, and Windows group logins
-(using the local SqlIntegrationTestGroup). The main test login
-`IntegrationTestSqlLogin` and the Windows group login for
-`.\SqlIntegrationTestGroup` are left in place after the test completes so other
-tests can use them for validation purposes.
+Creates test logins on the DSCSQLTEST instance for use by other
+integration tests. Tests SQL Server logins, Windows user logins,
+and Windows group logins (using the local SqlIntegrationTestGroup).
+The main test login `IntegrationTestSqlLogin` and the Windows group
+login for `.\SqlIntegrationTestGroup` are left in place after the
+test completes so other tests can use them for validation purposes.
 
 ## Dependencies
 

--- a/tests/Integration/Commands/README.md
+++ b/tests/Integration/Commands/README.md
@@ -40,7 +40,7 @@ to each other. Dependencies are made to speed up the testing.**
 Command | Run order # | Depends on # | Use instance
 --- | --- | --- | ---
 Install-SqlDscServer | 1 | - | -
-New-SqlDscLogin | 2 | 1 (Install-SqlDscServer) | DSCSQLTEST
+New-SqlDscLogin | 2 | 1 (Install-SqlDscServer), Prerequisites | DSCSQLTEST
 
 ## Integration Tests
 
@@ -56,8 +56,11 @@ Installs all the [instances](#instances).
 ### `New-SqlDscLogin`
 
 Creates test logins on the DSCSQLTEST instance for use by other integration
-tests. The main test login `IntegrationTestSqlLogin` is left in place after
-the test completes so other tests can use it for validation purposes.
+tests. Tests SQL Server logins, Windows user logins, and Windows group logins
+(using the local SqlIntegrationTestGroup). The main test login
+`IntegrationTestSqlLogin` and the Windows group login for
+`.\SqlIntegrationTestGroup` are left in place after the test completes so other
+tests can use them for validation purposes.
 
 ## Dependencies
 
@@ -115,10 +118,21 @@ User | Password | Permission | Description
 .\svc-SqlSecondary | yig-C^Equ3 | Local Windows user. | Runs the SQL Server service in multi node scenarios.
 .\svc-SqlAgentSec | yig-C^Equ3 | Local Windows user. | Runs the SQL Server Agent service in multi node scenarios.
 
+### Groups
+
+The following local groups are created and can be used by integration tests.
+
+Group | Description
+--- | ---
+.\SqlIntegrationTestGroup | Local Windows group for SQL integration testing.
+
+### SQL Server Logins
+
 Login | Password | Permission | Description
 --- | --- | --- | ---
 sa | P@ssw0rd1 | sysadmin | Administrator of all the Database Engine instances.
 IntegrationTestSqlLogin | P@ssw0rd123! | - | SQL Server login created by New-SqlDscLogin integration tests for testing purposes.
+.\SqlIntegrationTestGroup | - | - | Windows group login created by New-SqlDscLogin integration tests for testing purposes.
 <!-- markdownlint-enable MD013 -->
 
 ### Image media (ISO)

--- a/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
@@ -139,7 +139,8 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
 
         It 'Should work with the Refresh parameter' {
             # Create the test login
-            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName3 -SqlLogin -SecurePassword (ConvertTo-SecureString -String 'P@ssw0rd3!' -AsPlainText -Force) -Force
+            $script:testLoginPassword3 = ConvertTo-SecureString -String 'P@ssw0rd3!' -AsPlainText -Force
+            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName3 -SqlLogin -SecurePassword $script:testLoginPassword3 -Force
 
             # Verify the login exists
             $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName3

--- a/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
@@ -148,8 +148,8 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
 
         It 'Should work with the Refresh parameter' {
             # Create the test login
-            $script:testLoginPassword3 = ConvertTo-SecureString -String 'P@ssw0rd3!' -AsPlainText -Force
-            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName3 -SqlLogin -SecurePassword $script:testLoginPassword3 -Force
+            $testLoginPassword3 = ConvertTo-SecureString -String 'P@ssw0rd3!' -AsPlainText -Force
+            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName3 -SqlLogin -SecurePassword $testLoginPassword3 -Force
 
             # Verify the login exists
             $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName3

--- a/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
@@ -74,6 +74,9 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
         }
 
         It 'Should handle WhatIf parameter correctly' {
+            # Ensure the login exists for this scenario (don't rely on other Its)
+            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName -SqlLogin -SecurePassword $script:testLoginPassword -Force
+
             # Use WhatIf - login should not be removed
             $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -WhatIf
 
@@ -83,6 +86,12 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
         }
 
         It 'Should throw an error when the login does not exist' {
+            # Ensure the login does not exist for this scenario (don't rely on other Its)
+            if (Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName)
+            {
+                $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -Force
+            }
+
             # Try to remove a non-existent login
             {
                 $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -Force -ErrorAction 'Stop'

--- a/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
@@ -57,23 +57,10 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
             $script:testLoginPassword = ConvertTo-SecureString -String 'P@ssw0rd1!' -AsPlainText -Force
         }
 
-        BeforeEach {
+        It 'Should remove the login when it exists' {
             # Create the test login
             $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName -SqlLogin -SecurePassword $script:testLoginPassword -Force
-        }
 
-        AfterEach {
-            # Clean up - remove the login if it still exists
-            try {
-                $cleanupQuery = "IF EXISTS (SELECT name FROM sys.server_principals WHERE name = '$($script:testLoginName)') DROP LOGIN [$($script:testLoginName)]"
-                $null = Invoke-SqlDscQuery -ServerObject $script:serverObject -DatabaseName 'master' -Query $cleanupQuery -Force
-            }
-            catch {
-                # Ignore cleanup errors
-            }
-        }
-
-        It 'Should remove the login when it exists' {
             # Verify the login exists
             $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName
             $loginExists | Should -BeTrue
@@ -87,10 +74,6 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
         }
 
         It 'Should handle WhatIf parameter correctly' {
-            # Verify the login exists
-            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName
-            $loginExists | Should -BeTrue
-
             # Use WhatIf - login should not be removed
             $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -WhatIf
 
@@ -100,9 +83,6 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
         }
 
         It 'Should throw an error when the login does not exist' {
-            # Remove the login first to ensure it doesn't exist
-            $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -Force
-
             # Try to remove a non-existent login
             {
                 $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -Force -ErrorAction 'Stop'
@@ -116,23 +96,10 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
             $script:testLoginPassword2 = ConvertTo-SecureString -String 'P@ssw0rd2!' -AsPlainText -Force
         }
 
-        BeforeEach {
+        It 'Should remove the login when passed as LoginObject' {
             # Create the test login
             $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName2 -SqlLogin -SecurePassword $script:testLoginPassword2 -Force
-        }
 
-        AfterEach {
-            # Clean up - remove the login if it still exists
-            try {
-                $cleanupQuery = "IF EXISTS (SELECT name FROM sys.server_principals WHERE name = '$($script:testLoginName2)') DROP LOGIN [$($script:testLoginName2)]"
-                $null = Invoke-SqlDscQuery -ServerObject $script:serverObject -DatabaseName 'master' -Query $cleanupQuery -Force
-            }
-            catch {
-                # Ignore cleanup errors
-            }
-        }
-
-        It 'Should remove the login when passed as LoginObject' {
             # Get the login object
             $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName2
 
@@ -149,6 +116,13 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
         }
 
         It 'Should handle pipeline input correctly' {
+            # Create the test login
+            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName2 -SqlLogin -SecurePassword $script:testLoginPassword2 -Force
+
+            # Verify the login exists
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName2
+            $loginExists | Should -BeTrue
+
             # Get the login object and remove it via pipeline
             Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName2 | Remove-SqlDscLogin -Force
 
@@ -163,23 +137,14 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
             $script:testLoginName3 = 'TestRemoveLogin3'
         }
 
-        BeforeEach {
+        It 'Should work with the Refresh parameter' {
             # Create the test login
             $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName3 -SqlLogin -SecurePassword (ConvertTo-SecureString -String 'P@ssw0rd3!' -AsPlainText -Force) -Force
-        }
 
-        AfterEach {
-            # Clean up - remove the login if it still exists
-            try {
-                $cleanupQuery = "IF EXISTS (SELECT name FROM sys.server_principals WHERE name = '$($script:testLoginName3)') DROP LOGIN [$($script:testLoginName3)]"
-                $null = Invoke-SqlDscQuery -ServerObject $script:serverObject -DatabaseName 'master' -Query $cleanupQuery -Force
-            }
-            catch {
-                # Ignore cleanup errors
-            }
-        }
+            # Verify the login exists
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName3
+            $loginExists | Should -BeTrue
 
-        It 'Should work with the Refresh parameter' {
             # Remove the login with Refresh parameter
             $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName3 -Refresh -Force
 

--- a/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
@@ -55,13 +55,11 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
         BeforeAll {
             $script:testLoginName = 'TestRemoveLogin1'
             $script:testLoginPassword = ConvertTo-SecureString -String 'P@ssw0rd1!' -AsPlainText -Force
-            $script:testLoginCredential = [System.Management.Automation.PSCredential]::new($script:testLoginName, $script:testLoginPassword)
         }
 
         BeforeEach {
             # Create the test login
-            $createLoginQuery = "CREATE LOGIN [$($script:testLoginName)] WITH PASSWORD = 'P@ssw0rd1!'"
-            $null = Invoke-SqlDscQuery -ServerObject $script:serverObject -DatabaseName 'master' -Query $createLoginQuery -Force
+            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName -SqlLogin -SecurePassword $script:testLoginPassword -Force
         }
 
         AfterEach {
@@ -116,13 +114,11 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
         BeforeAll {
             $script:testLoginName2 = 'TestRemoveLogin2'
             $script:testLoginPassword2 = ConvertTo-SecureString -String 'P@ssw0rd2!' -AsPlainText -Force
-            $script:testLoginCredential2 = [System.Management.Automation.PSCredential]::new($script:testLoginName2, $script:testLoginPassword2)
         }
 
         BeforeEach {
             # Create the test login
-            $createLoginQuery = "CREATE LOGIN [$($script:testLoginName2)] WITH PASSWORD = 'P@ssw0rd2!'"
-            $null = Invoke-SqlDscQuery -ServerObject $script:serverObject -DatabaseName 'master' -Query $createLoginQuery -Force
+            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName2 -SqlLogin -SecurePassword $script:testLoginPassword2 -Force
         }
 
         AfterEach {
@@ -169,8 +165,7 @@ Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017
 
         BeforeEach {
             # Create the test login
-            $createLoginQuery = "CREATE LOGIN [$($script:testLoginName3)] WITH PASSWORD = 'P@ssw0rd3!'"
-            $null = Invoke-SqlDscQuery -ServerObject $script:serverObject -DatabaseName 'master' -Query $createLoginQuery -Force
+            $null = $script:serverObject | New-SqlDscLogin -Name $script:testLoginName3 -SqlLogin -SecurePassword (ConvertTo-SecureString -String 'P@ssw0rd3!' -AsPlainText -Force) -Force
         }
 
         AfterEach {

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -67,7 +67,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should create a SQL Server login without throwing' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -79,7 +79,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
 
         Context 'When creating a Windows user login' {
             It 'Should create a Windows user login without throwing' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DOMAIN\TestUser' -WindowsUser -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DOMAIN\TestUser' -WindowsUser -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -115,19 +115,19 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
 
         Context 'When creating certificate-based login' {
             It 'Should create a certificate login without throwing' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'CertLogin' -Certificate -CertificateName 'MyCert' -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'CertLogin' -Certificate -CertificateName 'MyCert' -Confirm:$false
             }
         }
 
         Context 'When creating asymmetric key-based login' {
             It 'Should create an asymmetric key login without throwing' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'KeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyKey' -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'KeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyKey' -Confirm:$false
             }
         }
 
         Context 'When creating Windows group login' {
             It 'Should create a Windows group login without throwing' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'NT AUTHORITY\SYSTEM' -WindowsGroup -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'NT AUTHORITY\SYSTEM' -WindowsGroup -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -139,7 +139,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should set ConfirmPreference to None when Force is used' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ForceLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Force } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ForceLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Force
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -151,7 +151,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should set custom language on login object' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'LangLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -DefaultLanguage 'Swedish' -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'LangLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -DefaultLanguage 'Swedish' -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -163,7 +163,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should set MustChange login create option' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'MustChangeLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -MustChangePassword -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'MustChangeLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -MustChangePassword -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -175,7 +175,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should set IsHashed login create option' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'HashedLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -IsHashed -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'HashedLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -IsHashed -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -187,7 +187,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should call Disable method on login object' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DisabledLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Disabled -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DisabledLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Disabled -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -199,7 +199,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should handle multiple options together' {
-                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ComplexLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -MustChangePassword -IsHashed -Disabled -DefaultLanguage 'English' -DefaultDatabase 'tempdb' -PasswordExpirationEnabled -PasswordPolicyEnforced -Confirm:$false } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ComplexLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -MustChangePassword -IsHashed -Disabled -DefaultLanguage 'English' -DefaultDatabase 'tempdb' -PasswordExpirationEnabled -PasswordPolicyEnforced -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -221,19 +221,19 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should create login with MustChangePassword option' {
-                { New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -MustChangePassword } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -MustChangePassword
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter $mockTestSqlDscIsLoginParameterFilter -Exactly -Times 1 -Scope It
             }
 
             It 'Should create login with IsHashed option' {
-                { New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -IsHashed } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -IsHashed
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter $mockTestSqlDscIsLoginParameterFilter -Exactly -Times 1 -Scope It
             }
 
             It 'Should create disabled login' {
-                { New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -Disabled } | Should -Not -Throw
+                $null = New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -Disabled
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter $mockTestSqlDscIsLoginParameterFilter -Exactly -Times 1 -Scope It
             }

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -312,7 +312,10 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
 
         Context 'When creating a Windows user login' {
             It 'Should create a Windows user login without throwing' {
-                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DOMAIN\TestUser' -WindowsUser -Confirm:$false
+                $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DOMAIN\TestUser' -WindowsUser -PassThru -Confirm:$false
+
+                $result | Should -Not -BeNullOrEmpty
+                $result.MockCreateCalled | Should -BeTrue
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
@@ -343,24 +346,47 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
                 $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -PassThru -Confirm:$false
 
                 $result | Should -Not -BeNullOrEmpty
+                $result.MockCreateCalled | Should -BeTrue
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should create login without throwing when PassThru is not specified' {
+                $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin2' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false
+                $result | Should -BeNullOrEmpty
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
         }
 
         Context 'When creating certificate-based login' {
             It 'Should create a certificate login without throwing' {
-                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'CertLogin' -Certificate -CertificateName 'MyCert' -Confirm:$false
+                $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'CertLogin' -Certificate -CertificateName 'MyCert' -PassThru -Confirm:$false
+
+                $result | Should -Not -BeNullOrEmpty
+                $result.MockCreateCalled | Should -BeTrue
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
         }
 
         Context 'When creating asymmetric key-based login' {
             It 'Should create an asymmetric key login without throwing' {
-                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'KeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyKey' -Confirm:$false
+                $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'KeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyKey' -PassThru -Confirm:$false
+
+                $result | Should -Not -BeNullOrEmpty
+                $result.MockCreateCalled | Should -BeTrue
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
         }
 
         Context 'When creating Windows group login' {
             It 'Should create a Windows group login without throwing' {
-                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'NT AUTHORITY\SYSTEM' -WindowsGroup -Confirm:$false
+                $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'NT AUTHORITY\SYSTEM' -WindowsGroup -PassThru -Confirm:$false
+
+                $result | Should -Not -BeNullOrEmpty
+                $result.MockCreateCalled | Should -BeTrue
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -39,10 +39,9 @@ BeforeAll {
 }
 
 AfterAll {
-    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
     $PSDefaultParameterValues.Remove('Mock:ModuleName')
     $PSDefaultParameterValues.Remove('Should:ModuleName')
-
+}
     # Unload the module being tested so that it doesn't impact any other tests.
     Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
 

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -7,14 +7,14 @@ BeforeDiscovery {
     {
         if (-not (Get-Module -Name 'DscResource.Test'))
         {
-            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
                 & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
-            # If the dependencies has not been resolved, this will throw an error.
+            # If the dependencies have not been resolved, this will throw an error.
             Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
         }
     }

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -410,7 +410,10 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
             }
 
             It 'Should set custom language on login object' {
-                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'LangLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -DefaultLanguage 'Swedish' -Confirm:$false
+                $login = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'LangLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -DefaultLanguage 'Swedish' -PassThru -Confirm:$false
+
+                $login.Language | Should -Be 'Swedish'
+                $login.MockCreateCalled | Should -BeTrue
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -29,7 +29,7 @@ BeforeAll {
 
     $env:SqlServerDscCI = $true
 
-    Import-Module -Name $script:dscModuleName -Force
+    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
 
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
@@ -307,10 +307,6 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
                 $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
-            }
-
-            It 'Should call Create method on login object' {
-                New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false
             }
         }
 

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -41,7 +41,7 @@ BeforeAll {
 AfterAll {
     $PSDefaultParameterValues.Remove('Mock:ModuleName')
     $PSDefaultParameterValues.Remove('Should:ModuleName')
-}
+
     # Unload the module being tested so that it doesn't impact any other tests.
     Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
 

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -375,7 +375,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
                 $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
             }
 
-            It 'Should set ConfirmPreference to None when Force is used' {
+            It 'Should create when Force is used' {
                 $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ForceLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Force
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -1,0 +1,242 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameter is used in test mocks.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    $env:SqlServerDscCI = $true
+
+    Import-Module -Name $script:dscModuleName -Force
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Item -Path 'env:SqlServerDscCI'
+}
+
+Describe 'New-SqlDscLogin' -Tag 'Public' {
+    Context 'When using parameter Confirm with value $false' {
+        BeforeAll {
+            Mock -CommandName Test-SqlDscIsLogin -MockWith {
+                return $false
+            }
+
+            $script:mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+            $script:mockServerObject.InstanceName = 'TestInstance'
+        }
+
+        Context 'When creating a SQL Server login' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should create a SQL Server login without throwing' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should call Create method on login object' {
+                New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false
+            }
+        }
+
+        Context 'When creating a Windows user login' {
+            It 'Should create a Windows user login without throwing' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DOMAIN\TestUser' -WindowsUser -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When login already exists' {
+            BeforeAll {
+                Mock -CommandName Test-SqlDscIsLogin -MockWith {
+                    return $true
+                }
+
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should throw an error when login already exists' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ExistingLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false } | Should -Throw -ExpectedMessage '*already exists*'
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When using PassThru parameter' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should return the login object when PassThru is specified' {
+                $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -PassThru -Confirm:$false
+
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        Context 'When creating certificate-based login' {
+            It 'Should create a certificate login without throwing' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'CertLogin' -Certificate -CertificateName 'MyCert' -Confirm:$false } | Should -Not -Throw
+            }
+        }
+
+        Context 'When creating asymmetric key-based login' {
+            It 'Should create an asymmetric key login without throwing' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'KeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyKey' -Confirm:$false } | Should -Not -Throw
+            }
+        }
+
+        Context 'When creating Windows group login' {
+            It 'Should create a Windows group login without throwing' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'NT AUTHORITY\SYSTEM' -WindowsGroup -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When using Force parameter without Confirm' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should set ConfirmPreference to None when Force is used' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ForceLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Force } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When using custom DefaultLanguage parameter' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should set custom language on login object' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'LangLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -DefaultLanguage 'Swedish' -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When using MustChangePassword parameter' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should set MustChange login create option' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'MustChangeLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -MustChangePassword -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When using IsHashed parameter' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should set IsHashed login create option' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'HashedLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -IsHashed -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When using Disabled parameter' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should call Disable method on login object' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DisabledLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Disabled -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When combining multiple SQL login options' {
+            BeforeAll {
+                $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+            }
+
+            It 'Should handle multiple options together' {
+                { New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'ComplexLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -MustChangePassword -IsHashed -Disabled -DefaultLanguage 'English' -DefaultDatabase 'tempdb' -PasswordExpirationEnabled -PasswordPolicyEnforced -Confirm:$false } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
+            }
+        }
+
+        Context 'When creating a SQL Server login with specific password options' {
+            BeforeAll {
+                Mock -CommandName Test-SqlDscIsLogin -MockWith {
+                    return $false
+                }
+
+                $mockServerObject = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server
+                $mockServerObject.InstanceName = 'TestInstance'
+                $mockSecurePassword = ConvertTo-SecureString -String 'MyStr0ngP@ssw0rd' -AsPlainText -Force
+
+                $mockTestSqlDscIsLoginParameterFilter = {
+                    $ServerObject -eq $mockServerObject -and $Name -eq 'NewLogin'
+                }
+            }
+
+            It 'Should create login with MustChangePassword option' {
+                { New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -MustChangePassword } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter $mockTestSqlDscIsLoginParameterFilter -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should create login with IsHashed option' {
+                { New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -IsHashed } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter $mockTestSqlDscIsLoginParameterFilter -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should create disabled login' {
+                { New-SqlDscLogin -ServerObject $mockServerObject -Name 'NewLogin' -SqlLogin -SecurePassword $mockSecurePassword -Disabled } | Should -Not -Throw
+
+                Should -Invoke -CommandName Test-SqlDscIsLogin -ParameterFilter $mockTestSqlDscIsLoginParameterFilter -Exactly -Times 1 -Scope It
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -1,4 +1,4 @@
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Pester discovery/context variables are declared before usage; this suppression aligns with repository test patterns.')]
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Parameter is used in test mocks.')]
 param ()
 
@@ -51,6 +51,215 @@ AfterAll {
 }
 
 Describe 'New-SqlDscLogin' -Tag 'Public' {
+    It 'Should have the correct parameters in parameter set <MockParameterSetName>' -ForEach @(
+        @{
+            MockParameterSetName = 'SqlLogin'
+            MockExpectedParameters = '-ServerObject <Server> -Name <string> -SqlLogin -SecurePassword <securestring> [-DefaultDatabase <string>] [-DefaultLanguage <string>] [-PasswordExpirationEnabled] [-PasswordPolicyEnforced] [-MustChangePassword] [-IsHashed] [-Disabled] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+        @{
+            MockParameterSetName = 'WindowsUser'
+            MockExpectedParameters = '-ServerObject <Server> -Name <string> -WindowsUser [-DefaultDatabase <string>] [-DefaultLanguage <string>] [-Disabled] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+        @{
+            MockParameterSetName = 'WindowsGroup'
+            MockExpectedParameters = '-ServerObject <Server> -Name <string> -WindowsGroup [-DefaultDatabase <string>] [-DefaultLanguage <string>] [-Disabled] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+        @{
+            MockParameterSetName = 'Certificate'
+            MockExpectedParameters = '-ServerObject <Server> -Name <string> -Certificate -CertificateName <string> [-DefaultDatabase <string>] [-DefaultLanguage <string>] [-Disabled] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+        @{
+            MockParameterSetName = 'AsymmetricKey'
+            MockExpectedParameters = '-ServerObject <Server> -Name <string> -AsymmetricKey -AsymmetricKeyName <string> [-DefaultDatabase <string>] [-DefaultLanguage <string>] [-Disabled] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+    ) {
+        $result = (Get-Command -Name 'New-SqlDscLogin').ParameterSets |
+            Where-Object -FilterScript {
+                $_.Name -eq $mockParameterSetName
+            } |
+            Select-Object -Property @(
+                @{
+                    Name = 'ParameterSetName'
+                    Expression = { $_.Name }
+                },
+                @{
+                    Name = 'ParameterListAsString'
+                    Expression = { $_.ToString() }
+                }
+            )
+
+        $result.ParameterSetName | Should -Be $MockParameterSetName
+        $result.ParameterListAsString | Should -Be $MockExpectedParameters
+    }
+
+    It 'Should have the correct command metadata' {
+        $command = Get-Command -Name 'New-SqlDscLogin'
+
+        $cmdletBindingAttribute = $command.ScriptBlock.Attributes |
+            Where-Object -FilterScript { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+
+        $cmdletBindingAttribute.SupportsShouldProcess | Should -BeTrue
+        $cmdletBindingAttribute.ConfirmImpact | Should -Be 'Medium'
+        $cmdletBindingAttribute.DefaultParameterSetName | Should -Be 'WindowsUser'
+    }
+
+    It 'Should have correct parameter attributes for parameter set <ParameterSetName>' -ForEach @(
+        @{
+            ParameterSetName = 'SqlLogin'
+            ExpectedParameterTests = @(
+                @{ ParameterName = 'ServerObject'; IsMandatory = $true; ValueFromPipeline = $true; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Name'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'SqlLogin'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'SecurePassword'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultDatabase'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultLanguage'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'PasswordExpirationEnabled'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'PasswordPolicyEnforced'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'MustChangePassword'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'IsHashed'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Disabled'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Force'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'PassThru'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'WindowsUser'; ShouldExist = $false }
+                @{ ParameterName = 'WindowsGroup'; ShouldExist = $false }
+                @{ ParameterName = 'Certificate'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKey'; ShouldExist = $false }
+                @{ ParameterName = 'CertificateName'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKeyName'; ShouldExist = $false }
+            )
+        }
+        @{
+            ParameterSetName = 'WindowsUser'
+            ExpectedParameterTests = @(
+                @{ ParameterName = 'ServerObject'; IsMandatory = $true; ValueFromPipeline = $true; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Name'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'WindowsUser'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultDatabase'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultLanguage'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Disabled'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Force'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'PassThru'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'SqlLogin'; ShouldExist = $false }
+                @{ ParameterName = 'WindowsGroup'; ShouldExist = $false }
+                @{ ParameterName = 'Certificate'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKey'; ShouldExist = $false }
+                @{ ParameterName = 'SecurePassword'; ShouldExist = $false }
+                @{ ParameterName = 'CertificateName'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKeyName'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordExpirationEnabled'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordPolicyEnforced'; ShouldExist = $false }
+                @{ ParameterName = 'MustChangePassword'; ShouldExist = $false }
+                @{ ParameterName = 'IsHashed'; ShouldExist = $false }
+            )
+        }
+        @{
+            ParameterSetName = 'WindowsGroup'
+            ExpectedParameterTests = @(
+                @{ ParameterName = 'ServerObject'; IsMandatory = $true; ValueFromPipeline = $true; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Name'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'WindowsGroup'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultDatabase'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultLanguage'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Disabled'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Force'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'PassThru'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'SqlLogin'; ShouldExist = $false }
+                @{ ParameterName = 'WindowsUser'; ShouldExist = $false }
+                @{ ParameterName = 'Certificate'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKey'; ShouldExist = $false }
+                @{ ParameterName = 'SecurePassword'; ShouldExist = $false }
+                @{ ParameterName = 'CertificateName'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKeyName'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordExpirationEnabled'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordPolicyEnforced'; ShouldExist = $false }
+                @{ ParameterName = 'MustChangePassword'; ShouldExist = $false }
+                @{ ParameterName = 'IsHashed'; ShouldExist = $false }
+            )
+        }
+        @{
+            ParameterSetName = 'Certificate'
+            ExpectedParameterTests = @(
+                @{ ParameterName = 'ServerObject'; IsMandatory = $true; ValueFromPipeline = $true; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Name'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Certificate'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'CertificateName'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultDatabase'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultLanguage'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Disabled'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Force'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'PassThru'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'SqlLogin'; ShouldExist = $false }
+                @{ ParameterName = 'WindowsUser'; ShouldExist = $false }
+                @{ ParameterName = 'WindowsGroup'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKey'; ShouldExist = $false }
+                @{ ParameterName = 'SecurePassword'; ShouldExist = $false }
+                @{ ParameterName = 'AsymmetricKeyName'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordExpirationEnabled'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordPolicyEnforced'; ShouldExist = $false }
+                @{ ParameterName = 'MustChangePassword'; ShouldExist = $false }
+                @{ ParameterName = 'IsHashed'; ShouldExist = $false }
+            )
+        }
+        @{
+            ParameterSetName = 'AsymmetricKey'
+            ExpectedParameterTests = @(
+                @{ ParameterName = 'ServerObject'; IsMandatory = $true; ValueFromPipeline = $true; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Name'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'AsymmetricKey'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'AsymmetricKeyName'; IsMandatory = $true; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultDatabase'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'DefaultLanguage'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Disabled'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'Force'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'PassThru'; IsMandatory = $false; ValueFromPipeline = $false; ValueFromPipelineByPropertyName = $false }
+                @{ ParameterName = 'SqlLogin'; ShouldExist = $false }
+                @{ ParameterName = 'WindowsUser'; ShouldExist = $false }
+                @{ ParameterName = 'WindowsGroup'; ShouldExist = $false }
+                @{ ParameterName = 'Certificate'; ShouldExist = $false }
+                @{ ParameterName = 'SecurePassword'; ShouldExist = $false }
+                @{ ParameterName = 'CertificateName'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordExpirationEnabled'; ShouldExist = $false }
+                @{ ParameterName = 'PasswordPolicyEnforced'; ShouldExist = $false }
+                @{ ParameterName = 'MustChangePassword'; ShouldExist = $false }
+                @{ ParameterName = 'IsHashed'; ShouldExist = $false }
+            )
+        }
+    ) {
+        $command = Get-Command -Name 'New-SqlDscLogin'
+
+        # Helper function to get parameter attribute for a specific parameter set
+        $getParameterAttribute = {
+            param($ParameterName, $ParameterSetName)
+
+            $parameter = $command.Parameters[$ParameterName]
+            if ($null -eq $parameter) {
+                return $null
+            }
+
+            $parameterAttribute = $parameter.Attributes |
+                Where-Object -FilterScript {
+                    $_ -is [System.Management.Automation.ParameterAttribute] -and
+                    ($_.ParameterSetName -eq $ParameterSetName -or $_.ParameterSetName -eq '__AllParameterSets')
+                } |
+                Select-Object -First 1
+
+            return $parameterAttribute
+        }
+
+        foreach ($parameterTest in $ExpectedParameterTests) {
+            $parameterAttribute = & $getParameterAttribute -ParameterName $parameterTest.ParameterName -ParameterSetName $ParameterSetName
+
+            if ($parameterTest.ContainsKey('ShouldExist') -and $parameterTest.ShouldExist -eq $false) {
+                $parameterAttribute | Should -BeNullOrEmpty -Because "Parameter '$($parameterTest.ParameterName)' should not exist in parameter set '$ParameterSetName'"
+            } else {
+                $parameterAttribute | Should -Not -BeNullOrEmpty -Because "Parameter '$($parameterTest.ParameterName)' should exist in parameter set '$ParameterSetName'"
+                $parameterAttribute.Mandatory | Should -Be $parameterTest.IsMandatory -Because "Parameter '$($parameterTest.ParameterName)' mandatory setting should be $($parameterTest.IsMandatory) in parameter set '$ParameterSetName'"
+                $parameterAttribute.ValueFromPipeline | Should -Be $parameterTest.ValueFromPipeline -Because "Parameter '$($parameterTest.ParameterName)' ValueFromPipeline setting should be $($parameterTest.ValueFromPipeline) in parameter set '$ParameterSetName'"
+                $parameterAttribute.ValueFromPipelineByPropertyName | Should -Be $parameterTest.ValueFromPipelineByPropertyName -Because "Parameter '$($parameterTest.ParameterName)' ValueFromPipelineByPropertyName setting should be $($parameterTest.ValueFromPipelineByPropertyName) in parameter set '$ParameterSetName'"
+            }
+        }
+    }
+
     Context 'When using parameter Confirm with value $false' {
         BeforeAll {
             Mock -CommandName Test-SqlDscIsLogin -MockWith {

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -34,7 +34,6 @@ BeforeAll {
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
 
-    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
 }

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -303,7 +303,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
                 $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
             }
 
-            It 'Should create a SQL Server login without throwing' {
+            It 'Should create a SQL Server login and invoke Test-SqlDscIsLogin' {
                 $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
@@ -311,7 +311,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
         }
 
         Context 'When creating a Windows user login' {
-            It 'Should create a Windows user login without throwing' {
+            It 'Should create a Windows user login and return the created object' {
                 $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DOMAIN\TestUser' -WindowsUser -PassThru -Confirm:$false
 
                 $result | Should -Not -BeNullOrEmpty
@@ -351,7 +351,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }
 
-            It 'Should create login without throwing when PassThru is not specified' {
+            It 'Should not return a login object when PassThru is not specified' {
                 $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'TestLogin2' -SqlLogin -SecurePassword $script:mockSecurePassword -Confirm:$false
                 $result | Should -BeNullOrEmpty
 
@@ -360,7 +360,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
         }
 
         Context 'When creating certificate-based login' {
-            It 'Should create a certificate login without throwing' {
+            It 'Should create a certificate login and return the created object' {
                 $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'CertLogin' -Certificate -CertificateName 'MyCert' -PassThru -Confirm:$false
 
                 $result | Should -Not -BeNullOrEmpty
@@ -371,7 +371,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
         }
 
         Context 'When creating asymmetric key-based login' {
-            It 'Should create an asymmetric key login without throwing' {
+            It 'Should create an asymmetric key login and return the created object' {
                 $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'KeyLogin' -AsymmetricKey -AsymmetricKeyName 'MyKey' -PassThru -Confirm:$false
 
                 $result | Should -Not -BeNullOrEmpty
@@ -382,7 +382,7 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
         }
 
         Context 'When creating Windows group login' {
-            It 'Should create a Windows group login without throwing' {
+            It 'Should create a Windows group login and return the created object' {
                 $result = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'NT AUTHORITY\SYSTEM' -WindowsGroup -PassThru -Confirm:$false
 
                 $result | Should -Not -BeNullOrEmpty

--- a/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscLogin.Tests.ps1
@@ -448,8 +448,10 @@ Describe 'New-SqlDscLogin' -Tag 'Public' {
                 $script:mockSecurePassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
             }
 
-            It 'Should call Disable method on login object' {
-                $null = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DisabledLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Disabled -Confirm:$false
+            It 'Should call Disable method on login object and set IsDisabled property' {
+                $login = New-SqlDscLogin -ServerObject $script:mockServerObject -Name 'DisabledLogin' -SqlLogin -SecurePassword $script:mockSecurePassword -Disabled -PassThru -Confirm:$false
+
+                $login.IsDisabled | Should -BeTrue
 
                 Should -Invoke -CommandName Test-SqlDscIsLogin -Exactly -Times 1 -Scope It
             }

--- a/tests/Unit/Stubs/SMO.cs
+++ b/tests/Unit/Stubs/SMO.cs
@@ -484,6 +484,14 @@ namespace Microsoft.SqlServer.Management.Smo
             }
         }
 
+        public void Disable()
+        {
+        }
+
+        public string Certificate;
+        public string AsymmetricKey;
+        public string Language;
+
         public void Drop()
         {
         }

--- a/tests/Unit/Stubs/SMO.cs
+++ b/tests/Unit/Stubs/SMO.cs
@@ -486,6 +486,12 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public void Disable()
         {
+            this.IsDisabled = true;
+        }
+
+        public void Enable()
+        {
+            this.IsDisabled = false;
         }
 
         public string Certificate;

--- a/tests/Unit/Stubs/SMO.cs
+++ b/tests/Unit/Stubs/SMO.cs
@@ -357,6 +357,7 @@ namespace Microsoft.SqlServer.Management.Smo
 
         public string Name;
         public LoginType LoginType = LoginType.Unknown;
+        public bool MockCreateCalled = false;
         public bool MustChangePassword = false;
         public bool PasswordPolicyEnforced = false;
         public bool PasswordExpirationEnabled = false;
@@ -433,6 +434,8 @@ namespace Microsoft.SqlServer.Management.Smo
             if( this.LoginType == LoginType.SqlLogin && _mockPasswordPassed != true ) {
                 throw new System.Exception( "Called Create() method for the LoginType 'SqlLogin' but called with the wrong overloaded method. Did not pass the password with the Create() method." );
             }
+
+            this.MockCreateCalled = true;
         }
 
         public void Create( SecureString secureString )


### PR DESCRIPTION

#### Pull Request (PR) description
- `New-SqlDscLogin`
  - Added new public command to create a new login on a SQL Server Database
    Engine instance.
  - Supports creating SQL Server logins, Windows user logins, Windows group
    logins, certificate-based logins, and asymmetric key-based logins.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2132)
<!-- Reviewable:end -->
