### PR TITLE
Fix to be compliant with QA tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ValidateSet for the Edition property.
 - Fixed commands continuing execution after `Assert-ElevatedUser` elevation
   errors by setting `$ErrorActionPreference = 'Stop'` [issue #2070](https://github.com/dsccommunity/SqlServerDsc/issues/2070)
+- Fixed incorrect array-return syntax in several public `Get-*` commands by
+  removing a leading comma in return statements which could cause incorrect
+  output and ScriptAnalyzer warnings: `Get-SqlDscAudit`,
+  `Get-SqlDscConfigurationOption`, `Get-SqlDscDatabasePermission`,
+  `Get-SqlDscServerPermission`, and `Get-SqlDscTraceFlag`.
+- New-SqlDscDatabase: use `New-ArgumentException` instead of
+  `New-InvalidArgumentException` for parameter validation errors.
 
 ### Added
 
@@ -131,6 +138,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved markdown, pester, powershell, and changelog instructions.
   - Fixed `Ignore` that seems in edge-cases fail.
   - Improved markdown and changelog instructions.
+- `RequiredModules.psd1`
+  - Updated `DscResource.Test` dependency to `latest` (was pinned to `0.17.2`).
+- Examples
+  - `source/Examples/Resources/SqlSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1`
+    - Removed redundant `$SqlAdministratorCredential` parameter from example
+      configuration.
 
 ## [17.1.0] - 2025-05-22
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -28,7 +28,7 @@
     Sampler                        = 'latest'
     'Sampler.GitHubTasks'          = 'latest'
     MarkdownLinkCheck              = 'latest'
-    'DscResource.Test'             = '0.17.2'
+    'DscResource.Test'             = 'latest'
     xDscResourceDesigner           = 'latest'
 
     # Build dependencies needed for using the module

--- a/source/Examples/Resources/SqlSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
+++ b/source/Examples/Resources/SqlSetup/5-InstallNamedInstanceInFailoverClusterSecondNode.ps1
@@ -36,11 +36,6 @@ Configuration Example
         [System.Management.Automation.PSCredential]
         $SqlInstallCredential,
 
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.PSCredential]
-        $SqlAdministratorCredential = $SqlInstallCredential,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]

--- a/source/Public/Get-SqlDscAudit.ps1
+++ b/source/Public/Get-SqlDscAudit.ps1
@@ -25,7 +25,7 @@
         Get the audit named **MyFileAudit**.
 
     .OUTPUTS
-        `[Microsoft.SqlServer.Management.Smo.Audit]`
+        `[Microsoft.SqlServer.Management.Smo.Audit[]]`
 #>
 function Get-SqlDscAudit
 {
@@ -61,7 +61,7 @@ function Get-SqlDscAudit
         {
             $auditObject = $ServerObject.Audits[$Name]
 
-            if (-not $AuditObject)
+            if (-not $auditObject)
             {
                 $missingAuditMessage = $script:localizedData.Audit_Missing -f $Name
 

--- a/source/Public/Get-SqlDscAudit.ps1
+++ b/source/Public/Get-SqlDscAudit.ps1
@@ -29,7 +29,6 @@
 #>
 function Get-SqlDscAudit
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [OutputType([Microsoft.SqlServer.Management.Smo.Audit[]])]
     [CmdletBinding()]
@@ -81,6 +80,6 @@ function Get-SqlDscAudit
             $auditObject = $ServerObject.Audits
         }
 
-        return , [Microsoft.SqlServer.Management.Smo.Audit[]] $auditObject
+        return [Microsoft.SqlServer.Management.Smo.Audit[]] $auditObject
     }
 }

--- a/source/Public/Get-SqlDscAudit.ps1
+++ b/source/Public/Get-SqlDscAudit.ps1
@@ -26,6 +26,7 @@
 
     .OUTPUTS
         `[Microsoft.SqlServer.Management.Smo.Audit[]]`
