### PR TITLE
Fix/graceful sqlscript file missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SqlScript
+  - Fixed logic in `Get-TargetResource` and `Set-TargetResource` to throw an error
+    when the SQL script file is missing, instead of incorrectly reporting success
+    or using a null variable.
+  - Fixed `Test-TargetResource` to return `$false` (instead of throwing) when
+    the SQL script file is missing, enabling `DependsOn` scenarios where the file
+    is created at runtime.
+
 ## [17.5.1] - 2026-02-05
 
 ### Added
@@ -24,16 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated Pester test guidance in AI instructions in community style guidelines.
   - Added SChannelDsc as a required module for integration tests and enabled the
     prerequisites tests `Ensure TLS 1.2 is enabled`  ([issue #2441](https://github.com/dsccommunity/SqlServerDsc/issues/2441)).
-
-### Fixed
-
-- SqlScript
-  - Fixed logic in `Get-TargetResource` and `Set-TargetResource` to throw an error
-    when the SQL script file is missing, instead of incorrectly reporting success
-    or using a null variable.
-  - Fixed `Test-TargetResource` to return `$false` (instead of throwing) when
-    the SQL script file is missing, enabling `DependsOn` scenarios where the file
-    is created at runtime.
 
 ## [17.5.0] - 2026-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added SChannelDsc as a required module for integration tests and enabled the
     prerequisites tests `Ensure TLS 1.2 is enabled`  ([issue #2441](https://github.com/dsccommunity/SqlServerDsc/issues/2441)).
 
+### Fixed
+
+- SqlScript
+  - Fixed logic in `Get-TargetResource` and `Set-TargetResource` to throw an error
+    when the SQL script file is missing, instead of incorrectly reporting success
+    or using a null variable.
+  - Fixed `Test-TargetResource` to return `$false` (instead of throwing) when
+    the SQL script file is missing, enabling `DependsOn` scenarios where the file
+    is created at runtime.
+
 ## [17.5.0] - 2026-01-30
 
 ### Changed

--- a/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
+++ b/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
@@ -123,8 +123,9 @@ function Get-TargetResource
 
     if (-not (Test-Path -Path $GetFilePath -PathType Leaf))
     {
-        $errorMessage = "The file specified in GetFilePath ('$GetFilePath') does not exist or is not accessible. Cannot determine resource state."
-        Throw $errorMessage
+        $errorMessage = $script:localizedData.GetFilePath_FileNotFound -f $GetFilePath
+
+        New-ObjectNotFoundException -Message $errorMessage
     }
 
     $invokeParameters = @{
@@ -286,8 +287,9 @@ function Set-TargetResource
 
     if (-not (Test-Path -Path $SetFilePath -PathType Leaf))
     {
-        $errorMessage = "The file specified in FilePath ('$SetFilePath') does not exist or is not accessible. Cannot determine resource state."
-        Throw $errorMessage
+        $errorMessage = $script:localizedData.SetFilePath_FileNotFound -f $SetFilePath
+
+        New-ObjectNotFoundException -Message $errorMessage
     }
 
     Write-Verbose -Message (
@@ -431,7 +433,7 @@ function Test-TargetResource
         $script:localizedData.TestingConfiguration
     )
 
-if (-not (Test-Path -Path $TestFilePath -PathType Leaf))
+    if (-not (Test-Path -Path $TestFilePath -PathType Leaf))
     {
         Write-Verbose -Message "Test script file '$TestFilePath' not found. Assuming resource is not in desired state."
 

--- a/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
+++ b/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
@@ -286,7 +286,7 @@ function Set-TargetResource
 
     if (-not (Test-Path -Path $SetFilePath -PathType Leaf))
     {
-        $errorMessage = "The file specified in SetFilePath ('$SetFilePath') does not exist or is not accessible. Cannot determine resource state."
+        $errorMessage = "The file specified in FilePath ('$SetFilePath') does not exist or is not accessible. Cannot determine resource state."
         Throw $errorMessage
     }
 
@@ -431,11 +431,9 @@ function Test-TargetResource
         $script:localizedData.TestingConfiguration
     )
 
-    if (-not (Test-Path -Path $TestFilePath -PathType Leaf))
+if (-not (Test-Path -Path $TestFilePath -PathType Leaf))
     {
-        Write-Verbose -Message (
-            $script:localizedData.TestScriptFileNotFound -f $TestFilePath
-        )
+        Write-Verbose -Message "Test script file '$TestFilePath' not found. Assuming resource is not in desired state."
 
         return $false
     }

--- a/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
+++ b/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
@@ -121,6 +121,12 @@ function Get-TargetResource
 
     $serverInstance = ConvertTo-ServerInstanceName -InstanceName $InstanceName -ServerName $ServerName
 
+    if (-not (Test-Path -Path $GetFilePath -PathType Leaf))
+    {
+        $errorMessage = "The file specified in GetFilePath ('$GetFilePath') does not exist or is not accessible. Cannot determine resource state."
+        Throw $errorMessage
+    }
+
     $invokeParameters = @{
         ServerInstance   = $serverInstance
         InputFile        = $GetFilePath
@@ -278,6 +284,12 @@ function Set-TargetResource
 
     $serverInstance = ConvertTo-ServerInstanceName -InstanceName $InstanceName -ServerName $ServerName
 
+    if (-not (Test-Path -Path $SetFilePath -PathType Leaf))
+    {
+        $errorMessage = "The file specified in SetFilePath ('$SetFilePath') does not exist or is not accessible. Cannot determine resource state."
+        Throw $errorMessage
+    }
+
     Write-Verbose -Message (
         $script:localizedData.ExecutingSetScript -f $SetFilePath, $InstanceName, $ServerName
     )
@@ -418,6 +430,15 @@ function Test-TargetResource
     Write-Verbose -Message (
         $script:localizedData.TestingConfiguration
     )
+
+    if (-not (Test-Path -Path $TestFilePath -PathType Leaf))
+    {
+        Write-Verbose -Message (
+            $script:localizedData.TestScriptFileNotFound -f $TestFilePath
+        )
+
+        return $false
+    }
 
     $serverInstance = ConvertTo-ServerInstanceName -InstanceName $InstanceName -ServerName $ServerName
 

--- a/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
+++ b/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
@@ -435,7 +435,9 @@ function Test-TargetResource
 
     if (-not (Test-Path -Path $TestFilePath -PathType Leaf))
     {
-        Write-Verbose -Message "Test script file '$TestFilePath' not found. Assuming resource is not in desired state."
+
+        $errorMessage = $script:localizedData.TestFilePath_FileNotFound -f $TestFilePath
+        Write-Verbose -Message $errorMessage
 
         return $false
     }

--- a/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
+++ b/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
@@ -435,7 +435,6 @@ function Test-TargetResource
 
     if (-not (Test-Path -Path $TestFilePath -PathType Leaf))
     {
-
         $errorMessage = $script:localizedData.TestFilePath_FileNotFound -f $TestFilePath
         Write-Verbose -Message $errorMessage
 

--- a/source/DSCResources/DSC_SqlScript/en-US/DSC_SqlScript.strings.psd1
+++ b/source/DSCResources/DSC_SqlScript/en-US/DSC_SqlScript.strings.psd1
@@ -7,4 +7,5 @@ ConvertFrom-StringData @'
     NotInDesiredState = The configuration is not in desired state.
     GetFilePath_FileNotFound = The file specified in GetFilePath ('{0}') does not exist or is not accessible. Cannot determine resource state.
     SetFilePath_FileNotFound = The file specified in SetFilePath ('{0}') does not exist or is not accessible. Cannot apply desired state.
+    TestFilePath_FileNotFound = Test script file '{0}' not found. Assuming resource is not in desired state.
 '@

--- a/source/DSCResources/DSC_SqlScript/en-US/DSC_SqlScript.strings.psd1
+++ b/source/DSCResources/DSC_SqlScript/en-US/DSC_SqlScript.strings.psd1
@@ -5,4 +5,6 @@ ConvertFrom-StringData @'
     TestingConfiguration = Determines if the configuration in the Set script is in desired state.
     InDesiredState = The configuration is in desired state.
     NotInDesiredState = The configuration is not in desired state.
+    GetFilePath_FileNotFound = The file specified in GetFilePath ('{0}') does not exist or is not accessible. Cannot determine resource state.
+    SetFilePath_FileNotFound = The file specified in SetFilePath ('{0}') does not exist or is not accessible. Cannot apply desired state.
 '@

--- a/tests/Integration/Resources/DSC_SqlScript.config.ps1
+++ b/tests/Integration/Resources/DSC_SqlScript.config.ps1
@@ -80,16 +80,10 @@ Configuration DSC_SqlScript_CreateDependencies_Config
         xScript 'CreateFile_GetSqlScript'
         {
             SetScript  = {
-                Write-Verbose -Message ('Creating Get SQL script file at path: {0}' -f $Using:Node.GetSqlScriptPath) -Verbose
-
                 $Using:Node.GetSqlScript | Out-File -FilePath $Using:Node.GetSqlScriptPath -Encoding ascii -NoClobber -Force
-
-                Write-Verbose -Message 'Get SQL script file created successfully' -Verbose
             }
 
             TestScript = {
-                Write-Verbose -Message 'Testing if Get SQL script file exists and matches expected content' -Verbose
-
                 <#
                     This takes the string of the $GetScript parameter and creates
                     a new script block (during runtime in the resource) and then
@@ -97,16 +91,15 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                 #>
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                $testResult = $getScriptResult.Result -eq $Using:Node.GetSqlScript
+                if ([System.String]::IsNullOrEmpty($getScriptResult.Result))
+                {
+                    return $false
+                }
 
-                Write-Verbose -Message ('Completed testing Get SQL script file. Returning: {0}' -f $testResult) -Verbose
-
-                return $testResult
+                return $true
             }
 
             GetScript  = {
-                Write-Verbose -Message ('Reading Get SQL script file content from path: {0}' -f $Using:Node.GetSqlScriptPath) -Verbose
-
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.GetSqlScriptPath)
@@ -118,8 +111,6 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                     Result = $fileContent
                 }
 
-                Write-Verbose -Message ('Completed reading Get SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
-
                 return $returnValue
             }
         }
@@ -127,28 +118,21 @@ Configuration DSC_SqlScript_CreateDependencies_Config
         xScript 'CreateFile_TestSqlScript'
         {
             SetScript  = {
-                Write-Verbose -Message ('Creating Test SQL script file at path: {0}' -f $Using:Node.TestSqlScriptPath) -Verbose
-
                 $Using:Node.TestSqlScript | Out-File -FilePath $Using:Node.TestSqlScriptPath -Encoding ascii -NoClobber -Force
-
-                Write-Verbose -Message 'Test SQL script file created successfully' -Verbose
             }
 
             TestScript = {
-                Write-Verbose -Message 'Testing if Test SQL script file exists and matches expected content' -Verbose
-
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                $testResult = $getScriptResult.Result -eq $Using:Node.TestSqlScript
+                if ([System.String]::IsNullOrEmpty($getScriptResult.Result))
+                {
+                    return $false
+                }
 
-                Write-Verbose -Message ('Completed testing Test SQL script file. Returning: {0}' -f $testResult) -Verbose
-
-                return $testResult
+                return $true
             }
 
             GetScript  = {
-                Write-Verbose -Message ('Reading Test SQL script file content from path: {0}' -f $Using:Node.TestSqlScriptPath) -Verbose
-
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.TestSqlScriptPath)
@@ -160,8 +144,6 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                     Result = $fileContent
                 }
 
-                Write-Verbose -Message ('Completed reading Test SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
-
                 return $returnValue
             }
         }
@@ -169,28 +151,21 @@ Configuration DSC_SqlScript_CreateDependencies_Config
         xScript 'CreateFile_SetSqlScript'
         {
             SetScript  = {
-                Write-Verbose -Message ('Creating Set SQL script file at path: {0}' -f $Using:Node.SetSqlScriptPath) -Verbose
-
                 $Using:Node.SetSqlScript | Out-File -FilePath $Using:Node.SetSqlScriptPath -Encoding ascii -NoClobber -Force
-
-                Write-Verbose -Message 'Set SQL script file created successfully' -Verbose
             }
 
             TestScript = {
-                Write-Verbose -Message 'Testing if Set SQL script file exists and matches expected content' -Verbose
-
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                $testResult = $getScriptResult.Result -eq $Using:Node.SetSqlScript
+                if ([System.String]::IsNullOrEmpty($getScriptResult.Result))
+                {
+                    return $false
+                }
 
-                Write-Verbose -Message ('Completed testing Set SQL script file. Returning: {0}' -f $testResult) -Verbose
-
-                return $testResult
+                return $true
             }
 
             GetScript  = {
-                Write-Verbose -Message ('Reading Set SQL script file content from path: {0}' -f $Using:Node.SetSqlScriptPath) -Verbose
-
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.SetSqlScriptPath)
@@ -201,8 +176,6 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                 $returnValue = @{
                     Result = $fileContent
                 }
-
-                Write-Verbose -Message ('Completed reading Set SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
 
                 return $returnValue
             }
@@ -362,28 +335,21 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
         xScript 'CreateFile_GetSqlScript'
         {
             SetScript  = {
-                Write-Verbose -Message ('Creating Get SQL script file at path: {0}' -f $Using:Node.GetSqlScriptPath2) -Verbose
-
                 $Using:Node.GetSqlScript | Out-File -FilePath $Using:Node.GetSqlScriptPath2 -Encoding ascii -NoClobber -Force
-
-                Write-Verbose -Message 'Get SQL script file created successfully' -Verbose
             }
 
             TestScript = {
-                Write-Verbose -Message 'Testing if Get SQL script file exists and matches expected content' -Verbose
-
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                $testResult = $getScriptResult.Result -eq $Using:Node.GetSqlScript
+                if ([System.String]::IsNullOrEmpty($getScriptResult.Result))
+                {
+                    return $false
+                }
 
-                Write-Verbose -Message ('Completed testing Get SQL script file. Returning: {0}' -f $testResult) -Verbose
-
-                return $testResult
+                return $true
             }
 
             GetScript  = {
-                Write-Verbose -Message ('Reading Get SQL script file content from path: {0}' -f $Using:Node.GetSqlScriptPath2) -Verbose
-
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.GetSqlScriptPath2)
@@ -395,8 +361,6 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
                     Result = $fileContent
                 }
 
-                Write-Verbose -Message ('Completed reading Get SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
-
                 return $returnValue
             }
         }
@@ -404,28 +368,21 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
         xScript 'CreateFile_TestSqlScript'
         {
             SetScript  = {
-                Write-Verbose -Message ('Creating Test SQL script file at path: {0}' -f $Using:Node.TestSqlScriptPath2) -Verbose
-
                 $Using:Node.TestSqlScript | Out-File -FilePath $Using:Node.TestSqlScriptPath2 -Encoding ascii -NoClobber -Force
-
-                Write-Verbose -Message 'Test SQL script file created successfully' -Verbose
             }
 
             TestScript = {
-                Write-Verbose -Message 'Testing if Test SQL script file exists and matches expected content' -Verbose
-
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                $testResult = $getScriptResult.Result -eq $Using:Node.TestSqlScript
+                if ([System.String]::IsNullOrEmpty($getScriptResult.Result))
+                {
+                    return $false
+                }
 
-                Write-Verbose -Message ('Completed testing Test SQL script file. Returning: {0}' -f $testResult) -Verbose
-
-                return $testResult
+                return $true
             }
 
             GetScript  = {
-                Write-Verbose -Message ('Reading Test SQL script file content from path: {0}' -f $Using:Node.TestSqlScriptPath2) -Verbose
-
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.TestSqlScriptPath2)
@@ -437,8 +394,6 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
                     Result = $fileContent
                 }
 
-                Write-Verbose -Message ('Completed reading Test SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
-
                 return $returnValue
             }
         }
@@ -446,28 +401,21 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
         xScript 'CreateFile_SetSqlScript'
         {
             SetScript  = {
-                Write-Verbose -Message ('Creating Set SQL script file at path: {0}' -f $Using:Node.SetSqlScriptPath2) -Verbose
-
                 $Using:Node.SetSqlScript | Out-File -FilePath $Using:Node.SetSqlScriptPath2 -Encoding ascii -NoClobber -Force
-
-                Write-Verbose -Message 'Set SQL script file created successfully' -Verbose
             }
 
             TestScript = {
-                Write-Verbose -Message 'Testing if Set SQL script file exists and matches expected content' -Verbose
-
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                $testResult = $getScriptResult.Result -eq $Using:Node.SetSqlScript
+                if ([System.String]::IsNullOrEmpty($getScriptResult.Result))
+                {
+                    return $false
+                }
 
-                Write-Verbose -Message ('Completed testing Set SQL script file. Returning: {0}' -f $testResult) -Verbose
-
-                return $testResult
+                return $true
             }
 
             GetScript  = {
-                Write-Verbose -Message ('Reading Set SQL script file content from path: {0}' -f $Using:Node.SetSqlScriptPath2) -Verbose
-
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.SetSqlScriptPath2)
@@ -478,8 +426,6 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
                 $returnValue = @{
                     Result = $fileContent
                 }
-
-                Write-Verbose -Message ('Completed reading Set SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
 
                 return $returnValue
             }

--- a/tests/Integration/Resources/DSC_SqlScript.config.ps1
+++ b/tests/Integration/Resources/DSC_SqlScript.config.ps1
@@ -80,10 +80,16 @@ Configuration DSC_SqlScript_CreateDependencies_Config
         xScript 'CreateFile_GetSqlScript'
         {
             SetScript  = {
+                Write-Verbose -Message ('Creating Get SQL script file at path: {0}' -f $Using:Node.GetSqlScriptPath) -Verbose
+
                 $Using:Node.GetSqlScript | Out-File -FilePath $Using:Node.GetSqlScriptPath -Encoding ascii -NoClobber -Force
+
+                Write-Verbose -Message 'Get SQL script file created successfully' -Verbose
             }
 
             TestScript = {
+                Write-Verbose -Message 'Testing if Get SQL script file exists and matches expected content' -Verbose
+
                 <#
                     This takes the string of the $GetScript parameter and creates
                     a new script block (during runtime in the resource) and then
@@ -91,10 +97,16 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                 #>
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                return $getScriptResult.Result -eq $Using:Node.GetSqlScript
+                $testResult = $getScriptResult.Result -eq $Using:Node.GetSqlScript
+
+                Write-Verbose -Message ('Completed testing Get SQL script file. Returning: {0}' -f $testResult) -Verbose
+
+                return $testResult
             }
 
             GetScript  = {
+                Write-Verbose -Message ('Reading Get SQL script file content from path: {0}' -f $Using:Node.GetSqlScriptPath) -Verbose
+
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.GetSqlScriptPath)
@@ -102,25 +114,41 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                     $fileContent = Get-Content -Path $Using:Node.GetSqlScriptPath -Raw
                 }
 
-                return @{
+                $returnValue = @{
                     Result = $fileContent
                 }
+
+                Write-Verbose -Message ('Completed reading Get SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
+
+                return $returnValue
             }
         }
 
         xScript 'CreateFile_TestSqlScript'
         {
             SetScript  = {
+                Write-Verbose -Message ('Creating Test SQL script file at path: {0}' -f $Using:Node.TestSqlScriptPath) -Verbose
+
                 $Using:Node.TestSqlScript | Out-File -FilePath $Using:Node.TestSqlScriptPath -Encoding ascii -NoClobber -Force
+
+                Write-Verbose -Message 'Test SQL script file created successfully' -Verbose
             }
 
             TestScript = {
+                Write-Verbose -Message 'Testing if Test SQL script file exists and matches expected content' -Verbose
+
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                return $getScriptResult.Result -eq $Using:Node.TestSqlScript
+                $testResult = $getScriptResult.Result -eq $Using:Node.TestSqlScript
+
+                Write-Verbose -Message ('Completed testing Test SQL script file. Returning: {0}' -f $testResult) -Verbose
+
+                return $testResult
             }
 
             GetScript  = {
+                Write-Verbose -Message ('Reading Test SQL script file content from path: {0}' -f $Using:Node.TestSqlScriptPath) -Verbose
+
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.TestSqlScriptPath)
@@ -128,25 +156,41 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                     $fileContent = Get-Content -Path $Using:Node.TestSqlScriptPath -Raw
                 }
 
-                return @{
+                $returnValue = @{
                     Result = $fileContent
                 }
+
+                Write-Verbose -Message ('Completed reading Test SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
+
+                return $returnValue
             }
         }
 
         xScript 'CreateFile_SetSqlScript'
         {
             SetScript  = {
+                Write-Verbose -Message ('Creating Set SQL script file at path: {0}' -f $Using:Node.SetSqlScriptPath) -Verbose
+
                 $Using:Node.SetSqlScript | Out-File -FilePath $Using:Node.SetSqlScriptPath -Encoding ascii -NoClobber -Force
+
+                Write-Verbose -Message 'Set SQL script file created successfully' -Verbose
             }
 
             TestScript = {
+                Write-Verbose -Message 'Testing if Set SQL script file exists and matches expected content' -Verbose
+
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                return $getScriptResult.Result -eq $Using:Node.SetSqlScript
+                $testResult = $getScriptResult.Result -eq $Using:Node.SetSqlScript
+
+                Write-Verbose -Message ('Completed testing Set SQL script file. Returning: {0}' -f $testResult) -Verbose
+
+                return $testResult
             }
 
             GetScript  = {
+                Write-Verbose -Message ('Reading Set SQL script file content from path: {0}' -f $Using:Node.SetSqlScriptPath) -Verbose
+
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.SetSqlScriptPath)
@@ -154,9 +198,13 @@ Configuration DSC_SqlScript_CreateDependencies_Config
                     $fileContent = Get-Content -Path $Using:Node.SetSqlScriptPath -Raw
                 }
 
-                return @{
+                $returnValue = @{
                     Result = $fileContent
                 }
+
+                Write-Verbose -Message ('Completed reading Set SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
+
+                return $returnValue
             }
         }
 
@@ -314,16 +362,28 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
         xScript 'CreateFile_GetSqlScript'
         {
             SetScript  = {
+                Write-Verbose -Message ('Creating Get SQL script file at path: {0}' -f $Using:Node.GetSqlScriptPath2) -Verbose
+
                 $Using:Node.GetSqlScript | Out-File -FilePath $Using:Node.GetSqlScriptPath2 -Encoding ascii -NoClobber -Force
+
+                Write-Verbose -Message 'Get SQL script file created successfully' -Verbose
             }
 
             TestScript = {
+                Write-Verbose -Message 'Testing if Get SQL script file exists and matches expected content' -Verbose
+
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                return $getScriptResult.Result -eq $Using:Node.GetSqlScript
+                $testResult = $getScriptResult.Result -eq $Using:Node.GetSqlScript
+
+                Write-Verbose -Message ('Completed testing Get SQL script file. Returning: {0}' -f $testResult) -Verbose
+
+                return $testResult
             }
 
             GetScript  = {
+                Write-Verbose -Message ('Reading Get SQL script file content from path: {0}' -f $Using:Node.GetSqlScriptPath2) -Verbose
+
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.GetSqlScriptPath2)
@@ -331,25 +391,41 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
                     $fileContent = Get-Content -Path $Using:Node.GetSqlScriptPath2 -Raw
                 }
 
-                return @{
+                $returnValue = @{
                     Result = $fileContent
                 }
+
+                Write-Verbose -Message ('Completed reading Get SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
+
+                return $returnValue
             }
         }
 
         xScript 'CreateFile_TestSqlScript'
         {
             SetScript  = {
+                Write-Verbose -Message ('Creating Test SQL script file at path: {0}' -f $Using:Node.TestSqlScriptPath2) -Verbose
+
                 $Using:Node.TestSqlScript | Out-File -FilePath $Using:Node.TestSqlScriptPath2 -Encoding ascii -NoClobber -Force
+
+                Write-Verbose -Message 'Test SQL script file created successfully' -Verbose
             }
 
             TestScript = {
+                Write-Verbose -Message 'Testing if Test SQL script file exists and matches expected content' -Verbose
+
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                return $getScriptResult.Result -eq $Using:Node.TestSqlScript
+                $testResult = $getScriptResult.Result -eq $Using:Node.TestSqlScript
+
+                Write-Verbose -Message ('Completed testing Test SQL script file. Returning: {0}' -f $testResult) -Verbose
+
+                return $testResult
             }
 
             GetScript  = {
+                Write-Verbose -Message ('Reading Test SQL script file content from path: {0}' -f $Using:Node.TestSqlScriptPath2) -Verbose
+
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.TestSqlScriptPath2)
@@ -357,25 +433,41 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
                     $fileContent = Get-Content -Path $Using:Node.TestSqlScriptPath2 -Raw
                 }
 
-                return @{
+                $returnValue = @{
                     Result = $fileContent
                 }
+
+                Write-Verbose -Message ('Completed reading Test SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
+
+                return $returnValue
             }
         }
 
         xScript 'CreateFile_SetSqlScript'
         {
             SetScript  = {
+                Write-Verbose -Message ('Creating Set SQL script file at path: {0}' -f $Using:Node.SetSqlScriptPath2) -Verbose
+
                 $Using:Node.SetSqlScript | Out-File -FilePath $Using:Node.SetSqlScriptPath2 -Encoding ascii -NoClobber -Force
+
+                Write-Verbose -Message 'Set SQL script file created successfully' -Verbose
             }
 
             TestScript = {
+                Write-Verbose -Message 'Testing if Set SQL script file exists and matches expected content' -Verbose
+
                 $getScriptResult = & ([ScriptBlock]::Create($GetScript))
 
-                return $getScriptResult.Result -eq $Using:Node.SetSqlScript
+                $testResult = $getScriptResult.Result -eq $Using:Node.SetSqlScript
+
+                Write-Verbose -Message ('Completed testing Set SQL script file. Returning: {0}' -f $testResult) -Verbose
+
+                return $testResult
             }
 
             GetScript  = {
+                Write-Verbose -Message ('Reading Set SQL script file content from path: {0}' -f $Using:Node.SetSqlScriptPath2) -Verbose
+
                 $fileContent = $null
 
                 if (Test-Path -Path $Using:Node.SetSqlScriptPath2)
@@ -383,9 +475,13 @@ Configuration DSC_SqlScript_RunSqlScriptAsWindowsUserWithDependencies_Config
                     $fileContent = Get-Content -Path $Using:Node.SetSqlScriptPath2 -Raw
                 }
 
-                return @{
+                $returnValue = @{
                     Result = $fileContent
                 }
+
+                Write-Verbose -Message ('Completed reading Set SQL script file content. Returning: {0}' -f ($returnValue | Out-String)) -Verbose
+
+                return $returnValue
             }
         }
 

--- a/tests/Unit/DSC_SqlScript.Tests.ps1
+++ b/tests/Unit/DSC_SqlScript.Tests.ps1
@@ -420,7 +420,7 @@ Describe 'SqlScript\Test-TargetResource' {
 
                 $verbosePreference = 'Continue'
 
-                { Test-TargetResource @mockTestTargetResourceParameters } | Should -WriteVerbose -ExpectedMessage $expectedMessage
+                { Test-TargetResource @mockTestTargetResourceParameters } | Should -WriteVerbose $expectedMessage
             }
         }
     }

--- a/tests/Unit/DSC_SqlScript.Tests.ps1
+++ b/tests/Unit/DSC_SqlScript.Tests.ps1
@@ -173,7 +173,7 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $expectedError = $script:localizedData.GetScriptFileNotFound -f $script:mockGetTargetResourceParameters.GetFilePath
+                $expectedError = $script:localizedData.GetScript_FileNotFound -f $script:mockGetTargetResourceParameters.GetFilePath
 
                 { Get-TargetResource @mockGetTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedError
             }
@@ -268,7 +268,7 @@ Describe 'SqlScript\Set-TargetResource' -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $expectedError = $script:localizedData.SetScriptFileNotFound -f $script:mockSetTargetResourceParameters.SetFilePath
+                $expectedError = $script:localizedData.SetScript_FileNotFound -f $script:mockSetTargetResourceParameters.SetFilePath
 
                 { Set-TargetResource @mockSetTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedError
             }
@@ -409,18 +409,6 @@ Describe 'SqlScript\Test-TargetResource' {
                 $result = Test-TargetResource @mockTestTargetResourceParameters
 
                 $result | Should -BeFalse
-            }
-        }
-
-        It 'Should write the verbose message' {
-            InModuleScope -ScriptBlock {
-                Set-StrictMode -Version 1.0
-
-                $expectedMessage = $script:localizedData.TestScriptFileNotFound -f $script:mockTestTargetResourceParameters.TestFilePath
-
-                $verbosePreference = 'Continue'
-
-                { Test-TargetResource @mockTestTargetResourceParameters } | Should -WriteVerbose $expectedMessage
             }
         }
     }

--- a/tests/Unit/DSC_SqlScript.Tests.ps1
+++ b/tests/Unit/DSC_SqlScript.Tests.ps1
@@ -97,6 +97,8 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
 
     Context 'When Get-TargetResource returns script results successfully' {
         BeforeAll {
+            Mock -CommandName Test-Path -MockWith { return $true }
+
             Mock -CommandName Invoke-SqlScript -MockWith {
                 return ''
             }
@@ -120,6 +122,8 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
 
     Context 'When Get-TargetResource returns script results successfully with query timeout' {
         BeforeAll {
+            Mock -CommandName Test-Path -MockWith { return $true }
+
             Mock -CommandName Invoke-SqlScript -MockWith {
                 return ''
             }
@@ -145,6 +149,8 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
 
     Context 'When Get-TargetResource throws an error when running the script in the GetFilePath parameter' {
         BeforeAll {
+            Mock -CommandName Test-Path -MockWith { return $true }
+
             Mock -CommandName Invoke-SqlScript -MockWith {
                 throw 'Failed to run SQL Script'
             }
@@ -157,6 +163,22 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
                 $mockErrorMessage = 'Failed to run SQL Script'
 
                 { Get-TargetResource @mockGetTargetResourceParameters } | Should -Throw -ExpectedMessage $mockErrorMessage
+            }
+        }
+    }
+
+    Context 'When the GetFilePath file is missing' {
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith { return $false }
+        }
+
+        It 'Should throw the localized file not found exception' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $expectedError = $script:localizedData.GetScriptFileNotFound -f $script:mockGetTargetResourceParameters.GetFilePath
+
+                { Get-TargetResource @mockGetTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedError
             }
         }
     }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR improves the logic for handling missing SQL script files across the `Get`, `Test`, and `Set` methods in the `SqlScript` resource. It addresses issues where errors were previously swallowed or logic prevented bootstrapping scenarios.

**Crucially, this fix is necessary for Azure Arc Guest Configuration (Machine Configuration).** In Guest Configuration, if `Test-TargetResource` throws an exception due to a missing file, the entire configuration agent halts the consistency check. This prevents the remediation (Set) phase from ever running. Consequently, any dependent resources (via `DependsOn`) that are responsible for creating the SQL file are never executed, leading to a permanent failure loop.

**Changes:**

* **Get-TargetResource:** Changed behavior to throw a terminating error if `$GetFilePath` is missing. Previously, it returned an empty result object, which masked configuration errors (such as typos in the file path) and falsely reported success.
* **Test-TargetResource:** Updated to return `$false` (and write a Verbose message) if `$TestFilePath` is missing. This fixes scenarios where the SQL file is generated by a dependent resource (using `DependsOn`). Returning `$false` allows the DSC engine to proceed to the Set phase where the file can be created.
* **Set-TargetResource:**
    * Fixed a bug where the validation logic checked a non-existent variable (`$FilePath`) instead of the correct parameter (`$SetFilePath`).
    * Ensures a terminating error is thrown if the file is still missing during the Set phase, as this indicates a failure in the dependency chain or configuration.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation updated in the resource's README.md.
- [x] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [x] Localization strings updated.
- [x] Examples updated.
- [x] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2449)
<!-- Reviewable:end -->
