### PR TITLE
`Remove-SqlDscLogin`: Command to delete SQL Server logins

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,7 @@
             "label": "build",
             "type": "shell",
             "command": "&${cwd}/build.ps1",
-            "args": [],
+            "args": ["-AutoRestore", "-UseModuleFast", "-Tasks", "build"],
             "presentation": {
                 "echo": true,
                 "reveal": "always",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make sure tests forcibly imports the module being tested to avoid AI failing
   when testing changes.
+- VS Code tasks configuration was improved to support AI.
 
 ### Added
 
@@ -27,9 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Supports getting a specific login by name or all logins if no name is specified.
   - Includes a `-Refresh` parameter to refresh the server's login collection
     before retrieval.
+- `Remove-SqlDscLogin`
+  - Added new public command to remove a SQL Server login from a Database
+    Engine instance.
+  - Supports removing a login by specifying a `ServerObject` and `Name`, or by
+    passing a `LoginObject` through the pipeline.
+  - Includes confirmation prompts with `-Force` parameter to bypass confirmation.
+  - Includes a `-Refresh` parameter to refresh the server's login collection
+    before attempting removal.
+  - Provides detailed error messages with localization support.
 
 ### Changed
 
+- Module no longer outputs a warning message during import if SMO dependency
+  module does not exist, it now outputs a verbose message which is normally
+  silent by default. This change was made to workaround an issue with DSC v3.
 - `azure-pipelines.yml`
   - Remove `windows-2019` images fixes [#2106](https://github.com/dsccommunity/SqlServerDsc/issues/2106).
   - Move individual tasks to `windows-latest`.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -250,6 +250,7 @@ stages:
                   # Group 2
                   'tests/Integration/Commands/Assert-SqlDscLogin.Integration.Tests.ps1'
                   'tests/Integration/Commands/Get-SqlDscLogin.Integration.Tests.ps1'
+                  'tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1'
                   # Group 9
                   'tests/Integration/Commands/Uninstall-SqlDscServer.Integration.Tests.ps1'
               )

--- a/source/Public/Remove-SqlDscLogin.ps1
+++ b/source/Public/Remove-SqlDscLogin.ps1
@@ -1,0 +1,137 @@
+<#
+    .SYNOPSIS
+        Removes a SQL Server login.
+
+    .DESCRIPTION
+        This command removes a SQL Server login from a SQL Server Database Engine instance.
+
+    .PARAMETER ServerObject
+        Specifies current server connection object.
+
+    .PARAMETER LoginObject
+        Specifies a login object to remove.
+
+    .PARAMETER Name
+        Specifies the name of the server login to be removed.
+
+    .PARAMETER Force
+        Specifies that the login should be removed without any confirmation.
+
+    .PARAMETER Refresh
+        Specifies that the **ServerObject**'s logins should be refreshed before
+        trying removing the login object. This is helpful when logins could have
+        been modified outside of the **ServerObject**, for example through T-SQL.
+        But on instances with a large amount of logins it might be better to make
+        sure the **ServerObject** is recent enough, or pass in **LoginObject**.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $loginObject = $serverObject | Get-SqlDscLogin -Name 'MyLogin'
+        $loginObject | Remove-SqlDscLogin
+
+        Removes the login named **MyLogin**.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $serverObject | Remove-SqlDscLogin -Name 'MyLogin'
+
+        Removes the login named **MyLogin**.
+
+    .INPUTS
+        Microsoft.SqlServer.Management.Smo.Server
+
+        Specifies a server connection object.
+
+    .INPUTS
+        Microsoft.SqlServer.Management.Smo.Login
+
+        Specifies a login object.
+
+    .OUTPUTS
+        None.
+#>
+function Remove-SqlDscLogin
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
+    [OutputType()]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param
+    (
+        [Parameter(ParameterSetName = 'ServerObject', Mandatory = $true, ValueFromPipeline = $true)]
+        [Microsoft.SqlServer.Management.Smo.Server]
+        $ServerObject,
+
+        [Parameter(ParameterSetName = 'LoginObject', Mandatory = $true, ValueFromPipeline = $true)]
+        [Microsoft.SqlServer.Management.Smo.Login]
+        $LoginObject,
+
+        [Parameter(ParameterSetName = 'ServerObject', Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Force,
+
+        [Parameter(ParameterSetName = 'ServerObject')]
+        [System.Management.Automation.SwitchParameter]
+        $Refresh
+    )
+
+    process
+    {
+        if ($Force.IsPresent -and -not $Confirm)
+        {
+            $ConfirmPreference = 'None'
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'ServerObject')
+        {
+            $getSqlDscLoginParameters = @{
+                ServerObject = $ServerObject
+                Name         = $Name
+                Refresh      = $Refresh
+                ErrorAction  = 'Stop'
+            }
+
+            # If this command does not find the login it will throw an exception.
+            $loginObjectArray = Get-SqlDscLogin @getSqlDscLoginParameters
+
+            # Pick the only object in the array.
+            $LoginObject = $loginObjectArray | Select-Object -First 1
+        }
+
+        $verboseDescriptionMessage = $script:localizedData.Login_Remove_ShouldProcessVerboseDescription -f $LoginObject.Name, $LoginObject.Parent.InstanceName
+        $verboseWarningMessage = $script:localizedData.Login_Remove_ShouldProcessVerboseWarning -f $LoginObject.Name
+        $captionMessage = $script:localizedData.Login_Remove_ShouldProcessCaption
+
+        if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
+        {
+            try
+            {
+                $originalErrorActionPreference = $ErrorActionPreference
+
+                $ErrorActionPreference = 'Stop'
+
+                $LoginObject.Drop()
+            }
+            catch
+            {
+                $errorMessage = $script:localizedData.Login_Remove_Failed -f $LoginObject.Name
+
+                $PSCmdlet.ThrowTerminatingError(
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.InvalidOperationException]::new($errorMessage, $_.Exception),
+                        'RSDL0001', # cspell: disable-line
+                        [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                        $LoginObject.Name
+                    )
+                )
+            }
+            finally
+            {
+                $ErrorActionPreference = $originalErrorActionPreference
+            }
+        }
+    }
+}

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -67,6 +67,13 @@ ConvertFrom-StringData @'
     Login_Get_RetrievingByName = Retrieving login by name '{0}' from server '{1}'.
     Login_Get_ReturningAllLogins = Returning all logins from server '{0}'.
 
+    ## Remove-SqlDscLogin
+    Login_Remove_ShouldProcessVerboseDescription = Removing the login '{0}' on the instance '{1}'.
+    Login_Remove_ShouldProcessVerboseWarning = Are you sure you want to remove the login '{0}'?
+    # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
+    Login_Remove_ShouldProcessCaption = Remove login on instance
+    Login_Remove_Failed = Removal of the login '{0}' failed. (RSDL0001)
+
     ## Remove-SqlDscAudit
     Audit_Remove_ShouldProcessVerboseDescription = Removing the audit '{0}' on the instance '{1}'.
     Audit_Remove_ShouldProcessVerboseWarning = Are you sure you want to remove the audit '{0}'?

--- a/source/suffix.ps1
+++ b/source/suffix.ps1
@@ -21,6 +21,6 @@ if (-not $env:SqlServerDscCI)
             It is not possible to throw the error from Import-SqlDscPreferredModule
             since it will just fail the command Import-Module with an obscure error.
         #>
-        Write-Warning -Message $_.Exception.Message
+        Write-Verbose -Message $_.Exception.Message
     }
 }