+        Array of SMO Audit objects from the target SQL Server instance.
 #>
 function Get-SqlDscAudit
 {

--- a/source/Public/Get-SqlDscConfigurationOption.ps1
+++ b/source/Public/Get-SqlDscConfigurationOption.ps1
@@ -31,6 +31,7 @@
 
     .OUTPUTS
         `[Microsoft.SqlServer.Management.Smo.ConfigProperty[]]`
+        Array of SMO ConfigProperty objects representing server configuration options.
 #>
 function Get-SqlDscConfigurationOption
 {

--- a/source/Public/Get-SqlDscConfigurationOption.ps1
+++ b/source/Public/Get-SqlDscConfigurationOption.ps1
@@ -57,12 +57,12 @@ function Get-SqlDscConfigurationOption
         if ($Refresh.IsPresent)
         {
             # Make sure the configuration option values are up-to-date.
-            $serverObject.Configuration.Refresh()
+            $ServerObject.Configuration.Refresh()
         }
 
         if ($PSBoundParameters.ContainsKey('Name'))
         {
-            $configurationOption = $serverObject.Configuration.Properties |
+            $configurationOption = $ServerObject.Configuration.Properties |
                 Where-Object -FilterScript {
                     $_.DisplayName -like $Name
                 }
@@ -83,7 +83,7 @@ function Get-SqlDscConfigurationOption
         }
         else
         {
-            $configurationOption = $serverObject.Configuration.Properties.ForEach({ $_ })
+            $configurationOption = $ServerObject.Configuration.Properties.ForEach({ $_ })
         }
 
         return [Microsoft.SqlServer.Management.Smo.ConfigProperty[]] (

--- a/source/Public/Get-SqlDscConfigurationOption.ps1
+++ b/source/Public/Get-SqlDscConfigurationOption.ps1
@@ -34,7 +34,6 @@
 #>
 function Get-SqlDscConfigurationOption
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [OutputType([Microsoft.SqlServer.Management.Smo.ConfigProperty[]])]
     [CmdletBinding()]
@@ -87,7 +86,7 @@ function Get-SqlDscConfigurationOption
             $configurationOption = $serverObject.Configuration.Properties.ForEach({ $_ })
         }
 
-        return , [Microsoft.SqlServer.Management.Smo.ConfigProperty[]] (
+        return [Microsoft.SqlServer.Management.Smo.ConfigProperty[]] (
             $configurationOption |
                 Sort-Object -Property 'DisplayName'
         )

--- a/source/Public/Get-SqlDscDatabasePermission.ps1
+++ b/source/Public/Get-SqlDscDatabasePermission.ps1
@@ -36,7 +36,6 @@
 #>
 function Get-SqlDscDatabasePermission
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('AvoidThrowOutsideOfTry', '', Justification = 'Because the code throws based on an prior expression')]
     [CmdletBinding()]
@@ -97,6 +96,6 @@ function Get-SqlDscDatabasePermission
             Write-Error -Message $missingDatabaseMessage -Category 'InvalidOperation' -ErrorId 'GSDDP0002' -TargetObject $DatabaseName
         }
 
-        return , [Microsoft.SqlServer.Management.Smo.DatabasePermissionInfo[]] $getSqlDscDatabasePermissionResult
+        return [Microsoft.SqlServer.Management.Smo.DatabasePermissionInfo[]] $getSqlDscDatabasePermissionResult
     }
 }

--- a/source/Public/Get-SqlDscServerPermission.ps1
+++ b/source/Public/Get-SqlDscServerPermission.ps1
@@ -95,7 +95,6 @@
 #>
 function Get-SqlDscServerPermission
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.String[]] when using , (comma) in the return statement')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('AvoidThrowOutsideOfTry', '', Justification = 'Because the code throws based on an prior expression')]
     [CmdletBinding(DefaultParameterSetName = 'ByName')]
@@ -196,6 +195,6 @@ function Get-SqlDscServerPermission
             Write-Error -Message $missingPrincipalMessage -Category 'InvalidOperation' -ErrorId 'GSDSP0001' -TargetObject $principalName
         }
 
-        return , [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]] $getSqlDscServerPermissionResult
+        return [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]] $getSqlDscServerPermissionResult
     }
 }

--- a/source/Public/Get-SqlDscTraceFlag.ps1
+++ b/source/Public/Get-SqlDscTraceFlag.ps1
@@ -45,7 +45,6 @@
 #>
 function Get-SqlDscTraceFlag
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Because the rule does not understands that the command returns [System.UInt32[]] when using , (comma) in the return statement')]
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues/8.')]
     [OutputType([System.UInt32[]])]
     [CmdletBinding(DefaultParameterSetName = 'ByServerName')]
@@ -83,5 +82,5 @@ function Get-SqlDscTraceFlag
         $script:localizedData.TraceFlag_Get_DebugReturningTraceFlags -f $MyInvocation.MyCommand, ($traceFlags -join ', ')
     )
 
-    return , [System.UInt32[]] $traceFlags
+    return [System.UInt32[]] $traceFlags
 }

--- a/source/Public/New-SqlDscDatabase.ps1
+++ b/source/Public/New-SqlDscDatabase.ps1
@@ -139,7 +139,7 @@ function New-SqlDscDatabase
             if ($CompatibilityLevel -notin $supportedCompatibilityLevels.$($ServerObject.VersionMajor))
             {
                 $errorMessage = $script:localizedData.Database_InvalidCompatibilityLevel -f $CompatibilityLevel, $ServerObject.InstanceName
-                New-InvalidArgumentException -ArgumentName 'CompatibilityLevel' -Message $errorMessage
+                New-ArgumentException -ArgumentName 'CompatibilityLevel' -Message $errorMessage
             }
         }
 
@@ -149,7 +149,7 @@ function New-SqlDscDatabase
             if ($Collation -notin $ServerObject.EnumCollations().Name)
             {
                 $errorMessage = $script:localizedData.Database_InvalidCollation -f $Collation, $ServerObject.InstanceName
-                New-InvalidArgumentException -ArgumentName 'Collation' -Message $errorMessage
+                New-ArgumentException -ArgumentName 'Collation' -Message $errorMessage
             }
         }
 

