### PR TITLE
`New-SqlDscAudit`: Fix ReserveDiskSpace parameter requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `New-SqlDscAudit`
+  - Fixed parameter validation to prevent the `ReserveDiskSpace` parameter from
+    being used with the `FileWithMaxFiles` parameter set (when only `MaximumFiles`
+    is specified without `MaximumFileSize`). This combination always resulted in
+    a SQL Server error because `RESERVE_DISK_SPACE` cannot be specified when
+    `MAXSIZE = UNLIMITED`. The `ReserveDiskSpace` parameter now correctly requires
+    both `MaximumFiles` and `MaximumFileSize` to be specified
+    ([issue #2289](https://github.com/dsccommunity/SqlServerDsc/issues/2289)).
 - `Add-SqlDscTraceFlag` and `Remove-SqlDscTraceFlag`
   - Fixed parameter binding error when `ErrorAction` was specified both
     explicitly and via `PSBoundParameters` by using `Remove-CommonParameter`

--- a/source/Public/New-SqlDscAudit.ps1
+++ b/source/Public/New-SqlDscAudit.ps1
@@ -47,7 +47,7 @@
 
     .PARAMETER ReserveDiskSpace
         Specifies if the needed file space should be reserved. To use this parameter
-        the parameter **MaximumFiles** must also be used.
+        the parameters **MaximumFiles** and **MaximumFileSize** must also be used.
 
     .PARAMETER MaximumFiles
         Specifies the number of files on disk.
@@ -188,7 +188,6 @@ function New-SqlDscAudit
         [System.UInt32]
         $MaximumFiles,
 
-        [Parameter(ParameterSetName = 'FileWithMaxFiles')]
         [Parameter(ParameterSetName = 'FileWithSizeAndMaxFiles')]
         [System.Management.Automation.SwitchParameter]
         $ReserveDiskSpace,

--- a/tests/Unit/Public/New-SqlDscAudit.Tests.ps1
+++ b/tests/Unit/Public/New-SqlDscAudit.Tests.ps1
@@ -65,7 +65,7 @@ Describe 'New-SqlDscAudit' -Tag 'Public' {
         }
         @{
             MockParameterSetName = 'FileWithMaxFiles'
-            MockExpectedParameters = '-ServerObject <Server> -Name <string> -Path <string> -MaximumFiles <uint> [-AuditFilter <string>] [-OnFailure <string>] [-QueueDelay <uint>] [-AuditGuid <string>] [-Force] [-Refresh] [-PassThru] [-ReserveDiskSpace] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            MockExpectedParameters = '-ServerObject <Server> -Name <string> -Path <string> -MaximumFiles <uint> [-AuditFilter <string>] [-OnFailure <string>] [-QueueDelay <uint>] [-AuditGuid <string>] [-Force] [-Refresh] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
         }
         @{
             MockParameterSetName = 'FileWithMaxRolloverFiles'
@@ -490,74 +490,6 @@ Describe 'New-SqlDscAudit' -Tag 'Public' {
             $mockCreateAuditObject.MaximumFiles | Should -Be 2
 
             $mockMethodCreateCallCount | Should -Be 1
-        }
-    }
-
-    Context 'When passing file audit optional parameters MaximumFiles and ReserveDiskSpace' {
-        BeforeAll {
-            $script:mockCreateAuditObject = $null
-
-            Mock -CommandName New-Object -ParameterFilter {
-                $TypeName -eq 'Microsoft.SqlServer.Management.Smo.Audit'
-            } -MockWith {
-                <#
-                    The Audit object is created in the script scope so that the
-                    properties can be validated.
-                #>
-                $script:mockCreateAuditObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Audit' -ArgumentList @(
-                    $PesterBoundParameters.ArgumentList[0],
-                    $PesterBoundParameters.ArgumentList[1]
-                ) |
-                    Add-Member -MemberType 'ScriptMethod' -Name 'Create' -Value {
-                        $script:mockMethodCreateCallCount += 1
-                    } -PassThru -Force
-
-                return $script:mockCreateAuditObject
-            }
-
-            Mock -CommandName Get-SqlDscAudit
-
-            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
-            $mockServerObject.InstanceName = 'TestInstance'
-
-            $mockDefaultParameters = @{
-                ServerObject = $mockServerObject
-                Name = 'Log1'
-                Path = Get-TemporaryFolder
-                Force = $true
-            }
-        }
-
-        BeforeEach {
-            $script:mockMethodCreateCallCount = 0
-        }
-
-        It 'Should call the mocked method and have correct values in the object' {
-            New-SqlDscAudit -MaximumFiles 2 -ReserveDiskSpace @mockDefaultParameters
-
-            # This is the object created by the mock and modified by the command.
-            $mockCreateAuditObject.Name | Should -Be 'Log1'
-            $mockCreateAuditObject.DestinationType | Should -Be 'File'
-            $mockCreateAuditObject.FilePath | Should -Be (Get-TemporaryFolder)
-            $mockCreateAuditObject.MaximumFiles | Should -Be 2
-            $mockCreateAuditObject.ReserveDiskSpace | Should -BeTrue
-
-            $mockMethodCreateCallCount | Should -Be 1
-        }
-
-        Context 'When ReserveDiskSpace is set to $false' {
-            It 'Should call the mocked method and have correct values in the object' {
-                New-SqlDscAudit -MaximumFiles 2 -ReserveDiskSpace:$false @mockDefaultParameters
-
-                # This is the object created by the mock and modified by the command.
-                $mockCreateAuditObject.Name | Should -Be 'Log1'
-                $mockCreateAuditObject.DestinationType | Should -Be 'File'
-                $mockCreateAuditObject.FilePath | Should -Be (Get-TemporaryFolder)
-                $mockCreateAuditObject.MaximumFiles | Should -Be 2
-                $mockCreateAuditObject.ReserveDiskSpace | Should -BeFalse
-
-                $mockMethodCreateCallCount | Should -Be 1
-            }
         }
     }
 


### PR DESCRIPTION

#### Pull Request (PR) description
- `New-SqlDscAudit`
  - Fixed parameter validation to prevent the `ReserveDiskSpace` parameter from
    being used with the `FileWithMaxFiles` parameter set (when only `MaximumFiles`
    is specified without `MaximumFileSize`). This combination always resulted in
    a SQL Server error because `RESERVE_DISK_SPACE` cannot be specified when
    `MAXSIZE = UNLIMITED`. The `ReserveDiskSpace` parameter now correctly requires
    both `MaximumFiles` and `MaximumFileSize` to be specified
    ([issue #2289](https://github.com/dsccommunity/SqlServerDsc/issues/2289)).

#### This Pull Request (PR) fixes the following issues

- Fixes #2289


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2292)
<!-- Reviewable:end -->
