### PR TITLE
`Get-SqlDscLogin`: command to retrieve SQL Server logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     exists as a login, throwing a terminating error if it doesn't exist.
   - Supports pipeline input and provides detailed error messages with localization.
   - Uses `Test-SqlDscIsLogin` command for login validation following module patterns.
+- `Get-SqlDscLogin`
+  - Added new public command to get a SQL Server login from a Database Engine instance.
+  - Returns a `Microsoft.SqlServer.Management.Smo.Login` object that represents
+    the login.
+  - Supports getting a specific login by name or all logins if no name is specified.
+  - Includes a `-Refresh` parameter to refresh the server's login collection
+    before retrieval.
 
 ### Changed
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,6 +249,7 @@ stages:
                   'tests/Integration/Commands/Connect-SqlDscDatabaseEngine.Integration.Tests.ps1'
                   # Group 2
                   'tests/Integration/Commands/Assert-SqlDscLogin.Integration.Tests.ps1'
+                  'tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1'
                   # Group 9
                   'tests/Integration/Commands/Uninstall-SqlDscServer.Integration.Tests.ps1'
               )

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -61,6 +61,8 @@ function Get-SqlDscLogin
     {
         if ($Refresh.IsPresent)
         {
+            Write-Verbose -Message ($script:localizedData.Login_Get_RefreshingLogins -f $ServerObject.InstanceName)
+
             # Make sure the logins are up-to-date to get any newly created logins.
             $ServerObject.Logins.Refresh()
         }
@@ -69,6 +71,8 @@ function Get-SqlDscLogin
 
         if ($PSBoundParameters.ContainsKey('Name'))
         {
+            Write-Verbose -Message ($script:localizedData.Login_Get_RetrievingByName -f $Name, $ServerObject.InstanceName)
+
             $loginObject = $ServerObject.Logins[$Name]
 
             if (-not $loginObject)
@@ -87,6 +91,8 @@ function Get-SqlDscLogin
         }
         else
         {
+            Write-Verbose -Message ($script:localizedData.Login_Get_ReturningAllLogins -f $ServerObject.InstanceName)
+
             $loginObject = $ServerObject.Logins
         }
 

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -29,7 +29,6 @@
 #>
 function Get-SqlDscLogin
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [OutputType([Microsoft.SqlServer.Management.Smo.Login[]])]
     [CmdletBinding()]

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -6,8 +6,8 @@
         This command gets a server login from a SQL Server Database Engine instance.
 
     .PARAMETER ServerObject
-        Specifies current server connection object.
-
+        .PARAMETER ServerObject
+            Specifies the current server connection object.
     .PARAMETER Name
         Specifies the name of the server login to get.
 

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -12,11 +12,11 @@
         Specifies the name of the server login to get.
 
     .PARAMETER Refresh
-        Specifies that the **ServerObject**'s logins should be refreshed before
-        trying get the login object. This is helpful when logins could have been
-        modified outside of the **ServerObject**, for example through T-SQL. But
-        on instances with a large amount of logins it might be better to make
-        sure the **ServerObject** is recent enough.
+        Specifies that the **ServerObject** logins should be refreshed before
+        trying to get the login object. This is helpful when logins might have
+        been modified outside of the **ServerObject**, for example through T-SQL.
+        On instances with a large number of logins, consider ensuring the
+        **ServerObject** is recent enough.
 
     .EXAMPLE
         $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -64,7 +64,7 @@ function Get-SqlDscLogin
 
             if (-not $loginObject)
             {
-                $missingLoginMessage = $script:localizedData.Login_Missing -f $Name
+                $missingLoginMessage = $script:localizedData.Login_Get_Missing -f $Name
 
                 $writeErrorParameters = @{
                     Message      = $missingLoginMessage

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -1,0 +1,86 @@
+<#
+    .SYNOPSIS
+        Get server login.
+
+    .DESCRIPTION
+        This command gets a server login from a SQL Server Database Engine instance.
+
+    .PARAMETER ServerObject
+        Specifies current server connection object.
+
+    .PARAMETER Name
+        Specifies the name of the server login to get.
+
+    .PARAMETER Refresh
+        Specifies that the **ServerObject**'s logins should be refreshed before
+        trying get the login object. This is helpful when logins could have been
+        modified outside of the **ServerObject**, for example through T-SQL. But
+        on instances with a large amount of logins it might be better to make
+        sure the **ServerObject** is recent enough, or pass in **LoginObject**.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | Get-SqlDscLogin -Name 'MyLogin'
+
+        Get the login named **MyLogin**.
+
+    .OUTPUTS
+        `[Microsoft.SqlServer.Management.Smo.Login]`
+#>
+function Get-SqlDscLogin
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
+    [OutputType([Microsoft.SqlServer.Management.Smo.Login[]])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Microsoft.SqlServer.Management.Smo.Server]
+        $ServerObject,
+
+        [Parameter()]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Refresh
+    )
+
+    process
+    {
+        if ($Refresh.IsPresent)
+        {
+            # Make sure the logins are up-to-date to get any newly created logins.
+            $ServerObject.Logins.Refresh()
+        }
+
+        $loginObject = @()
+
+        if ($PSBoundParameters.ContainsKey('Name'))
+        {
+            $loginObject = $ServerObject.Logins[$Name]
+
+            if (-not $loginObject)
+            {
+                $missingLoginMessage = $script:localizedData.Login_Missing -f $Name
+
+                $writeErrorParameters = @{
+                    Message      = $missingLoginMessage
+                    Category     = 'InvalidOperation'
+                    ErrorId      = 'GSDL0001' # cspell: disable-line
+                    TargetObject = $Name
+                }
+
+                Write-Error @writeErrorParameters
+            }
+        }
+        else
+        {
+            $loginObject = $ServerObject.Logins
+        }
+
+        return [Microsoft.SqlServer.Management.Smo.Login[]] $loginObject
+    }
+}

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -26,6 +26,15 @@
 
     .OUTPUTS
         `[Microsoft.SqlServer.Management.Smo.Login]`
+
+        Returns a single Login object when the Name parameter is specified and a
+        match is found.
+
+    .OUTPUTS
+        `[Microsoft.SqlServer.Management.Smo.Login[]]`
+
+        Returns an array of Login objects when the Name parameter is not specified
+        (returns all logins) or when multiple matches are found.
 #>
 function Get-SqlDscLogin
 {

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -76,7 +76,7 @@ function Get-SqlDscLogin
 
                 $writeErrorParameters = @{
                     Message      = $missingLoginMessage
-                    Category     = 'InvalidOperation'
+                    Category     = 'ObjectNotFound'
                     ErrorId      = 'GSDL0001' # cspell: disable-line
                     TargetObject = $Name
                 }

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -1,9 +1,11 @@
 <#
     .SYNOPSIS
-        Get server login.
+        Gets SQL Server logins.
 
     .DESCRIPTION
-        This command gets a server login from a SQL Server Database Engine instance.
+        Retrieves login objects from a SQL Server Database Engine instance. Specify -Name
+        to return a specific login, or omit -Name to return all logins. Use -Refresh to
+        refresh the login collection before retrieval.
 
     .PARAMETER ServerObject
         .PARAMETER ServerObject

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -16,7 +16,7 @@
         trying get the login object. This is helpful when logins could have been
         modified outside of the **ServerObject**, for example through T-SQL. But
         on instances with a large amount of logins it might be better to make
-        sure the **ServerObject** is recent enough, or pass in **LoginObject**.
+        sure the **ServerObject** is recent enough.
 
     .EXAMPLE
         $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'

--- a/source/Public/Get-SqlDscLogin.ps1
+++ b/source/Public/Get-SqlDscLogin.ps1
@@ -8,7 +8,6 @@
         refresh the login collection before retrieval.
 
     .PARAMETER ServerObject
-        .PARAMETER ServerObject
             Specifies the current server connection object.
     .PARAMETER Name
         Specifies the name of the server login to get.

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -63,6 +63,9 @@ ConvertFrom-StringData @'
 
     ## Get-SqlDscLogin
     Login_Get_Missing = There is no login with the name '{0}'.
+    Login_Get_RefreshingLogins = Refreshing logins on server '{0}'.
+    Login_Get_RetrievingByName = Retrieving login by name '{0}' from server '{1}'.
+    Login_Get_ReturningAllLogins = Returning all logins from server '{0}'.
 
     ## Remove-SqlDscAudit
     Audit_Remove_ShouldProcessVerboseDescription = Removing the audit '{0}' on the instance '{1}'.

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -61,6 +61,9 @@ ConvertFrom-StringData @'
     ## Get-SqlDscAudit
     Audit_Missing = There is no audit with the name '{0}'.
 
+    ## Get-SqlDscLogin
+    Login_Missing = There is no login with the name '{0}'.
+
     ## Remove-SqlDscAudit
     Audit_Remove_ShouldProcessVerboseDescription = Removing the audit '{0}' on the instance '{1}'.
     Audit_Remove_ShouldProcessVerboseWarning = Are you sure you want to remove the audit '{0}'?

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -62,7 +62,7 @@ ConvertFrom-StringData @'
     Audit_Missing = There is no audit with the name '{0}'.
 
     ## Get-SqlDscLogin
-    Login_Missing = There is no login with the name '{0}'.
+    Login_Get_Missing = There is no login with the name '{0}'.
 
     ## Remove-SqlDscAudit
     Audit_Remove_ShouldProcessVerboseDescription = Removing the audit '{0}' on the instance '{1}'.

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -31,19 +31,19 @@ BeforeAll {
 
 Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
-        $mockInstanceName = Get-ComputerName
+        $script:mockInstanceName = Get-ComputerName
 
-        $mockSqlAdministratorUserName = 'SqlAdmin' # Using computer name as NetBIOS name throw exception.
-        $mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+        $script:mockSqlAdministratorUserName = 'SqlAdmin' # Using the computer name as NetBIOS name throws an exception.
+        $script:mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
 
-        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
+        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($script:mockSqlAdministratorUserName, $script:mockSqlAdministratorPassword)
 
         $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
     }
 
     Context 'When getting all SQL Server logins' {
         It 'Should return an array of Login objects' {
-            $result = Get-SqlDscLogin -ServerObject $serverObject
+            $result = Get-SqlDscLogin -ServerObject $script:serverObject
 
             <#
                 Casting to array to ensure we get the count on Windows PowerShell
@@ -54,7 +54,7 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
         }
 
         It 'Should return system logins including sa' {
-            $result = Get-SqlDscLogin -ServerObject $serverObject
+            $result = Get-SqlDscLogin -ServerObject $script:serverObject
 
             $result.Name | Should -Contain 'sa'
         }
@@ -62,7 +62,7 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
     Context 'When getting a specific SQL Server login' {
         It 'Should return the specified login when it exists' {
-            $result = Get-SqlDscLogin -ServerObject $serverObject -Name 'sa'
+            $result = Get-SqlDscLogin -ServerObject $script:serverObject -Name 'sa'
 
             $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
             $result.Name | Should -Be 'sa'
@@ -70,12 +70,12 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
         }
 
         It 'Should throw an error when the login does not exist' {
-            { Get-SqlDscLogin -ServerObject $serverObject -Name 'NonExistentLogin' -ErrorAction 'Stop' } |
+            { Get-SqlDscLogin -ServerObject $script:serverObject -Name 'NonExistentLogin' -ErrorAction 'Stop' } |
                 Should -Throw -ExpectedMessage 'There is no login with the name ''NonExistentLogin''.'
         }
 
         It 'Should return null when the login does not exist and error action is SilentlyContinue' {
-            $result = Get-SqlDscLogin -ServerObject $serverObject -Name 'NonExistentLogin' -ErrorAction 'SilentlyContinue'
+            $result = Get-SqlDscLogin -ServerObject $script:serverObject -Name 'NonExistentLogin' -ErrorAction 'SilentlyContinue'
 
             $result | Should -BeNullOrEmpty
         }
@@ -83,8 +83,8 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
     Context 'When using the Refresh parameter' {
         It 'Should return the same results with and without Refresh' {
-            $resultWithoutRefresh = Get-SqlDscLogin -ServerObject $serverObject
-            $resultWithRefresh = Get-SqlDscLogin -ServerObject $serverObject -Refresh
+            $resultWithoutRefresh = Get-SqlDscLogin -ServerObject $script:serverObject
+            $resultWithRefresh = Get-SqlDscLogin -ServerObject $script:serverObject -Refresh
 
             @($resultWithoutRefresh).Count | Should -Be @($resultWithRefresh).Count
         }
@@ -92,7 +92,7 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
     Context 'When using pipeline input' {
         It 'Should accept ServerObject from pipeline' {
-            $result = $serverObject | Get-SqlDscLogin -Name 'sa'
+            $result = $script:serverObject | Get-SqlDscLogin -Name 'sa'
 
             $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
             $result.Name | Should -Be 'sa'

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -86,7 +86,7 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
             $resultWithoutRefresh = Get-SqlDscLogin -ServerObject $serverObject
             $resultWithRefresh = Get-SqlDscLogin -ServerObject $serverObject -Refresh
 
-            $resultWithoutRefresh.Count | Should -Be $resultWithRefresh.Count
+            @($resultWithoutRefresh).Count | Should -Be @($resultWithRefresh).Count
         }
     }
 

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -31,28 +31,14 @@ BeforeAll {
 
 Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
     BeforeAll {
-        $mockInstanceName = $env:COMPUTERNAME
-        $mockSqlCredential = $null
-        $mockConnectTimeout = 30
-        $mockEncryptConnection = $true
+        $mockInstanceName = Get-ComputerName
 
-        if ($env:INTEGRATION_TESTS_SQLSERVER_CREDENTIAL)
-        {
-            <#
-                This is set by the pipeline so we can run the tests towards the
-                SQL Server instance on the AppVeyor build worker.
-            #>
-            $mockSqlCredential = (ConvertFrom-Json -InputObject $env:INTEGRATION_TESTS_SQLSERVER_CREDENTIAL)
-        }
+        $mockSqlAdministratorUserName = 'SqlAdmin' # Using computer name as NetBIOS name throw exception.
+        $mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
 
-        try
-        {
-            $serverObject = Connect-SqlDscDatabaseEngine -InstanceName $mockInstanceName -Credential $mockSqlCredential -ConnectTimeout $mockConnectTimeout -EncryptConnection $mockEncryptConnection
-        }
-        catch
-        {
-            Set-ItResult -Skip -Because 'Could not connect to SQL Server instance'
-        }
+        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
+
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
     }
 
     Context 'When getting all SQL Server logins' {

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
                 when there is only one login.
             #>
             @($result).Count | Should -BeGreaterOrEqual 1
-            $result[0] | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
+            @($result)[0] | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
         }
 
         It 'Should return system logins including sa' {

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 
 
         It 'Should throw an error when the login does not exist' {
             { Get-SqlDscLogin -ServerObject $serverObject -Name 'NonExistentLogin' -ErrorAction 'Stop' } |
-                Should -Throw -ExpectedMessage "There is no login with the name 'NonExistentLogin'."
+                Should -Throw -ExpectedMessage 'There is no login with the name ''NonExistentLogin''.'
         }
 
         It 'Should return null when the login does not exist and error action is SilentlyContinue' {

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -1,0 +1,131 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Suppressing this rule because Script Analyzer does not understand Pester syntax.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:dscModuleName
+
+    # Loading stub cmdlets
+    Import-Module -Name "$PSScriptRoot/../../Stubs/SqlServerStub.psm1" -Force
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+    BeforeAll {
+        $mockInstanceName = $env:COMPUTERNAME
+        $mockSqlCredential = $null
+        $mockConnectTimeout = 30
+        $mockEncryptConnection = $true
+
+        if ($env:INTEGRATION_TESTS_SQLSERVER_CREDENTIAL)
+        {
+            <#
+                This is set by the pipeline so we can run the tests towards the
+                SQL Server instance on the AppVeyor build worker.
+            #>
+            $mockSqlCredential = (ConvertFrom-Json -InputObject $env:INTEGRATION_TESTS_SQLSERVER_CREDENTIAL)
+        }
+
+        try
+        {
+            $serverObject = Connect-SqlDscDatabaseEngine -InstanceName $mockInstanceName -Credential $mockSqlCredential -ConnectTimeout $mockConnectTimeout -EncryptConnection $mockEncryptConnection
+        }
+        catch
+        {
+            Set-ItResult -Skip -Because 'Could not connect to SQL Server instance'
+        }
+    }
+
+    Context 'When getting all SQL Server logins' {
+        It 'Should return an array of Login objects' {
+            $result = Get-SqlDscLogin -ServerObject $serverObject
+
+            <#
+                Casting to array to ensure we get the count on Windows PowerShell
+                when there is only one login.
+            #>
+            @($result).Count | Should -BeGreaterOrEqual 1
+            $result[0] | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
+        }
+
+        It 'Should return system logins including sa' {
+            $result = Get-SqlDscLogin -ServerObject $serverObject
+
+            $result.Name | Should -Contain 'sa'
+        }
+    }
+
+    Context 'When getting a specific SQL Server login' {
+        It 'Should return the specified login when it exists' {
+            $result = Get-SqlDscLogin -ServerObject $serverObject -Name 'sa'
+
+            $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
+            $result.Name | Should -Be 'sa'
+            $result.LoginType | Should -Be 'SqlLogin'
+        }
+
+        It 'Should throw an error when the login does not exist' {
+            { Get-SqlDscLogin -ServerObject $serverObject -Name 'NonExistentLogin' -ErrorAction 'Stop' } |
+                Should -Throw -ExpectedMessage "There is no login with the name 'NonExistentLogin'."
+        }
+
+        It 'Should return null when the login does not exist and error action is SilentlyContinue' {
+            $result = Get-SqlDscLogin -ServerObject $serverObject -Name 'NonExistentLogin' -ErrorAction 'SilentlyContinue'
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When using the Refresh parameter' {
+        It 'Should return the same results with and without Refresh' {
+            $resultWithoutRefresh = Get-SqlDscLogin -ServerObject $serverObject
+            $resultWithRefresh = Get-SqlDscLogin -ServerObject $serverObject -Refresh
+
+            $resultWithoutRefresh.Count | Should -Be $resultWithRefresh.Count
+        }
+    }
+
+    Context 'When using pipeline input' {
+        It 'Should accept ServerObject from pipeline' {
+            $result = $serverObject | Get-SqlDscLogin -Name 'sa'
+
+            $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
+            $result.Name | Should -Be 'sa'
+        }
+    }
+}

--- a/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1
@@ -27,22 +27,6 @@ BeforeAll {
     $script:dscModuleName = 'SqlServerDsc'
 
     Import-Module -Name $script:dscModuleName
-
-    # Loading stub cmdlets
-    Import-Module -Name "$PSScriptRoot/../../Stubs/SqlServerStub.psm1" -Force
-
-    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
-    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
-    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
-}
-
-AfterAll {
-    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
-    $PSDefaultParameterValues.Remove('Mock:ModuleName')
-    $PSDefaultParameterValues.Remove('Should:ModuleName')
-
-    # Unload the module being tested so that it doesn't impact any other tests.
-    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
 }
 
 Describe 'Get-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {

--- a/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
@@ -28,7 +28,7 @@ BeforeAll {
 
     $env:SqlServerDscCI = $true
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     # Loading mocked classes
     Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')

--- a/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
@@ -75,6 +75,23 @@ Describe 'Get-SqlDscLogin' -Tag 'Public' {
         $result.ParameterListAsString | Should -Be $MockExpectedParameters
     }
 
+    It 'Should have the correct parameter metadata for ServerObject, Name, and Refresh' {
+        $cmd = Get-Command -Name 'Get-SqlDscLogin'
+        
+        # Test ServerObject parameter
+        $cmd.Parameters['ServerObject'].ParameterType.FullName | Should -Be 'Microsoft.SqlServer.Management.Smo.Server'
+        $cmd.Parameters['ServerObject'].Attributes.Mandatory | Should -BeTrue
+        $cmd.Parameters['ServerObject'].Attributes.ValueFromPipeline | Should -BeTrue
+        
+        # Test Name parameter
+        $cmd.Parameters['Name'].ParameterType.FullName | Should -Be 'System.String'
+        $cmd.Parameters['Name'].Attributes.Mandatory | Should -BeFalse
+        
+        # Test Refresh parameter
+        $cmd.Parameters['Refresh'].ParameterType.FullName | Should -Be 'System.Management.Automation.SwitchParameter'
+        $cmd.Parameters['Refresh'].Attributes.Mandatory | Should -BeFalse
+    }
+
     Context 'When no login exists' {
         BeforeAll {
             $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |

--- a/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
@@ -6,14 +6,14 @@ BeforeDiscovery {
     {
         if (-not (Get-Module -Name 'DscResource.Test'))
         {
-            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
             if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
             {
                 # Redirect all streams to $null, except the error stream (stream 2)
                 & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
             }
 
-            # If the dependencies has not been resolved, this will throw an error.
+            # If the dependencies have not been resolved, this will throw an error.
             Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
         }
     }
@@ -75,7 +75,7 @@ Describe 'Get-SqlDscLogin' -Tag 'Public' {
         $result.ParameterListAsString | Should -Be $MockExpectedParameters
     }
 
-    Context 'When no login exist' {
+    Context 'When no login exists' {
         BeforeAll {
             $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |
                 Add-Member -MemberType 'ScriptProperty' -Name 'Logins' -Value {

--- a/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
@@ -91,7 +91,7 @@ Describe 'Get-SqlDscLogin' -Tag 'Public' {
         Context 'When specifying to throw on error' {
             BeforeAll {
                 $mockErrorMessage = InModuleScope -ScriptBlock {
-                    $script:localizedData.Login_Missing
+                    $script:localizedData.Login_Get_Missing
                 }
             }
 

--- a/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscLogin.Tests.ps1
@@ -1,0 +1,223 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    $env:SqlServerDscCI = $true
+
+    Import-Module -Name $script:dscModuleName
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Item -Path 'env:SqlServerDscCI'
+}
+
+Describe 'Get-SqlDscLogin' -Tag 'Public' {
+    It 'Should have the correct parameters in parameter set <MockParameterSetName>' -ForEach @(
+        @{
+            MockParameterSetName = '__AllParameterSets'
+            MockExpectedParameters = '[-ServerObject] <Server> [[-Name] <string>] [-Refresh] [<CommonParameters>]'
+        }
+    ) {
+        $result = (Get-Command -Name 'Get-SqlDscLogin').ParameterSets |
+            Where-Object -FilterScript {
+                $_.Name -eq $mockParameterSetName
+            } |
+            Select-Object -Property @(
+                @{
+                    Name = 'ParameterSetName'
+                    Expression = { $_.Name }
+                },
+                @{
+                    Name = 'ParameterListAsString'
+                    Expression = { $_.ToString() }
+                }
+            )
+
+        $result.ParameterSetName | Should -Be $MockParameterSetName
+        $result.ParameterListAsString | Should -Be $MockExpectedParameters
+    }
+
+    Context 'When no login exist' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server' |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Logins' -Value {
+                    return @{}
+                } -PassThru -Force
+
+            $mockDefaultParameters = @{
+                ServerObject = $mockServerObject
+                Name = 'TestLogin'
+            }
+        }
+
+        Context 'When specifying to throw on error' {
+            BeforeAll {
+                $mockErrorMessage = InModuleScope -ScriptBlock {
+                    $script:localizedData.Login_Missing
+                }
+            }
+
+            It 'Should throw the correct error' {
+                { Get-SqlDscLogin @mockDefaultParameters -ErrorAction 'Stop' } |
+                    Should -Throw -ExpectedMessage ($mockErrorMessage -f 'TestLogin')
+            }
+        }
+
+        Context 'When ignoring the error' {
+            It 'Should not throw an exception and return $null' {
+                Get-SqlDscLogin @mockDefaultParameters -ErrorAction 'SilentlyContinue' |
+                    Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'When getting a specific login' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject.InstanceName = 'TestInstance'
+
+            $mockServerObject = $mockServerObject |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Logins' -Value {
+                    return @{
+                        'TestLogin' = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList @(
+                            $mockServerObject,
+                            'TestLogin'
+                        )
+                    }
+                } -PassThru -Force
+
+            $mockDefaultParameters = @{
+                ServerObject = $mockServerObject
+                Name = 'TestLogin'
+            }
+        }
+
+        It 'Should return the correct values' {
+            $result = Get-SqlDscLogin @mockDefaultParameters
+
+            $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
+            $result.Name | Should -Be 'TestLogin'
+        }
+
+        Context 'When passing parameter ServerObject over the pipeline' {
+            It 'Should return the correct values' {
+                $result = $mockServerObject | Get-SqlDscLogin -Name 'TestLogin'
+
+                $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
+                $result.Name | Should -Be 'TestLogin'
+            }
+        }
+    }
+
+    Context 'When getting all current logins' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject.InstanceName = 'TestInstance'
+
+            $mockServerObject = $mockServerObject |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Logins' -Value {
+                    return @(
+                        (
+                            New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList @(
+                                $mockServerObject,
+                                'TestLogin1'
+                            )
+                        ),
+                        (
+                            New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList @(
+                                $mockServerObject,
+                                'TestLogin2'
+                            )
+                        )
+                    )
+                } -PassThru -Force
+
+            $mockDefaultParameters = @{
+                ServerObject = $mockServerObject
+            }
+        }
+
+        It 'Should return the correct values' {
+            $result = Get-SqlDscLogin @mockDefaultParameters
+
+            $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Login'
+            $result | Should -HaveCount 2
+            $result.Name | Should -Contain 'TestLogin1'
+            $result.Name | Should -Contain 'TestLogin2'
+        }
+    }
+
+    Context 'When using the Refresh parameter' {
+        BeforeAll {
+            $script:mockRefreshCallCount = 0
+
+            $mockLoginsCollection = @{
+                'TestLogin' = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList @(
+                    $null,
+                    'TestLogin'
+                )
+            } |
+                Add-Member -MemberType 'ScriptMethod' -Name 'Refresh' -Value {
+                    $script:mockRefreshCallCount++
+                } -PassThru -Force
+
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject.InstanceName = 'TestInstance'
+
+            $mockServerObject = $mockServerObject |
+                Add-Member -MemberType 'ScriptProperty' -Name 'Logins' -Value {
+                    return $mockLoginsCollection
+                } -PassThru -Force
+
+            $mockDefaultParameters = @{
+                ServerObject = $mockServerObject
+                Name = 'TestLogin'
+                Refresh = $true
+            }
+        }
+
+        It 'Should call the Refresh method on the Logins collection' {
+            Get-SqlDscLogin @mockDefaultParameters
+
+            $script:mockRefreshCallCount | Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION

#### Pull Request (PR) description
- `Get-SqlDscLogin`
  - Added new public command to get a SQL Server login from a Database Engine instance.
  - Returns a `Microsoft.SqlServer.Management.Smo.Login` object that represents
    the login.
  - Supports getting a specific login by name or all logins if no name is specified.
  - Includes a `-Refresh` parameter to refresh the server's login collection
    before retrieval.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2134)
<!-- Reviewable:end -->