--- a/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Get-SqlDscServerPermission.Integration.Tests.ps1
@@ -233,7 +233,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration
                 $result = $loginObjects | Get-SqlDscServerPermission
 
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]]
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
                 $result.Count | Should -BeGreaterThan 1
             }
         }
@@ -271,7 +271,7 @@ Describe 'Get-SqlDscServerPermission' -Tag @('Integration_SQL2017', 'Integration
                 $result = $roleObjects | Get-SqlDscServerPermission
 
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[]]
+                $result | Should -BeOfType [Microsoft.SqlServer.Management.Smo.ServerPermissionInfo]
                 $result.Count | Should -BeGreaterThan 1
             }
         }

--- a/tests/Unit/Public/Get-SqlDscTraceFlag.Tests.ps1
+++ b/tests/Unit/Public/Get-SqlDscTraceFlag.Tests.ps1
@@ -100,8 +100,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
             It 'Should return an empty array' {
                 $result = Get-SqlDscTraceFlag
 
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
-
                 $result | Should -BeNullOrEmpty
 
                 Should -Invoke -CommandName Get-SqlDscStartupParameter -Exactly -Times 1 -Scope It
@@ -111,8 +109,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
         Context 'When passing specific server name' {
             It 'Should return an empty array' {
                 $result = Get-SqlDscTraceFlag -ServerName 'localhost'
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -BeNullOrEmpty
 
@@ -125,8 +121,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
         Context 'When passing specific instance name' {
             It 'Should return an empty array' {
                 $result = Get-SqlDscTraceFlag -InstanceName 'SQL2022'
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -BeNullOrEmpty
 
@@ -145,8 +139,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
                 $mockServiceObject.Type = 'SqlServer'
 
                 $result = Get-SqlDscTraceFlag -ServiceObject $mockServiceObject
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -BeNullOrEmpty
 
@@ -168,8 +160,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
             It 'Should return the correct values' {
                 $result = Get-SqlDscTraceFlag
 
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
-
                 $result | Should -HaveCount 1
                 $result | Should -Contain 4199
 
@@ -180,8 +170,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
         Context 'When passing specific server name' {
             It 'Should return the correct values' {
                 $result = Get-SqlDscTraceFlag -ServerName 'localhost'
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -HaveCount 1
                 $result | Should -Contain 4199
@@ -195,8 +183,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
         Context 'When passing specific instance name' {
             It 'Should return the correct values' {
                 $result = Get-SqlDscTraceFlag -InstanceName 'SQL2022'
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -HaveCount 1
                 $result | Should -Contain 4199
@@ -216,8 +202,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
                 $mockServiceObject.Type = 'SqlServer'
 
                 $result = Get-SqlDscTraceFlag -ServiceObject $mockServiceObject
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -HaveCount 1
                 $result | Should -Contain 4199
@@ -240,8 +224,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
             It 'Should return the correct values' {
                 $result = Get-SqlDscTraceFlag
 
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
-
                 $result | Should -HaveCount 2
                 $result | Should -Contain 4199
                 $result | Should -Contain 3226
@@ -253,8 +235,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
         Context 'When passing specific server name' {
             It 'Should return the correct values' {
                 $result = Get-SqlDscTraceFlag -ServerName 'localhost'
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -HaveCount 2
                 $result | Should -Contain 4199
@@ -269,8 +249,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
         Context 'When passing specific instance name' {
             It 'Should return the correct values' {
                 $result = Get-SqlDscTraceFlag -InstanceName 'SQL2022'
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -HaveCount 2
                 $result | Should -Contain 4199
@@ -291,8 +269,6 @@ Describe 'Get-SqlDscTraceFlag' -Tag 'Public' {
                 $mockServiceObject.Type = 'SqlServer'
 
                 $result = Get-SqlDscTraceFlag -ServiceObject $mockServiceObject
-
-                Should -ActualValue $result -BeOfType 'System.UInt32[]'
 
                 $result | Should -HaveCount 2
                 $result | Should -Contain 4199


### PR DESCRIPTION

#### Pull Request (PR) description
- Fixed incorrect array-return syntax in several public `Get-*` commands by
  removing a leading comma in return statements which could cause incorrect
  output and ScriptAnalyzer warnings: `Get-SqlDscAudit`,
  `Get-SqlDscConfigurationOption`, `Get-SqlDscDatabasePermission`,
  `Get-SqlDscServerPermission`, and `Get-SqlDscTraceFlag`.
- New-SqlDscDatabase: use `New-ArgumentException` instead of
  `New-InvalidArgumentException` for parameter validation errors.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list of the issues using a GitHub closing keyword, e.g.:

- Fixes #123
- Fixes #124
-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2162)
<!-- Reviewable:end -->