--- a/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Remove-SqlDscLogin.Integration.Tests.ps1
@@ -1,0 +1,197 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Suppressing this rule because Script Analyzer does not understand Pester syntax.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies have not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:dscModuleName
+}
+
+Describe 'Remove-SqlDscLogin' -Tag @('Integration_SQL2016', 'Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+    BeforeAll {
+        # Starting the named instance SQL Server service prior to running tests.
+        Start-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
+
+        $script:mockInstanceName = 'DSCSQLTEST'
+        $script:mockComputerName = Get-ComputerName
+
+        $mockSqlAdministratorUserName = 'SqlAdmin' # Using computer name as NetBIOS name throw exception.
+        $mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+
+        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
+
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential
+    }
+
+    AfterAll {
+        Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject
+
+        # Stop the named instance SQL Server service to save memory on the build worker.
+        Stop-Service -Name 'MSSQL$DSCSQLTEST' -Verbose -ErrorAction 'Stop'
+    }
+
+    Context 'When removing a SQL Server login by ServerObject and Name' {
+        BeforeAll {
+            $script:testLoginName = 'TestRemoveLogin1'
+            $script:testLoginPassword = ConvertTo-SecureString -String 'P@ssw0rd1!' -AsPlainText -Force
+            $script:testLoginCredential = [System.Management.Automation.PSCredential]::new($script:testLoginName, $script:testLoginPassword)
+        }
+
+        BeforeEach {
+            # Create the test login
+            $createLoginQuery = "CREATE LOGIN [$($script:testLoginName)] WITH PASSWORD = 'P@ssw0rd1!'"
+            Invoke-SqlDscQuery -ServerObject $script:serverObject -Query $createLoginQuery
+        }
+
+        AfterEach {
+            # Clean up - remove the login if it still exists
+            try {
+                $cleanupQuery = "IF EXISTS (SELECT name FROM sys.server_principals WHERE name = '$($script:testLoginName)') DROP LOGIN [$($script:testLoginName)]"
+                Invoke-SqlDscQuery -ServerObject $script:serverObject -Query $cleanupQuery
+            }
+            catch {
+                # Ignore cleanup errors
+            }
+        }
+
+        It 'Should remove the login when it exists' {
+            # Verify the login exists
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName
+            $loginExists | Should -BeTrue
+
+            # Remove the login
+            $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -Force
+
+            # Verify the login is removed
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName
+            $loginExists | Should -BeFalse
+        }
+
+        It 'Should handle WhatIf parameter correctly' {
+            # Verify the login exists
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName
+            $loginExists | Should -BeTrue
+
+            # Use WhatIf - login should not be removed
+            $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -WhatIf
+
+            # Verify the login still exists
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName
+            $loginExists | Should -BeTrue
+        }
+
+        It 'Should throw an error when the login does not exist' {
+            # Remove the login first to ensure it doesn't exist
+            $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -Force
+
+            # Try to remove a non-existent login
+            {
+                $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName -Force -ErrorAction 'Stop'
+            } | Should -Throw -ExpectedMessage "*There is no login with the name '$($script:testLoginName)'*"
+        }
+    }
+
+    Context 'When removing a SQL Server login by LoginObject' {
+        BeforeAll {
+            $script:testLoginName2 = 'TestRemoveLogin2'
+            $script:testLoginPassword2 = ConvertTo-SecureString -String 'P@ssw0rd2!' -AsPlainText -Force
+            $script:testLoginCredential2 = [System.Management.Automation.PSCredential]::new($script:testLoginName2, $script:testLoginPassword2)
+        }
+
+        BeforeEach {
+            # Create the test login
+            $createLoginQuery = "CREATE LOGIN [$($script:testLoginName2)] WITH PASSWORD = 'P@ssw0rd2!'"
+            Invoke-SqlDscQuery -ServerObject $script:serverObject -Query $createLoginQuery
+        }
+
+        AfterEach {
+            # Clean up - remove the login if it still exists
+            try {
+                $cleanupQuery = "IF EXISTS (SELECT name FROM sys.server_principals WHERE name = '$($script:testLoginName2)') DROP LOGIN [$($script:testLoginName2)]"
+                Invoke-SqlDscQuery -ServerObject $script:serverObject -Query $cleanupQuery
+            }
+            catch {
+                # Ignore cleanup errors
+            }
+        }
+
+        It 'Should remove the login when passed as LoginObject' {
+            # Get the login object
+            $loginObject = Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName2
+
+            # Verify the login exists
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName2
+            $loginExists | Should -BeTrue
+
+            # Remove the login using LoginObject
+            $loginObject | Remove-SqlDscLogin -Force
+
+            # Verify the login is removed
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName2
+            $loginExists | Should -BeFalse
+        }
+
+        It 'Should handle pipeline input correctly' {
+            # Get the login object and remove it via pipeline
+            Get-SqlDscLogin -ServerObject $script:serverObject -Name $script:testLoginName2 | Remove-SqlDscLogin -Force
+
+            # Verify the login is removed
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName2
+            $loginExists | Should -BeFalse
+        }
+    }
+
+    Context 'When using the Refresh parameter' {
+        BeforeAll {
+            $script:testLoginName3 = 'TestRemoveLogin3'
+        }
+
+        BeforeEach {
+            # Create the test login
+            $createLoginQuery = "CREATE LOGIN [$($script:testLoginName3)] WITH PASSWORD = 'P@ssw0rd3!'"
+            Invoke-SqlDscQuery -ServerObject $script:serverObject -Query $createLoginQuery
+        }
+
+        AfterEach {
+            # Clean up - remove the login if it still exists
+            try {
+                $cleanupQuery = "IF EXISTS (SELECT name FROM sys.server_principals WHERE name = '$($script:testLoginName3)') DROP LOGIN [$($script:testLoginName3)]"
+                Invoke-SqlDscQuery -ServerObject $script:serverObject -Query $cleanupQuery
+            }
+            catch {
+                # Ignore cleanup errors
+            }
+        }
+
+        It 'Should work with the Refresh parameter' {
+            # Remove the login with Refresh parameter
+            $script:serverObject | Remove-SqlDscLogin -Name $script:testLoginName3 -Refresh -Force
+
+            # Verify the login is removed
+            $loginExists = Test-SqlDscIsLogin -ServerObject $script:serverObject -Name $script:testLoginName3
+            $loginExists | Should -BeFalse
+        }
+    }
+}

