### PR TITLE
`Set-SqlDscDatabaseDefaultFullTextCatalog`: add new command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   isolation for a database in a SQL Server Database Engine instance. This command
   uses the SMO `SetSnapshotIsolation()` method to disable row-versioning and snapshot
   isolation settings ([issue #2329](https://github.com/dsccommunity/SqlServerDsc/issues/2329)).
+- Added public command `Set-SqlDscDatabaseDefaultFullTextCatalog` to set the default
+  full-text catalog for a database in a SQL Server Database Engine instance. This
+  command uses the SMO `SetDefaultFullTextCatalog()` method to configure the default
+  catalog ([issue #2330](https://github.com/dsccommunity/SqlServerDsc/issues/2330)).
 - Added public command `New-SqlDscDatabaseSnapshot` to create database snapshots
   in a SQL Server Database Engine instance using SMO. This command provides an
   automated and DSC-friendly approach to snapshot management by leveraging

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -344,6 +344,7 @@ stages:
                   'tests/Integration/Commands/Get-SqlDscCompatibilityLevel.Integration.Tests.ps1'
                   'tests/Integration/Commands/Set-SqlDscDatabaseProperty.Integration.Tests.ps1'
                   'tests/Integration/Commands/Set-SqlDscDatabaseOwner.Integration.Tests.ps1'
+                  'tests/Integration/Commands/Set-SqlDscDatabaseDefaultFullTextCatalog.Integration.Tests.ps1'
                   'tests/Integration/Commands/Test-SqlDscIsDatabase.Integration.Tests.ps1'
                   'tests/Integration/Commands/Test-SqlDscDatabaseProperty.Integration.Tests.ps1'
                   'tests/Integration/Commands/Get-SqlDscDatabasePermission.Integration.Tests.ps1'

--- a/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
+++ b/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
@@ -157,6 +157,7 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
                 try
                 {
                     $sqlDatabaseObject.SetDefaultFullTextCatalog($CatalogName)
+                    $sqlDatabaseObject.Alter()
                 }
                 catch
                 {
@@ -176,13 +177,12 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
             }
 
             <#
-                Refresh the database object to get the updated DefaultFullTextCatalog property if:
+                Refresh the database object even if no change was made to ensure
+                the object is up to date when:
                 - PassThru is specified (user wants the updated object back)
                 - Using DatabaseObject parameter set (user's object reference should be updated)
-
-                Refresh even if no change was made to ensure the object is up to date.
             #>
-            if ($PassThru.IsPresent -or $PSCmdlet.ParameterSetName -eq 'DatabaseObjectSet')
+            if ($PassThru.IsPresent -and $sqlDatabaseObject.DefaultFullTextCatalog -ne $CatalogName)
             {
                 $sqlDatabaseObject.Refresh()
             }

--- a/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
+++ b/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
@@ -177,10 +177,9 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
             }
 
             <#
-                Refresh the database object even if no change was made to ensure
-                the object is up to date when:
+                Refresh the database object if:
                 - PassThru is specified (user wants the updated object back)
-                - Using DatabaseObject parameter set (user's object reference should be updated)
+                - DefaultFullTextCatalog is different than the requested catalog
             #>
             if ($PassThru.IsPresent -and $sqlDatabaseObject.DefaultFullTextCatalog -ne $CatalogName)
             {

--- a/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
+++ b/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
@@ -157,7 +157,9 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
                 try
                 {
                     $sqlDatabaseObject.SetDefaultFullTextCatalog($CatalogName)
-                    $sqlDatabaseObject.Alter()
+
+                    # Refresh the database object to get the updated DefaultFullTextCatalog value from the server
+                    $sqlDatabaseObject.Refresh()
                 }
                 catch
                 {
@@ -174,16 +176,6 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
                 }
 
                 Write-Debug -Message ($script:localizedData.DatabaseDefaultFullTextCatalog_Updated -f $sqlDatabaseObject.Name, $CatalogName)
-            }
-
-            <#
-                Refresh the database object if:
-                - PassThru is specified (user wants the updated object back)
-                - DefaultFullTextCatalog is different than the requested catalog
-            #>
-            if ($PassThru.IsPresent -and $sqlDatabaseObject.DefaultFullTextCatalog -ne $CatalogName)
-            {
-                $sqlDatabaseObject.Refresh()
             }
 
             if ($PassThru.IsPresent)

--- a/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
+++ b/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
@@ -157,9 +157,6 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
                 try
                 {
                     $sqlDatabaseObject.SetDefaultFullTextCatalog($CatalogName)
-
-                    # Refresh the database object to get the updated DefaultFullTextCatalog value from the server
-                    $sqlDatabaseObject.Refresh()
                 }
                 catch
                 {
@@ -180,6 +177,9 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
 
             if ($PassThru.IsPresent)
             {
+                # Refresh the database object to get the updated DefaultFullTextCatalog value from the server
+                $sqlDatabaseObject.Refresh()
+
                 return $sqlDatabaseObject
             }
         }

--- a/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
+++ b/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
@@ -128,7 +128,7 @@ function Set-SqlDscDatabaseDefaultFullTextCatalog
                 $ErrorActionPreference = 'Stop'
 
                 $sqlDatabaseObject = $ServerObject |
-                    Get-SqlDscDatabase -Name $Name -Refresh:$Refresh -ErrorAction 'Stop'
+                    Get-SqlDscDatabase -Name $Name -Refresh:($Refresh.IsPresent) -ErrorAction 'Stop'
 
                 $ErrorActionPreference = $previousErrorActionPreference
             }

--- a/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
+++ b/source/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.ps1
@@ -1,0 +1,196 @@
+<#
+    .SYNOPSIS
+        Sets the default full-text catalog for a database in a SQL Server Database Engine instance.
+
+    .DESCRIPTION
+        This command sets the default full-text catalog for a database in a SQL Server
+        Database Engine instance. The catalog name must be a valid full-text catalog
+        that exists in the database. The command uses the SetDefaultFullTextCatalog()
+        method on the SMO Database object to set the default catalog.
+
+    .PARAMETER ServerObject
+        Specifies current server connection object.
+
+    .PARAMETER Name
+        Specifies the name of the database to modify.
+
+    .PARAMETER DatabaseObject
+        Specifies the database object to modify (from Get-SqlDscDatabase).
+
+    .PARAMETER Refresh
+        Specifies that the **ServerObject**'s databases should be refreshed before
+        trying to get the database object. This is helpful when databases could have been
+        modified outside of the **ServerObject**, for example through T-SQL. But
+        on instances with a large amount of databases it might be better to make
+        sure the **ServerObject** is recent enough.
+
+        This parameter is only used when setting the default full-text catalog using
+        **ServerObject** and **Name** parameters.
+
+    .PARAMETER CatalogName
+        Specifies the name of the full-text catalog to set as the default for the database.
+
+    .PARAMETER Force
+        Specifies that the default full-text catalog should be modified without any confirmation.
+
+    .PARAMETER PassThru
+        Specifies that the database object should be returned after modification.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $serverObject -Name 'MyDatabase' -CatalogName 'MyCatalog'
+
+        Sets the default full-text catalog of the database named **MyDatabase** to **MyCatalog**.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        $databaseObject = $serverObject | Get-SqlDscDatabase -Name 'MyDatabase'
+        Set-SqlDscDatabaseDefaultFullTextCatalog -DatabaseObject $databaseObject -CatalogName 'MyCatalog' -Force
+
+        Sets the default full-text catalog using a database object without prompting for confirmation.
+
+    .EXAMPLE
+        $serverObject = Connect-SqlDscDatabaseEngine -InstanceName 'MyInstance'
+        Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $serverObject -Name 'MyDatabase' -CatalogName 'MyCatalog' -PassThru
+
+        Sets the default full-text catalog and returns the updated database object.
+
+    .EXAMPLE
+        $databaseObject | Set-SqlDscDatabaseDefaultFullTextCatalog -CatalogName 'MyCatalog'
+
+        Sets the default full-text catalog using pipeline input.
+
+    .INPUTS
+        Microsoft.SqlServer.Management.Smo.Database
+
+        The database object to modify (from Get-SqlDscDatabase).
+
+    .OUTPUTS
+        None.
+
+        When PassThru is specified the output is [Microsoft.SqlServer.Management.Smo.Database].
+#>
+function Set-SqlDscDatabaseDefaultFullTextCatalog
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('UseSyntacticallyCorrectExamples', '', Justification = 'Because the rule does not yet support parsing the code when a parameter type is not available. The ScriptAnalyzer rule UseSyntacticallyCorrectExamples will always error in the editor due to https://github.com/indented-automation/Indented.ScriptAnalyzerRules/issues.')]
+    [OutputType()]
+    [OutputType([Microsoft.SqlServer.Management.Smo.Database])]
+    [CmdletBinding(DefaultParameterSetName = 'ServerObjectSet', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param
+    (
+        [Parameter(ParameterSetName = 'ServerObjectSet', Mandatory = $true)]
+        [Microsoft.SqlServer.Management.Smo.Server]
+        $ServerObject,
+
+        [Parameter(ParameterSetName = 'ServerObjectSet', Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter(ParameterSetName = 'ServerObjectSet')]
+        [System.Management.Automation.SwitchParameter]
+        $Refresh,
+
+        [Parameter(ParameterSetName = 'DatabaseObjectSet', Mandatory = $true, ValueFromPipeline = $true)]
+        [Microsoft.SqlServer.Management.Smo.Database]
+        $DatabaseObject,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $CatalogName,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Force,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru
+    )
+
+    begin
+    {
+        if ($Force.IsPresent -and -not $Confirm)
+        {
+            $ConfirmPreference = 'None'
+        }
+    }
+
+    process
+    {
+        # Get the database object based on the parameter set
+        switch ($PSCmdlet.ParameterSetName)
+        {
+            'ServerObjectSet'
+            {
+                $previousErrorActionPreference = $ErrorActionPreference
+                $ErrorActionPreference = 'Stop'
+
+                $sqlDatabaseObject = $ServerObject |
+                    Get-SqlDscDatabase -Name $Name -Refresh:$Refresh -ErrorAction 'Stop'
+
+                $ErrorActionPreference = $previousErrorActionPreference
+            }
+
+            'DatabaseObjectSet'
+            {
+                $sqlDatabaseObject = $DatabaseObject
+            }
+        }
+
+        $verboseDescriptionMessage = $script:localizedData.DatabaseDefaultFullTextCatalog_Set_ShouldProcessVerboseDescription -f $sqlDatabaseObject.Name, $CatalogName, $sqlDatabaseObject.Parent.InstanceName
+        $verboseWarningMessage = $script:localizedData.DatabaseDefaultFullTextCatalog_Set_ShouldProcessVerboseWarning -f $sqlDatabaseObject.Name, $CatalogName
+        $captionMessage = $script:localizedData.DatabaseDefaultFullTextCatalog_Set_ShouldProcessCaption
+
+        if ($PSCmdlet.ShouldProcess($verboseDescriptionMessage, $verboseWarningMessage, $captionMessage))
+        {
+            # Check if the default full-text catalog is already correct (idempotence)
+            if ($sqlDatabaseObject.DefaultFullTextCatalog -eq $CatalogName)
+            {
+                Write-Debug -Message ($script:localizedData.DatabaseDefaultFullTextCatalog_AlreadyCorrect -f $sqlDatabaseObject.Name, $CatalogName)
+            }
+            else
+            {
+                Write-Debug -Message ($script:localizedData.DatabaseDefaultFullTextCatalog_Updating -f $sqlDatabaseObject.Name, $CatalogName)
+
+                try
+                {
+                    $sqlDatabaseObject.SetDefaultFullTextCatalog($CatalogName)
+                }
+                catch
+                {
+                    $errorMessage = $script:localizedData.DatabaseDefaultFullTextCatalog_SetFailed -f $sqlDatabaseObject.Name, $CatalogName
+
+                    $PSCmdlet.ThrowTerminatingError(
+                        [System.Management.Automation.ErrorRecord]::new(
+                            [System.InvalidOperationException]::new($errorMessage, $_.Exception),
+                            'SSDDF0004', # cspell: disable-line
+                            [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                            $sqlDatabaseObject
+                        )
+                    )
+                }
+
+                Write-Debug -Message ($script:localizedData.DatabaseDefaultFullTextCatalog_Updated -f $sqlDatabaseObject.Name, $CatalogName)
+            }
+
+            <#
+                Refresh the database object to get the updated DefaultFullTextCatalog property if:
+                - PassThru is specified (user wants the updated object back)
+                - Using DatabaseObject parameter set (user's object reference should be updated)
+
+                Refresh even if no change was made to ensure the object is up to date.
+            #>
+            if ($PassThru.IsPresent -or $PSCmdlet.ParameterSetName -eq 'DatabaseObjectSet')
+            {
+                $sqlDatabaseObject.Refresh()
+            }
+
+            if ($PassThru.IsPresent)
+            {
+                return $sqlDatabaseObject
+            }
+        }
+    }
+}

--- a/source/en-US/SqlServerDsc.strings.psd1
+++ b/source/en-US/SqlServerDsc.strings.psd1
@@ -422,6 +422,16 @@ ConvertFrom-StringData @'
     # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
     DatabaseOwner_Set_ShouldProcessCaption = Set database owner on instance
 
+    ## Set-SqlDscDatabaseDefaultFullTextCatalog
+    DatabaseDefaultFullTextCatalog_Updating = Setting default full-text catalog of database '{0}' to '{1}'. (SSDDF0001)
+    DatabaseDefaultFullTextCatalog_Updated = Default full-text catalog of database '{0}' was set to '{1}'. (SSDDF0002)
+    DatabaseDefaultFullTextCatalog_AlreadyCorrect = Default full-text catalog of database '{0}' is already set to '{1}'. (SSDDF0003)
+    DatabaseDefaultFullTextCatalog_SetFailed = Failed to set default full-text catalog of database '{0}' to '{1}'. (SSDDF0004)
+    DatabaseDefaultFullTextCatalog_Set_ShouldProcessVerboseDescription = Setting the default full-text catalog of the database '{0}' to '{1}' on the instance '{2}'.
+    DatabaseDefaultFullTextCatalog_Set_ShouldProcessVerboseWarning = Are you sure you want to change the default full-text catalog of the database '{0}' to '{1}'?
+    # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
+    DatabaseDefaultFullTextCatalog_Set_ShouldProcessCaption = Set database default full-text catalog on instance
+
     ## Enable-SqlDscDatabaseSnapshotIsolation
     DatabaseSnapshotIsolation_Enabling = Enabling snapshot isolation for database '{0}'. (ESDSI0002)
     DatabaseSnapshotIsolation_Enabled = Snapshot isolation for database '{0}' was enabled. (ESDSI0003)

--- a/tests/Integration/Commands/README.md
+++ b/tests/Integration/Commands/README.md
@@ -95,6 +95,7 @@ New-SqlDscDatabaseSnapshot | 5 | 4 (New-SqlDscDatabase), 1 (Install-SqlDscServer
 Get-SqlDscCompatibilityLevel | 4 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 Set-SqlDscDatabaseProperty | 4 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 Set-SqlDscDatabaseOwner | 4 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
+Set-SqlDscDatabaseDefaultFullTextCatalog | 4 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 Test-SqlDscIsDatabase | 4 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 Test-SqlDscDatabaseProperty | 4 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | -
 Get-SqlDscDatabasePermission | 4 | 1 (Install-SqlDscServer), 0 (Prerequisites) | DSCSQLTEST | Test database, Test user

--- a/tests/Integration/Commands/Set-SqlDscDatabaseDefaultFullTextCatalog.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Set-SqlDscDatabaseDefaultFullTextCatalog.Integration.Tests.ps1
@@ -1,0 +1,162 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Suppressing this rule because Script Analyzer does not understand Pester syntax.')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies have not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks noop" first.'
+    }
+}
+
+BeforeAll {
+    $script:moduleName = 'SqlServerDsc'
+
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+}
+
+Describe 'Set-SqlDscDatabaseDefaultFullTextCatalog' -Tag @('Integration_SQL2017', 'Integration_SQL2019', 'Integration_SQL2022') {
+    BeforeAll {
+        $script:mockInstanceName = 'DSCSQLTEST'
+        $script:mockComputerName = Get-ComputerName
+
+        $mockSqlAdministratorUserName = 'SqlAdmin'
+        $mockSqlAdministratorPassword = ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force
+
+        $script:mockSqlAdminCredential = [System.Management.Automation.PSCredential]::new($mockSqlAdministratorUserName, $mockSqlAdministratorPassword)
+
+        $script:serverObject = Connect-SqlDscDatabaseEngine -InstanceName $script:mockInstanceName -Credential $script:mockSqlAdminCredential -ErrorAction 'Stop'
+
+        # Test database names
+        $script:testDatabaseName = 'SqlDscTestSetFTCatalog_' + (Get-Random)
+
+        # Create test database for the integration tests
+        $script:testDatabaseObject = New-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -Force -ErrorAction 'Stop'
+
+        # Create full-text catalogs for testing
+        $script:testCatalogName1 = 'TestFTCatalog1_' + (Get-Random)
+        $script:testCatalogName2 = 'TestFTCatalog2_' + (Get-Random)
+
+        # Create full-text catalogs using T-SQL
+        $null = $script:testDatabaseObject.ExecuteNonQuery("CREATE FULLTEXT CATALOG [$script:testCatalogName1]")
+        $null = $script:testDatabaseObject.ExecuteNonQuery("CREATE FULLTEXT CATALOG [$script:testCatalogName2]")
+
+        # Refresh database object to get the newly created catalogs
+        $script:testDatabaseObject.Refresh()
+
+        # Store the original default full-text catalog to restore later
+        $script:originalDefaultCatalog = $script:testDatabaseObject.DefaultFullTextCatalog
+        Write-Verbose -Message "Original default full-text catalog of database '$($script:testDatabaseName)' is '$($script:originalDefaultCatalog)'." -Verbose
+    }
+
+    AfterAll {
+        # Clean up test database (this will also remove the full-text catalogs)
+        $existingDb = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -ErrorAction 'SilentlyContinue'
+
+        if ($existingDb)
+        {
+            $null = Remove-SqlDscDatabase -DatabaseObject $existingDb -Force -ErrorAction 'Stop'
+        }
+
+        # Disconnect from the database engine
+        Disconnect-SqlDscDatabaseEngine -ServerObject $script:serverObject -ErrorAction 'Stop'
+    }
+
+    Context 'When setting default full-text catalog using ServerObject parameter set' {
+        It 'Should set default catalog successfully' {
+            $resultDb = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName1 -Force -PassThru -ErrorAction 'Stop'
+            $resultDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName1
+
+            # Verify the change
+            $updatedDb = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -Refresh -ErrorAction 'Stop'
+            $updatedDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName1
+        }
+
+        It 'Should change to a different catalog' {
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName2 -Force -ErrorAction 'Stop'
+
+            # Verify the change
+            $updatedDb = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -Refresh -ErrorAction 'Stop'
+            $updatedDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName2
+        }
+
+        It 'Should be idempotent when catalog is already set' {
+            # Set catalog
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName1 -Force -ErrorAction 'Stop'
+
+            # Set same catalog again - should not throw
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName1 -Force -ErrorAction 'Stop'
+
+            # Verify the value is still correct
+            $updatedDb = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -Refresh -ErrorAction 'Stop'
+            $updatedDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName1
+        }
+
+        It 'Should throw error when trying to set catalog of non-existent database' {
+            { Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name 'NonExistentDatabase' -CatalogName $script:testCatalogName1 -Force -ErrorAction 'Stop' } |
+                Should -Throw
+        }
+
+        It 'Should throw error when trying to set non-existent catalog' {
+            { Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName 'NonExistentCatalog' -Force -ErrorAction 'Stop' } |
+                Should -Throw
+        }
+    }
+
+    Context 'When setting default full-text catalog using DatabaseObject parameter set' {
+        It 'Should set catalog using database object' {
+            $databaseObject = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -ErrorAction 'Stop'
+
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -DatabaseObject $databaseObject -CatalogName $script:testCatalogName2 -Force -ErrorAction 'Stop'
+
+            # Verify the change
+            $updatedDb = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -Refresh -ErrorAction 'Stop'
+            $updatedDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName2
+        }
+
+        It 'Should support pipeline input with database object' {
+            $databaseObject = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -ErrorAction 'Stop'
+
+            $null = $databaseObject | Set-SqlDscDatabaseDefaultFullTextCatalog -CatalogName $script:testCatalogName1 -Force -ErrorAction 'Stop'
+
+            # Verify the change
+            $updatedDb = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -Refresh -ErrorAction 'Stop'
+            $updatedDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName1
+        }
+    }
+
+    Context 'When using the Refresh parameter' {
+        It 'Should refresh the database collection before setting catalog' {
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName2 -Refresh -Force -ErrorAction 'Stop'
+
+            # Verify the change
+            $updatedDb = Get-SqlDscDatabase -ServerObject $script:serverObject -Name $script:testDatabaseName -Refresh -ErrorAction 'Stop'
+            $updatedDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName2
+        }
+    }
+
+    Context 'When using the PassThru parameter' {
+        It 'Should return the database object when PassThru is specified' {
+            $result = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName1 -PassThru -Force -ErrorAction 'Stop'
+
+            $result | Should -Not -BeNullOrEmpty
+            $result | Should -BeOfType 'Microsoft.SqlServer.Management.Smo.Database'
+            $result.Name | Should -Be $script:testDatabaseName
+            $result.DefaultFullTextCatalog | Should -Be $script:testCatalogName1
+        }
+    }
+}

--- a/tests/Integration/Commands/Set-SqlDscDatabaseDefaultFullTextCatalog.Integration.Tests.ps1
+++ b/tests/Integration/Commands/Set-SqlDscDatabaseDefaultFullTextCatalog.Integration.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'Set-SqlDscDatabaseDefaultFullTextCatalog' -Tag @('Integration_SQL2017'
 
     Context 'When setting default full-text catalog using ServerObject parameter set' {
         It 'Should set default catalog successfully' {
-            $resultDb = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName1 -Force -PassThru -ErrorAction 'Stop'
+            $resultDb = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $script:serverObject -Name $script:testDatabaseName -CatalogName $script:testCatalogName1 -Force -Refresh -PassThru -ErrorAction 'Stop'
             $resultDb.DefaultFullTextCatalog | Should -Be $script:testCatalogName1
 
             # Verify the change

--- a/tests/Unit/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.Tests.ps1
+++ b/tests/Unit/Public/Set-SqlDscDatabaseDefaultFullTextCatalog.Tests.ps1
@@ -1,0 +1,325 @@
+<#
+    .SYNOPSIS
+        Unit tests for Set-SqlDscDatabaseDefaultFullTextCatalog.
+
+    .DESCRIPTION
+        Unit tests for Set-SqlDscDatabaseDefaultFullTextCatalog.
+#>
+
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies have been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies have not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks noop" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'SqlServerDsc'
+
+    $env:SqlServerDscCI = $true
+
+    Import-Module -Name $script:dscModuleName -Force -ErrorAction 'Stop'
+
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../Stubs') -ChildPath 'SMO.cs')
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+
+    Remove-Item -Path 'env:SqlServerDscCI'
+}
+
+Describe 'Set-SqlDscDatabaseDefaultFullTextCatalog' -Tag 'Public' {
+    Context 'When setting default full-text catalog using ServerObject and Name' {
+        BeforeAll {
+            $mockDatabaseObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Database'
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'Name' -Value 'TestDatabase' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'DefaultFullTextCatalog' -Value 'OldCatalog' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptProperty' -Name 'Parent' -Value {
+                $mockParent = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+                $mockParent | Add-Member -MemberType 'NoteProperty' -Name 'InstanceName' -Value 'TestInstance' -Force
+                return $mockParent
+            } -Force
+            $script:setDefaultFullTextCatalogCalled = $false
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'SetDefaultFullTextCatalog' -Value {
+                param($CatalogName)
+                $script:setDefaultFullTextCatalogCalled = $true
+                $this.DefaultFullTextCatalog = $CatalogName
+            } -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'Refresh' -Value {
+                # Mock implementation - in real SMO this updates properties from server
+            } -Force
+
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject | Add-Member -MemberType 'NoteProperty' -Name 'InstanceName' -Value 'TestInstance' -Force
+            $mockServerObject | Add-Member -MemberType 'ScriptProperty' -Name 'Databases' -Value {
+                return @{
+                    'TestDatabase' = $mockDatabaseObject
+                } | Add-Member -MemberType 'ScriptMethod' -Name 'Refresh' -Value {
+                    # Mock implementation
+                } -PassThru -Force
+            } -Force
+        }
+
+        It 'Should set default full-text catalog successfully' {
+            $script:setDefaultFullTextCatalogCalled = $false
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $mockServerObject -Name 'TestDatabase' -CatalogName 'MyCatalog' -Force
+            $mockDatabaseObject.DefaultFullTextCatalog | Should -Be 'MyCatalog'
+            $script:setDefaultFullTextCatalogCalled | Should -BeTrue -Because 'SetDefaultFullTextCatalog should be called to change the catalog'
+        }
+
+        It 'Should return a database object when PassThru is specified' {
+            # Reset catalog to ensure the test starts with a different catalog
+            $mockDatabaseObject.DefaultFullTextCatalog = 'OldCatalog'
+            $script:setDefaultFullTextCatalogCalled = $false
+            $result = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $mockServerObject -Name 'TestDatabase' -CatalogName 'MyCatalog' -Force -PassThru
+            $result | Should -Not -BeNullOrEmpty
+            $result.Name | Should -Be 'TestDatabase'
+        }
+
+        It 'Should refresh database properties when Refresh is specified' {
+            # Reset catalog for this test
+            $mockDatabaseObject.DefaultFullTextCatalog = 'OldCatalog'
+            $script:setDefaultFullTextCatalogCalled = $false
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $mockServerObject -Name 'TestDatabase' -CatalogName 'MyCatalog' -Force -Refresh
+            $mockDatabaseObject.DefaultFullTextCatalog | Should -Be 'MyCatalog'
+        }
+
+        It 'Should call SetDefaultFullTextCatalog with correct catalog name' {
+            # Reset catalog for this test
+            $mockDatabaseObject.DefaultFullTextCatalog = 'OldCatalog'
+            $script:setDefaultFullTextCatalogCalled = $false
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $mockServerObject -Name 'TestDatabase' -CatalogName 'NewCatalog' -Force
+            $mockDatabaseObject.DefaultFullTextCatalog | Should -Be 'NewCatalog'
+            $script:setDefaultFullTextCatalogCalled | Should -BeTrue -Because 'SetDefaultFullTextCatalog should be called to change the catalog'
+        }
+    }
+
+    Context 'When setting default full-text catalog using DatabaseObject' {
+        BeforeAll {
+            $mockDatabaseObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Database'
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'Name' -Value 'TestDatabase' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'DefaultFullTextCatalog' -Value 'OldCatalog' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptProperty' -Name 'Parent' -Value {
+                $mockParent = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+                $mockParent | Add-Member -MemberType 'NoteProperty' -Name 'InstanceName' -Value 'TestInstance' -Force
+                return $mockParent
+            } -Force
+            $script:setDefaultFullTextCatalogCalled = $false
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'SetDefaultFullTextCatalog' -Value {
+                param($CatalogName)
+                $script:setDefaultFullTextCatalogCalled = $true
+                $this.DefaultFullTextCatalog = $CatalogName
+            } -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'Refresh' -Value {
+                # Mock implementation - in real SMO this updates properties from server
+            } -Force
+        }
+
+        It 'Should set default full-text catalog successfully' {
+            $script:setDefaultFullTextCatalogCalled = $false
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -DatabaseObject $mockDatabaseObject -CatalogName 'MyCatalog' -Force
+            $mockDatabaseObject.DefaultFullTextCatalog | Should -Be 'MyCatalog'
+            $script:setDefaultFullTextCatalogCalled | Should -BeTrue -Because 'SetDefaultFullTextCatalog should be called to change the catalog'
+        }
+
+        It 'Should return a database object when PassThru is specified' {
+            # Reset catalog to ensure the test starts with a different catalog
+            $mockDatabaseObject.DefaultFullTextCatalog = 'OldCatalog'
+            $script:setDefaultFullTextCatalogCalled = $false
+            $result = Set-SqlDscDatabaseDefaultFullTextCatalog -DatabaseObject $mockDatabaseObject -CatalogName 'MyCatalog' -Force -PassThru
+            $result | Should -Not -BeNullOrEmpty
+            $result.Name | Should -Be 'TestDatabase'
+        }
+
+        It 'Should call SetDefaultFullTextCatalog with correct catalog name' {
+            $mockDatabaseObject.DefaultFullTextCatalog = 'OldCatalog'
+            $script:setDefaultFullTextCatalogCalled = $false
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -DatabaseObject $mockDatabaseObject -CatalogName 'NewCatalog' -Force
+            $mockDatabaseObject.DefaultFullTextCatalog | Should -Be 'NewCatalog'
+            $script:setDefaultFullTextCatalogCalled | Should -BeTrue -Because 'SetDefaultFullTextCatalog should be called to change the catalog'
+        }
+    }
+
+    Context 'When default full-text catalog is already set to desired value' {
+        BeforeAll {
+            $mockDatabaseObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Database'
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'Name' -Value 'TestDatabase' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'DefaultFullTextCatalog' -Value 'MyCatalog' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptProperty' -Name 'Parent' -Value {
+                $mockParent = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+                $mockParent | Add-Member -MemberType 'NoteProperty' -Name 'InstanceName' -Value 'TestInstance' -Force
+                return $mockParent
+            } -Force
+            # Track whether SetDefaultFullTextCatalog was called using script-scoped variables
+            $script:setDefaultFullTextCatalogCalled = $false
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'SetDefaultFullTextCatalog' -Value {
+                param($CatalogName)
+                $script:setDefaultFullTextCatalogCalled = $true
+                $this.DefaultFullTextCatalog = $CatalogName
+            } -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'Refresh' -Value {
+                # Mock implementation - in real SMO this updates properties from server
+            } -Force
+        }
+
+        It 'Should not call SetDefaultFullTextCatalog when catalog already matches the desired value' {
+            # Reset the flags before the test
+            $script:setDefaultFullTextCatalogCalled = $false
+
+            # The command should skip calling SetDefaultFullTextCatalog when the catalog already matches
+            $null = Set-SqlDscDatabaseDefaultFullTextCatalog -DatabaseObject $mockDatabaseObject -CatalogName 'MyCatalog' -Force
+
+            # Verify SetDefaultFullTextCatalog was not called (idempotent behavior)
+            $script:setDefaultFullTextCatalogCalled | Should -BeFalse -Because 'SetDefaultFullTextCatalog should not be called when the catalog already matches'
+            $mockDatabaseObject.DefaultFullTextCatalog | Should -Be 'MyCatalog'
+        }
+    }
+
+    Context 'When database modification fails' {
+        BeforeAll {
+            $mockDatabaseObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Database'
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'Name' -Value 'TestDatabase' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'NoteProperty' -Name 'DefaultFullTextCatalog' -Value 'OldCatalog' -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptProperty' -Name 'Parent' -Value {
+                $mockParent = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+                $mockParent | Add-Member -MemberType 'NoteProperty' -Name 'InstanceName' -Value 'TestInstance' -Force
+                return $mockParent
+            } -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'SetDefaultFullTextCatalog' -Value {
+                param($CatalogName)
+                throw 'Simulated SetDefaultFullTextCatalog() failure'
+            } -Force
+            $mockDatabaseObject | Add-Member -MemberType 'ScriptMethod' -Name 'Refresh' -Value {
+                # Mock implementation - in real SMO this updates properties from server
+            } -Force
+        }
+
+        It 'Should throw error when SetDefaultFullTextCatalog() fails' {
+            { Set-SqlDscDatabaseDefaultFullTextCatalog -DatabaseObject $mockDatabaseObject -CatalogName 'MyCatalog' -Force } |
+                Should -Throw -ExpectedMessage '*Failed to set default full-text catalog of database*'
+        }
+    }
+
+    Context 'When database does not exist' {
+        BeforeAll {
+            $mockServerObject = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Server'
+            $mockServerObject | Add-Member -MemberType 'NoteProperty' -Name 'InstanceName' -Value 'TestInstance' -Force
+            $mockServerObject | Add-Member -MemberType 'ScriptProperty' -Name 'Databases' -Value {
+                return @{} | Add-Member -MemberType 'ScriptMethod' -Name 'Refresh' -Value {
+                    # Mock implementation
+                } -PassThru -Force
+            } -Force
+        }
+
+        It 'Should throw error when database does not exist' {
+            { Set-SqlDscDatabaseDefaultFullTextCatalog -ServerObject $mockServerObject -Name 'NonExistentDatabase' -CatalogName 'MyCatalog' -Force } |
+                Should -Throw -ExpectedMessage '*Database * was not found*'
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Should have the correct parameters in parameter set ServerObjectSet' -ForEach @(
+            @{
+                ExpectedParameterSetName = 'ServerObjectSet'
+                ExpectedParameters = '-ServerObject <Server> -Name <string> -CatalogName <string> [-Refresh] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            }
+        ) {
+            $result = (Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog').ParameterSets |
+                Where-Object -FilterScript { $_.Name -eq $ExpectedParameterSetName } |
+                Select-Object -Property @(
+                    @{ Name = 'ParameterSetName'; Expression = { $_.Name } },
+                    @{ Name = 'ParameterListAsString'; Expression = { $_.ToString() } }
+                )
+
+            $result.ParameterSetName | Should -Be $ExpectedParameterSetName
+            $result.ParameterListAsString | Should -Be $ExpectedParameters
+        }
+
+        It 'Should have the correct parameters in parameter set DatabaseObjectSet' -ForEach @(
+            @{
+                ExpectedParameterSetName = 'DatabaseObjectSet'
+                ExpectedParameters = '-DatabaseObject <Database> -CatalogName <string> [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]'
+            }
+        ) {
+            $result = (Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog').ParameterSets |
+                Where-Object -FilterScript { $_.Name -eq $ExpectedParameterSetName } |
+                Select-Object -Property @(
+                    @{ Name = 'ParameterSetName'; Expression = { $_.Name } },
+                    @{ Name = 'ParameterListAsString'; Expression = { $_.ToString() } }
+                )
+
+            $result.ParameterSetName | Should -Be $ExpectedParameterSetName
+            $result.ParameterListAsString | Should -Be $ExpectedParameters
+        }
+
+        It 'Should have CatalogName as a mandatory parameter' {
+            $command = Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog'
+            $catalogNameParam = $command.Parameters['CatalogName']
+
+            $catalogNameParam | Should -Not -BeNullOrEmpty
+            $catalogNameParam.ParameterType.Name | Should -Be 'String'
+
+            # Check if parameter is mandatory in at least one parameter set
+            $mandatoryInAnySets = $catalogNameParam.Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+                Where-Object { $_.Mandatory -eq $true }
+
+            $mandatoryInAnySets | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should support ShouldProcess (WhatIf and Confirm)' {
+            $command = Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog'
+            $command.Parameters.Keys | Should -Contain 'WhatIf'
+            $command.Parameters.Keys | Should -Contain 'Confirm'
+        }
+
+        It 'Should have Force parameter to bypass confirmation' {
+            $command = Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog'
+            $command.Parameters.Keys | Should -Contain 'Force'
+        }
+
+        It 'Should have PassThru parameter to return the database object' {
+            $command = Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog'
+            $command.Parameters.Keys | Should -Contain 'PassThru'
+        }
+
+        It 'Should have ServerObject as a mandatory parameter in ServerObjectSet' {
+            $param = (Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog').Parameters['ServerObject']
+            ($param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'ServerObjectSet' }).Mandatory | Should -BeTrue
+        }
+
+        It 'Should have DatabaseObject as a mandatory parameter in DatabaseObjectSet' {
+            $param = (Get-Command -Name 'Set-SqlDscDatabaseDefaultFullTextCatalog').Parameters['DatabaseObject']
+            ($param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'DatabaseObjectSet' }).Mandatory | Should -BeTrue
+        }
+    }
+}


### PR DESCRIPTION

#### Pull Request (PR) description

- Added public command `Set-SqlDscDatabaseDefaultFullTextCatalog` to set the default
  full-text catalog for a database in a SQL Server Database Engine instance. This
  command uses the SMO `SetDefaultFullTextCatalog()` method to configure the default
  catalog ([issue #2330](https://github.com/dsccommunity/SqlServerDsc/issues/2330)).

#### This Pull Request (PR) fixes the following issues

- Fixes #2330


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2352)
<!-- Reviewable:end -->