--- a/tests/Unit/Public/Remove-SqlDscLogin.Tests.ps1
+++ b/tests/Unit/Public/Remove-SqlDscLogin.Tests.ps1
@@ -1,0 +1,227 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Suppressing this rule because Script Analyzer does not understand Pester syntax.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies have not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    $env:SqlServerDscCI = $true
+
+    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Item -Path 'env:SqlServerDscCI'
+}
+
+Describe 'Remove-SqlDscLogin' -Tag 'Public' {
+    It 'Should have the correct parameters in parameter set <MockParameterSetName>' -ForEach @(
+        @{
+            MockParameterSetName = 'ServerObject'
+            MockExpectedParameters = '-ServerObject <Server> -Name <string> [-Force] [-Refresh] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+        @{
+            MockParameterSetName = 'LoginObject'
+            MockExpectedParameters = '-LoginObject <Login> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]'
+        }
+    ) {
+        $result = (Get-Command -Name 'Remove-SqlDscLogin').ParameterSets |
+            Where-Object -FilterScript {
+                $_.Name -eq $mockParameterSetName
+            } |
+            Select-Object -Property @(
+                @{
+                    Name = 'ParameterSetName'
+                    Expression = { $_.Name }
+                },
+                @{
+                    Name = 'ParameterListAsString'
+                    Expression = { $_.ToString() }
+                }
+            )
+
+        $result.ParameterSetName | Should -Be $MockParameterSetName
+        $result.ParameterListAsString | Should -Be $MockExpectedParameters
+    }
+
+    Context 'When removing a login by ServerObject' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject.InstanceName = 'TestInstance'
+
+            Mock -CommandName Get-SqlDscLogin -MockWith {
+                return New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList @(
+                    $mockServerObject,
+                    'TestLogin'
+                ) |
+                    Add-Member -MemberType 'ScriptMethod' -Name 'Drop' -Value {
+                        $script:mockMethodDropCallCount += 1
+                    } -PassThru -Force
+            }
+
+            $mockDefaultParameters = @{
+                ServerObject = $mockServerObject
+                Name = 'TestLogin'
+            }
+        }
+
+        BeforeEach {
+            $script:mockMethodDropCallCount = 0
+        }
+
+        Context 'When using parameter Confirm with value $false' {
+            It 'Should call the mocked method and have correct values in the object' {
+                Remove-SqlDscLogin -Confirm:$false @mockDefaultParameters
+
+                $mockMethodDropCallCount | Should -Be 1
+            }
+        }
+
+        Context 'When using parameter Force' {
+            It 'Should call the mocked method and have correct values in the object' {
+                Remove-SqlDscLogin -Force @mockDefaultParameters
+
+                $mockMethodDropCallCount | Should -Be 1
+            }
+        }
+
+        Context 'When using parameter WhatIf' {
+            It 'Should call the mocked method and have correct values in the object' {
+                Remove-SqlDscLogin -WhatIf @mockDefaultParameters
+
+                $mockMethodDropCallCount | Should -Be 0
+            }
+        }
+
+        Context 'When passing parameter ServerObject over the pipeline' {
+            It 'Should call the mocked method and have correct values in the object' {
+                $mockServerObject | Remove-SqlDscLogin -Name 'TestLogin' -Force
+
+                $mockMethodDropCallCount | Should -Be 1
+            }
+        }
+
+        Context 'When using parameter Refresh' {
+            It 'Should call Get-SqlDscLogin with Refresh parameter' {
+                $mockServerObject | Remove-SqlDscLogin -Name 'TestLogin' -Refresh -Force
+
+                Should -Invoke -CommandName Get-SqlDscLogin -ParameterFilter {
+                    $Refresh -eq $true
+                }
+            }
+        }
+    }
+
+    Context 'When removing a login by LoginObject' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject.InstanceName = 'TestInstance'
+
+            $mockLoginObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList @(
+                $mockServerObject,
+                'TestLogin'
+            ) |
+                Add-Member -MemberType 'ScriptMethod' -Name 'Drop' -Value {
+                    $script:mockMethodDropCallCount += 1
+                } -PassThru -Force
+
+            $mockDefaultParameters = @{
+                LoginObject = $mockLoginObject
+            }
+        }
+
+        BeforeEach {
+            $script:mockMethodDropCallCount = 0
+        }
+
+        Context 'When using parameter Confirm with value $false' {
+            It 'Should call the mocked method and have correct values in the object' {
+                Remove-SqlDscLogin -Confirm:$false @mockDefaultParameters
+
+                $mockMethodDropCallCount | Should -Be 1
+            }
+        }
+
+        Context 'When using parameter Force' {
+            It 'Should call the mocked method and have correct values in the object' {
+                Remove-SqlDscLogin -Force @mockDefaultParameters
+
+                $mockMethodDropCallCount | Should -Be 1
+            }
+        }
+
+        Context 'When using parameter WhatIf' {
+            It 'Should call the mocked method and have correct values in the object' {
+                Remove-SqlDscLogin -WhatIf @mockDefaultParameters
+
+                $mockMethodDropCallCount | Should -Be 0
+            }
+        }
+
+        Context 'When passing parameter LoginObject over the pipeline' {
+            It 'Should call the mocked method and have correct values in the object' {
+                $mockLoginObject | Remove-SqlDscLogin -Force
+
+                $mockMethodDropCallCount | Should -Be 1
+            }
+        }
+    }
+
+    Context 'When Drop() method throws an exception' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject.InstanceName = 'TestInstance'
+
+            $mockLoginObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Login' -ArgumentList @(
+                $mockServerObject,
+                'TestLogin'
+            ) |
+                Add-Member -MemberType 'ScriptMethod' -Name 'Drop' -Value {
+                    throw 'Mock drop exception'
+                } -PassThru -Force
+
+            $mockDefaultParameters = @{
+                LoginObject = $mockLoginObject
+            }
+        }
+
+        It 'Should throw the correct error when Drop() method fails' {
+            { Remove-SqlDscLogin -Force @mockDefaultParameters } | Should -Throw -ExpectedMessage '*Removal of the login ''TestLogin'' failed*'
+        }
+    }
+}


### PR DESCRIPTION

#### Pull Request (PR) description
- Module no longer outputs a warning message during import if SMO dependency
  module does not exist, it now outputs a verbose message which is normally
  silent by default. This change was made to workaround an issue with DSC v3.
- VS Code tasks configuration was improved to support AI.
- `Remove-SqlDscLogin`
  - Added new public command to remove a SQL Server login from a Database
    Engine instance.
  - Supports removing a login by specifying a `ServerObject` and `Name`, or by
    passing a `LoginObject` through the pipeline.
  - Includes confirmation prompts with `-Force` parameter to bypass confirmation.
  - Includes a `-Refresh` parameter to refresh the server's login collection
    before attempting removal.
  - Provides detailed error messages with localization support.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
