### PR TITLE
Fix Test-TargetResource crash when SQL instance is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed `Test-TargetResource` to return `$false` (instead of throwing) when
     the SQL script file is missing, enabling `DependsOn` scenarios where the file
     is created at runtime.
+- SqlAgentAlert, SqlAudit, SqlDatabase, SqlDatabasePermission, SqlPermission,
+  SqlRSSetup
+  - Fixed `Test()` method to return `$false` (instead of throwing) when the SQL
+    Server instance is not reachable or an error occurs, enabling graceful
+    handling and better support for `DependsOn` scenarios.
+- SqlAG, SqlAGDatabase, SqlAGListener, SqlAGReplica, SqlAgentFailsafe,
+  SqlAgentOperator, SqlAlias, SqlAlwaysOnService, SqlConfiguration,
+  SqlDatabaseDefaultLocation, SqlDatabaseMail, SqlDatabaseObjectPermission,
+  SqlDatabaseRole, SqlDatabaseUser, SqlEndpoint, SqlEndpointPermission, SqlLogin,
+  SqlMaxDop, SqlMemory, SqlProtocol, SqlProtocolTcpIp, SqlRS, SqlReplication,
+  SqlRole, SqlScript, SqlScriptQuery, SqlSecureConnection, SqlServiceAccount,
+  SqlSetup, SqlTraceFlag, SqlWaitForAG, SqlWindowsFirewall
+  - Fixed `Test-TargetResource` to return `$false` (instead of throwing) when
+    the SQL Server instance is not reachable or an error occurs during
+    `Get-TargetResource`, enabling graceful handling and better support for
+    `DependsOn` scenarios.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     is created at runtime.
 - SqlAgentAlert, SqlAudit, SqlDatabase, SqlDatabasePermission, SqlPermission,
   SqlRSSetup
-  - Fixed `Test()` method to return `$false` (instead of throwing) when the SQL
-    Server instance is not reachable or an error occurs, enabling graceful
-    handling and better support for `DependsOn` scenarios.
+  - Fixed `Test()` method to return `$false` (instead of throwing) when the
+    SQL Server instance is not reachable or an error occurs, enabling
+    graceful handling and better support for `DependsOn` scenarios.
 - SqlAG, SqlAGDatabase, SqlAGListener, SqlAGReplica, SqlAgentFailsafe,
   SqlAgentOperator, SqlAlias, SqlAlwaysOnService, SqlConfiguration,
   SqlDatabaseDefaultLocation, SqlDatabaseMail, SqlDatabaseObjectPermission,
-  SqlDatabaseRole, SqlDatabaseUser, SqlEndpoint, SqlEndpointPermission, SqlLogin,
-  SqlMaxDop, SqlMemory, SqlProtocol, SqlProtocolTcpIp, SqlRS, SqlReplication,
-  SqlRole, SqlScript, SqlScriptQuery, SqlSecureConnection, SqlServiceAccount,
-  SqlSetup, SqlTraceFlag, SqlWaitForAG, SqlWindowsFirewall
-  - Fixed `Test-TargetResource` to return `$false` (instead of throwing) when
-    the SQL Server instance is not reachable or an error occurs during
+  SqlDatabaseRole, SqlDatabaseUser, SqlEndpoint, SqlEndpointPermission,
+  SqlLogin, SqlMaxDop, SqlMemory, SqlProtocol, SqlProtocolTcpIp, SqlRS,
+  SqlReplication, SqlRole, SqlScript, SqlScriptQuery, SqlSecureConnection,
+  SqlServiceAccount, SqlSetup, SqlTraceFlag, SqlWaitForAG, SqlWindowsFirewall
+  - Fixed `Test-TargetResource` to return `$false` (instead of throwing)
+    when the SQL Server instance is not reachable or an error occurs during
     `Get-TargetResource`, enabling graceful handling and better support for
     `DependsOn` scenarios.
 

--- a/source/Classes/020.SqlAgentAlert.ps1
+++ b/source/Classes/020.SqlAgentAlert.ps1
@@ -155,7 +155,15 @@ class SqlAgentAlert : SqlResourceBase
     [System.Boolean] Test()
     {
         # Call base implementation to test current state
-        return ([ResourceBase] $this).Test()
+        try
+        {
+            return ([ResourceBase] $this).Test()
+        }
+        catch
+        {
+            Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_)
+            return $false
+        }
     }
 
     [void] Set()
@@ -179,10 +187,10 @@ class SqlAgentAlert : SqlResourceBase
 
         # Validate that both Severity and MessageId are not specified
         $assertMutuallyExclusiveParams = @{
-            BoundParameterList       = $properties
-            MutuallyExclusiveList1   = @('Severity')
-            MutuallyExclusiveList2   = @('MessageId')
-            IfEqualParameterList     = @{
+            BoundParameterList     = $properties
+            MutuallyExclusiveList1 = @('Severity')
+            MutuallyExclusiveList2 = @('MessageId')
+            IfEqualParameterList   = @{
                 Ensure = 'Present'
             }
         }

--- a/source/Classes/020.SqlAudit.ps1
+++ b/source/Classes/020.SqlAudit.ps1
@@ -207,7 +207,15 @@ class SqlAudit : SqlResourceBase
     [System.Boolean] Test()
     {
         # Call the base method to test all of the properties that should be enforced.
-        return ([ResourceBase] $this).Test()
+        try
+        {
+            return ([ResourceBase] $this).Test()
+        }
+        catch
+        {
+            Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_)
+            return $false
+        }
     }
 
     [void] Set()

--- a/source/Classes/020.SqlDatabase.ps1
+++ b/source/Classes/020.SqlDatabase.ps1
@@ -683,7 +683,15 @@ class SqlDatabase : SqlResourceBase
     [System.Boolean] Test()
     {
         # Call the base method to test all of the properties that should be enforced.
-        return ([ResourceBase] $this).Test()
+        try
+        {
+            return ([ResourceBase] $this).Test()
+        }
+        catch
+        {
+            Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_)
+            return $false
+        }
     }
 
     [void] Set()

--- a/source/Classes/020.SqlDatabasePermission.ps1
+++ b/source/Classes/020.SqlDatabasePermission.ps1
@@ -179,7 +179,15 @@ class SqlDatabasePermission : SqlResourceBase
     [System.Boolean] Test()
     {
         # Call the base method to test all of the properties that should be enforced.
-        return ([ResourceBase] $this).Test()
+        try
+        {
+            return ([ResourceBase] $this).Test()
+        }
+        catch
+        {
+            Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_)
+            return $false
+        }
     }
 
     [void] Set()

--- a/source/Classes/020.SqlPermission.ps1
+++ b/source/Classes/020.SqlPermission.ps1
@@ -178,15 +178,15 @@ class SqlPermission : SqlResourceBase
 
     [System.Boolean] Test()
     {
-            try
-            {
-                return ([ResourceBase] $this).Test()
-            }
-            catch
-            {
-                Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_)
-                return $false
-            }
+        try
+        {
+            return ([ResourceBase] $this).Test()
+        }
+        catch
+        {
+            Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_)
+            return $false
+        }
     }
 
     [void] Set()

--- a/source/Classes/020.SqlPermission.ps1
+++ b/source/Classes/020.SqlPermission.ps1
@@ -228,19 +228,7 @@ class SqlPermission : SqlResourceBase
             )
         )
 
-        $serverObject = $null
-        try
-        {
-            $serverObject = $this.GetServerObject()
-        }
-        catch
-        {
-            Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_.Exception.Message)
-            # Returning an empty hashtable will cause Test() to see all properties
-            # as being different from the desired state, which will result in
-            # Test() returning $false and triggering Set().
-            return @{}
-        }
+        $serverObject = $this.GetServerObject()
 
         $serverPermissionInfo = $serverObject |
             Get-SqlDscServerPermission -Name $this.Name -ErrorAction 'SilentlyContinue'

--- a/source/Classes/020.SqlRSSetup.ps1
+++ b/source/Classes/020.SqlRSSetup.ps1
@@ -243,7 +243,15 @@ class SqlRSSetup : ResourceBase
     [System.Boolean] Test()
     {
         # Call the base method to test all of the properties that should be enforced.
-        $baseTestResult = ([ResourceBase] $this).Test()
+        try
+        {
+            $baseTestResult = ([ResourceBase] $this).Test()
+        }
+        catch
+        {
+            Write-Verbose -Message ($this.localizedData.SQLInstanceNotReachable -f $_)
+            $baseTestResult = $false
+        }
 
         # If $baseTestResult -eq $true, then the InstanceName exists.
         # If $baseTestResult -eq $false, then the InstanceName does not exist.

--- a/source/DSCResources/DSC_SqlAG/DSC_SqlAG.psm1
+++ b/source/DSCResources/DSC_SqlAG/DSC_SqlAG.psm1
@@ -697,7 +697,18 @@ function Test-TargetResource
     # Assume this will pass. We will determine otherwise later
     $result = $true
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     <#
         If this is supposed to process only the active node, and this is not the

--- a/source/DSCResources/DSC_SqlAG/en-US/DSC_SqlAG.strings.psd1
+++ b/source/DSCResources/DSC_SqlAG/en-US/DSC_SqlAG.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetAvailabilityGroup = Get the current configuration for the availability group '{0}' on the instance '{1}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     RemoveAvailabilityGroup = Removing the availability group '{0}' on the instance '{1}'.
     HadrNotEnabled = Always On Availability Groups is not enabled.
     FailedRemoveAvailabilityGroup = Failed to remove the availability group '{0}' from the instance '{1}'.

--- a/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
+++ b/source/DSCResources/DSC_SqlAGDatabase/DSC_SqlAGDatabase.psm1
@@ -788,7 +788,18 @@ function Test-TargetResource
         AvailabilityGroupName = $AvailabilityGroupName
         BackupPath            = $BackupPath
     }
-    $currentConfiguration = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $currentConfiguration = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     <#
         If this is supposed to process only the active node, and this is not the

--- a/source/DSCResources/DSC_SqlAGDatabase/en-US/DSC_SqlAGDatabase.strings.psd1
+++ b/source/DSCResources/DSC_SqlAGDatabase/en-US/DSC_SqlAGDatabase.strings.psd1
@@ -4,6 +4,7 @@ ConvertFrom-StringData @'
     AddingDatabasesToAvailabilityGroup = Adding the following databases to the '{0}' availability group: {1}.
     AlterAvailabilityGroupDatabaseMembershipFailure = {0}.
     AvailabilityGroupDoesNotExist = The availability group '{0}' does not exist.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     DatabaseShouldBeMember = The following databases should be a member of the availability group '{0}': {1}.
     DatabaseShouldNotBeMember = The following databases should not be a member of the availability group '{0}': {1}.
     DatabasesNotFound = The following databases were not found in the instance: {0}.

--- a/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
+++ b/source/DSCResources/DSC_SqlAGListener/DSC_SqlAGListener.psm1
@@ -492,7 +492,17 @@ function Test-TargetResource
         $script:localizedData.TestingConfiguration -f $Name, $AvailabilityGroup, $InstanceName
     )
 
-    $availabilityGroupListenerState = Get-TargetResource @parameters
+    try
+    {
+        $availabilityGroupListenerState = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable -f $_
+        )
+        return $false
+    }
 
     [System.Boolean] $result = $false
 

--- a/source/DSCResources/DSC_SqlAGListener/en-US/DSC_SqlAGListener.strings.psd1
+++ b/source/DSCResources/DSC_SqlAGListener/en-US/DSC_SqlAGListener.strings.psd1
@@ -4,6 +4,7 @@ ConvertFrom-StringData @'
     AvailabilityGroupListenerIsNotPresent = The Availability Group listener '{0}' does not exist.
     AvailabilityGroupListenerNotFound = Trying to make a change to the listener '{0}' that does not exist in the availability group '{1}'.
     CreateAvailabilityGroupListener = Create Availability Group listener '{0}' for the Availability Group '{1}' on the instance '{2}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     SetAvailabilityGroupListenerPort = Availability Group listener port is set to '{0}'.
     SetAvailabilityGroupListenerDhcp = Availability Group listener is using DHCP with the subnet '{0}'.
     SetAvailabilityGroupListenerDhcpDefaultSubnet = Availability Group listener is using DHCP with the server default subnet.

--- a/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
+++ b/source/DSCResources/DSC_SqlAGReplica/DSC_SqlAGReplica.psm1
@@ -695,7 +695,18 @@ function Test-TargetResource
     # Assume this will pass. We will determine otherwise later
     $result = $true
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     <#
         If this is supposed to process only the active node, and this is not the

--- a/source/DSCResources/DSC_SqlAGReplica/en-US/DSC_SqlAGReplica.strings.psd1
+++ b/source/DSCResources/DSC_SqlAGReplica/en-US/DSC_SqlAGReplica.strings.psd1
@@ -2,6 +2,7 @@ ConvertFrom-StringData @'
     GetAvailabilityGroup = Get the current configuration for the availability group replica '{0}' in the availability group '{1}' on the instance '{2}'.
     HadrNotEnabled = Always On Availability Groups is not enabled.
     FailedRemoveAvailabilityGroupReplica = Failed to remove the availability group replica '{0}' from the availability group '{1}' on the instance '{2}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     DatabaseMirroringEndpointNotFound = No database mirroring endpoint was found on '{0}'.
     ReplicaNotFound = Unable to find the availability group replica '{0}' in the availability group '{1}' on the instance '{2}'.
     FailedCreateAvailabilityGroupReplica = Failed to creating the availability group replica '{0}' for the availability group '{1}' on the instance '{2}'.

--- a/source/DSCResources/DSC_SqlAgentFailsafe/DSC_SqlAgentFailsafe.psm1
+++ b/source/DSCResources/DSC_SqlAgentFailsafe/DSC_SqlAgentFailsafe.psm1
@@ -267,7 +267,18 @@ function Test-TargetResource
 
     $returnValue = $false
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     Write-Verbose -Message (
         $script:localizedData.TestingConfiguration

--- a/source/DSCResources/DSC_SqlAgentFailsafe/en-US/DSC_SqlAgentFailsafe.strings.psd1
+++ b/source/DSCResources/DSC_SqlAgentFailsafe/en-US/DSC_SqlAgentFailsafe.strings.psd1
@@ -9,5 +9,6 @@ ConvertFrom-StringData @'
     UpdateFailsafeOperatorError = Unable to update Sql Agent Failsafe Operator '{0}' on {1}\\{2}.
     RemoveFailsafeOperator = Removing Sql Agent Failsafe Operator.
     ConnectServerFailed = Unable to connect to {0}\\{1}.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     TestingConfiguration = Determines if the SQL Agent Failsafe Operator is in the desired state.
 '@

--- a/source/DSCResources/DSC_SqlAgentOperator/DSC_SqlAgentOperator.psm1
+++ b/source/DSCResources/DSC_SqlAgentOperator/DSC_SqlAgentOperator.psm1
@@ -299,7 +299,18 @@ function Test-TargetResource
         InstanceName = $InstanceName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $isOperatorInDesiredState = $true
 

--- a/source/DSCResources/DSC_SqlAgentOperator/en-US/DSC_SqlAgentOperator.strings.psd1
+++ b/source/DSCResources/DSC_SqlAgentOperator/en-US/DSC_SqlAgentOperator.strings.psd1
@@ -15,4 +15,5 @@ ConvertFrom-StringData @'
     SqlAgentOperatorDoesNotExistButShould  = SQL Agent Operator does not exist but Ensure is set to Present. The SQL Agent Operator '{0}' should be created.
     SqlAgentOperatorExistsButEmailWrong  = SQL Agent Operator '{0}' exists but has the wrong email address. Email address is currently '{1}' and should be updated to '{2}'.
     ConnectServerFailed = Unable to connect to {0}\\{1}.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
 '@

--- a/source/DSCResources/DSC_SqlAlias/DSC_SqlAlias.psm1
+++ b/source/DSCResources/DSC_SqlAlias/DSC_SqlAlias.psm1
@@ -309,7 +309,18 @@ function Test-TargetResource
         Name = $PSBoundParameters.Name
     }
 
-    $currentValues = Get-TargetResource @parameters
+    try
+    {
+        $currentValues = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if ($Ensure -eq $currentValues.Ensure)
     {
@@ -364,18 +375,6 @@ function Test-TargetResource
         Write-Verbose -Message (
             $script:localizedData.NotInDesiredState -f $Name
         )
-    }
-    try
-    {
-        $currentValues = Get-TargetResource @parameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
     }
     return $result
 }

--- a/source/DSCResources/DSC_SqlAlias/DSC_SqlAlias.psm1
+++ b/source/DSCResources/DSC_SqlAlias/DSC_SqlAlias.psm1
@@ -365,6 +365,17 @@ function Test-TargetResource
             $script:localizedData.NotInDesiredState -f $Name
         )
     }
-
+    try
+    {
+        $currentValues = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
     return $result
 }

--- a/source/DSCResources/DSC_SqlAlias/en-US/DSC_SqlAlias.strings.psd1
+++ b/source/DSCResources/DSC_SqlAlias/en-US/DSC_SqlAlias.strings.psd1
@@ -6,7 +6,7 @@ ConvertFrom-StringData @'
     RemoveClientAlias64Bit = Removing the SQL Server Client Alias '{0}' (64-bit).
     RemoveClientAlias32Bit = Removing the SQL Server Client Alias '{0}' (32-bit).
     TestingConfiguration = Determines if the SQL Server Client Alias is in desired state.
-    ClientAliasMissing = The SQL Server Client Alias '{0}' does not exist.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     ClientAliasPresent = The SQL Server Client Alias '{0}' exist, verifying values.
     InDesiredState = The SQL Server Client Alias '{0}' is in desired state.
     NotInDesiredState = The SQL Server Client Alias '{0}' is not in desired state.

--- a/source/DSCResources/DSC_SqlAlias/en-US/DSC_SqlAlias.strings.psd1
+++ b/source/DSCResources/DSC_SqlAlias/en-US/DSC_SqlAlias.strings.psd1
@@ -7,6 +7,7 @@ ConvertFrom-StringData @'
     RemoveClientAlias32Bit = Removing the SQL Server Client Alias '{0}' (32-bit).
     TestingConfiguration = Determines if the SQL Server Client Alias is in desired state.
     SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
+    ClientAliasMissing = The SQL Server Client Alias '{0}' is missing.
     ClientAliasPresent = The SQL Server Client Alias '{0}' exist, verifying values.
     InDesiredState = The SQL Server Client Alias '{0}' is in desired state.
     NotInDesiredState = The SQL Server Client Alias '{0}' is not in desired state.

--- a/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
+++ b/source/DSCResources/DSC_SqlAlwaysOnService/DSC_SqlAlwaysOnService.psm1
@@ -241,7 +241,18 @@ function Test-TargetResource
         InstanceName = $InstanceName
     }
 
-    $state = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $state = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $isInDesiredState = $true
 

--- a/source/DSCResources/DSC_SqlAlwaysOnService/en-US/DSC_SqlAlwaysOnService.strings.psd1
+++ b/source/DSCResources/DSC_SqlAlwaysOnService/en-US/DSC_SqlAlwaysOnService.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetAlwaysOnServiceState = Always On Availability Groups is {0} on the instance '{1}\\{2}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     DisableAlwaysOnAvailabilityGroup = Disabling Always On Availability Groups for the instance '{0}\\{1}'.
     EnableAlwaysOnAvailabilityGroup = Enabling Always On Availability Groups for the instance '{0}\\{1}'.
     RestartingService = Always On Availability Groups has been {0} on the instance '{1}\\{2}'. Restarting the service.

--- a/source/DSCResources/DSC_SqlConfiguration/DSC_SqlConfiguration.psm1
+++ b/source/DSCResources/DSC_SqlConfiguration/DSC_SqlConfiguration.psm1
@@ -250,25 +250,38 @@ function Test-TargetResource
         $RestartTimeout = 120
     )
 
-    # Get the current value of the configuration option.
-    $getTargetResourceResult = Get-TargetResource @PSBoundParameters
+    $result = $false
 
-    if ($getTargetResourceResult.OptionValue -eq $OptionValue)
+    try
     {
-        Write-Verbose -Message (
-            $script:localizedData.InDesiredState `
-                -f $OptionName
-        )
+        # Get the current value of the configuration option.
+        $getTargetResourceResult = Get-TargetResource @PSBoundParameters
 
-        $result = $true
+        if ($getTargetResourceResult.OptionValue -eq $OptionValue)
+        {
+            Write-Verbose -Message (
+                $script:localizedData.InDesiredState `
+                    -f $OptionName
+            )
+
+            $result = $true
+        }
+        else
+        {
+            Write-Verbose -Message (
+                $script:localizedData.NotInDesiredState `
+                    -f $OptionName, $OptionValue, $getTargetResourceResult.OptionValue
+            )
+
+            $result = $false
+        }
     }
-    else
+    catch
     {
         Write-Verbose -Message (
-            $script:localizedData.NotInDesiredState `
-                -f $OptionName, $OptionValue, $getTargetResourceResult.OptionValue
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
         )
-
         $result = $false
     }
 

--- a/source/DSCResources/DSC_SqlConfiguration/en-US/DSC_SqlConfiguration.strings.psd1
+++ b/source/DSCResources/DSC_SqlConfiguration/en-US/DSC_SqlConfiguration.strings.psd1
@@ -9,4 +9,5 @@ ConvertFrom-StringData @'
     NotInDesiredState = Configuration option '{0}' is not in desired state. Expected '{1}', but was '{2}'.
     InDesiredState = Configuration option '{0}' is in desired state.
     NoRestartNeeded = The option was changed without the need to restart the SQL Server instance.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
 '@

--- a/source/DSCResources/DSC_SqlDatabaseDefaultLocation/DSC_SqlDatabaseDefaultLocation.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseDefaultLocation/DSC_SqlDatabaseDefaultLocation.psm1
@@ -296,7 +296,18 @@ function Test-TargetResource
 
     $isDefaultPathInDesiredState = $true
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
     <#
         If this is supposed to process only the active node, and this is not the
         active node, don't bother evaluating the test.

--- a/source/DSCResources/DSC_SqlDatabaseDefaultLocation/en-US/DSC_SqlDatabaseDefaultLocation.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseDefaultLocation/en-US/DSC_SqlDatabaseDefaultLocation.strings.psd1
@@ -2,6 +2,7 @@
 
 ConvertFrom-StringData @'
     GetCurrentPath = Getting default path for '{0}' for instance '{1}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     SettingDefaultPath = Setting the default path for the '{0}' files.
     DefaultPathChanged = The default path for '{0}' has been changed from '{1}' to '{2}'.
     RestartSqlServer = Restarting Sql Server: {0}\\{1}.

--- a/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/DSC_SqlDatabaseMail.psm1
@@ -751,7 +751,18 @@ function Test-TargetResource
         $script:localizedData.TestingConfiguration
     )
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $returnValue = $true
 

--- a/source/DSCResources/DSC_SqlDatabaseMail/en-US/DSC_SqlDatabaseMail.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseMail/en-US/DSC_SqlDatabaseMail.strings.psd1
@@ -31,4 +31,5 @@ ConvertFrom-StringData @'
     RemovingSqlAgentConfiguration = Configure the SQL Agent to not use Database Mail (changing it back to SQL Agent Mail).
     RemovingMailProfile = Removing the public default profile '{0}'.
     RemovingMailAccount = Removing the mail account '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
 '@

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -716,7 +716,18 @@ function Compare-TargetResourceState
         }
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $compareTargetResourceStateParameters = @{
         CurrentValues            = $getTargetResourceResult

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/DSC_SqlDatabaseObjectPermission.psm1
@@ -580,7 +580,17 @@ function Test-TargetResource
         )
     )
 
-    $propertyState = Compare-TargetResourceState @PSBoundParameters
+    try
+    {
+        $propertyState = Compare-TargetResourceState @PSBoundParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable -f $_
+        )
+        return $false
+    }
 
     if ($false -in $propertyState.InDesiredState)
     {
@@ -716,18 +726,7 @@ function Compare-TargetResourceState
         }
     }
 
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
     $compareTargetResourceStateParameters = @{
         CurrentValues            = $getTargetResourceResult

--- a/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseObjectPermission/en-US/DSC_SqlDatabaseObjectPermission.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetObjectPermission = Getting the current state of the permissions for the database object '{0}' of type '{1}' in the database '{2}' for the instance '{3}' on the server '{4}'. (SDOP0001)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     TestDesiredState = Determining the current state of the permissions for the database object '{0}' of type '{1}' in the database '{2}' for the instance '{3}' on the server '{4}'. (SDOP0002)
     NotInDesiredState = The permissions for the database object '{0}' is not in desired state. (SDOP0003)
     InDesiredState = The permissions for the database object '{0}' is in desired state. (SDOP0004)

--- a/source/DSCResources/DSC_SqlDatabaseRole/DSC_SqlDatabaseRole.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseRole/DSC_SqlDatabaseRole.psm1
@@ -471,7 +471,18 @@ function Test-TargetResource
         MembersToExclude = $PSBoundParameters.MembersToExclude
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $isDatabaseRoleInDesiredState = $true
 

--- a/source/DSCResources/DSC_SqlDatabaseRole/en-US/DSC_SqlDatabaseRole.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseRole/en-US/DSC_SqlDatabaseRole.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     AddDatabaseRoleMember = Adding member '{0}' to role '{1}' in database '{2}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     AddDatabaseRoleMemberError = Failed to add member '{0}' to role '{1}' in database '{2}'.
     CreateDatabaseRole = Creating role '{0}' in database '{1}'.
     CreateDatabaseRoleError = Failed to create role '{0}' in database '{1}'.

--- a/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
@@ -535,8 +535,7 @@ function Test-TargetResource
     catch
     {
         Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
+            $script:localizedData.SQLInstanceNotReachable -f $_
         )
         return $false
     }

--- a/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
@@ -217,7 +217,18 @@ function Set-TargetResource
     }
 
     # Get-TargetResource will also help us to test if the database exist.
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     # Default parameters for the cmdlet Invoke-SqlDscQuery used throughout.
     $invokeSqlDscQueryParameters = @{

--- a/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
+++ b/source/DSCResources/DSC_SqlDatabaseUser/DSC_SqlDatabaseUser.psm1
@@ -217,18 +217,7 @@ function Set-TargetResource
     }
 
     # Get-TargetResource will also help us to test if the database exist.
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
     # Default parameters for the cmdlet Invoke-SqlDscQuery used throughout.
     $invokeSqlDscQueryParameters = @{
@@ -539,7 +528,18 @@ function Test-TargetResource
         Name         = $Name
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if ( $false -eq $getTargetResourceResult.DatabaseIsUpdateable )
     {

--- a/source/DSCResources/DSC_SqlDatabaseUser/en-US/DSC_SqlDatabaseUser.strings.psd1
+++ b/source/DSCResources/DSC_SqlDatabaseUser/en-US/DSC_SqlDatabaseUser.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     RetrievingDatabaseUser = Retrieving information about the database user '{0}' from the database '{1}'. (SDU0001)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     DatabaseNotFound = The database '{0}' does not exist. (SDU0002)
     EvaluateDatabaseUser = Determining if the database user '{0}' in the database '{1}' is in the desired state. (SDU0003)
     DatabaseUserExist = The database user '{0}' exist in the database '{1}'. (SDU0004)

--- a/source/DSCResources/DSC_SqlEndpoint/DSC_SqlEndpoint.psm1
+++ b/source/DSCResources/DSC_SqlEndpoint/DSC_SqlEndpoint.psm1
@@ -222,18 +222,7 @@ function Set-TargetResource
         InstanceName = $InstanceName
     }
 
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
     $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 

--- a/source/DSCResources/DSC_SqlEndpoint/DSC_SqlEndpoint.psm1
+++ b/source/DSCResources/DSC_SqlEndpoint/DSC_SqlEndpoint.psm1
@@ -222,7 +222,18 @@ function Set-TargetResource
         InstanceName = $InstanceName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $sqlServerObject = Connect-SQL -ServerName $ServerName -InstanceName $InstanceName -ErrorAction 'Stop'
 
@@ -549,7 +560,18 @@ function Test-TargetResource
         InstanceName = $InstanceName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if ($getTargetResourceResult.Ensure -eq $Ensure)
     {

--- a/source/DSCResources/DSC_SqlEndpoint/en-US/DSC_SqlEndpoint.strings.psd1
+++ b/source/DSCResources/DSC_SqlEndpoint/en-US/DSC_SqlEndpoint.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetEndpoint = Getting the current values of the endpoint with the name '{0}' for the instance '{1}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     EndpointFoundButWrongType = The endpoint '{0}' is of type '{1}', but expected it to be of type '{2}'.
     ConnectedToInstance = Connect to the instance '{0}\\{1}'.
     NotConnectedToInstance = Was unable to connect to the instance '{0}\\{1}'.

--- a/source/DSCResources/DSC_SqlEndpointPermission/DSC_SqlEndpointPermission.psm1
+++ b/source/DSCResources/DSC_SqlEndpointPermission/DSC_SqlEndpointPermission.psm1
@@ -162,7 +162,18 @@ function Set-TargetResource
         Principal    = [System.String] $Principal
     }
 
-    $getTargetResourceResult = Get-TargetResource @parameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
     if ($getTargetResourceResult.Ensure -ne $Ensure)
     {
         Write-Verbose -Message (
@@ -278,7 +289,18 @@ function Test-TargetResource
         $script:localizedData.TestingConfiguration -f $Name, $InstanceName
     )
 
-    $getTargetResourceResult = Get-TargetResource @parameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $isInDesiredState = $getTargetResourceResult.Ensure -eq $Ensure
 

--- a/source/DSCResources/DSC_SqlEndpointPermission/DSC_SqlEndpointPermission.psm1
+++ b/source/DSCResources/DSC_SqlEndpointPermission/DSC_SqlEndpointPermission.psm1
@@ -162,18 +162,8 @@ function Set-TargetResource
         Principal    = [System.String] $Principal
     }
 
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource @parameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource @parameters
+
     if ($getTargetResourceResult.Ensure -ne $Ensure)
     {
         Write-Verbose -Message (

--- a/source/DSCResources/DSC_SqlEndpointPermission/en-US/DSC_SqlEndpointPermission.strings.psd1
+++ b/source/DSCResources/DSC_SqlEndpointPermission/en-US/DSC_SqlEndpointPermission.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetEndpointPermission = Enumerating the current permissions for the endpoint with the name '{0}' for the instance '{1}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     EndpointNotFound = The endpoint with the name '{0}' does not exist.
     UnexpectedErrorFromGet = Got unexpected result from Get-TargetResource. No change is made.
     SetEndpointPermission = Changing the permissions of the endpoint with the name '{0}' for the instance '{1}'.

--- a/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
+++ b/source/DSCResources/DSC_SqlLogin/DSC_SqlLogin.psm1
@@ -212,7 +212,7 @@ function Set-TargetResource
                     # Update SQL login data if either `PasswordPolicyEnforced or `PasswordExpirationEnabled` is specified and not in desired state.
                     # Avoids executing `Update-SQLServerLogin` twice if both are not in desired state.
                     if ( ( $PSBoundParameters.ContainsKey('LoginPasswordPolicyEnforced') -and $login.PasswordPolicyEnforced -ne $LoginPasswordPolicyEnforced ) -or
-                         ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') -and $login.PasswordExpirationEnabled -ne $LoginPasswordExpirationEnabled ) )
+                        ( $PSBoundParameters.ContainsKey('LoginPasswordExpirationEnabled') -and $login.PasswordExpirationEnabled -ne $LoginPasswordExpirationEnabled ) )
                     {
                         <#
                             PasswordExpirationEnabled can only be set to $true if PasswordPolicyEnforced
@@ -272,7 +272,7 @@ function Set-TargetResource
                 }
 
                 if ( ( $PSBoundParameters.ContainsKey('DefaultDatabase') -and ($login.DefaultDatabase -ne $DefaultDatabase) ) -or
-                     ( $PSBoundParameters.ContainsKey('Language') -and $login.Language -ne $Language ) )
+                    ( $PSBoundParameters.ContainsKey('Language') -and $login.Language -ne $Language ) )
                 {
                     if ( $PSBoundParameters.ContainsKey('DefaultDatabase') )
                     {
@@ -356,7 +356,7 @@ function Set-TargetResource
                 }
 
                 if ( ( $PSBoundParameters.ContainsKey('DefaultDatabase') -and ($login.DefaultDatabase -ne $DefaultDatabase) ) -or
-                     ( $PSBoundParameters.ContainsKey('Language') -and $login.Language -ne $Language ) )
+                    ( $PSBoundParameters.ContainsKey('Language') -and $login.Language -ne $Language ) )
                 {
                     # Set the default database if specified
                     if ( $PSBoundParameters.ContainsKey('DefaultDatabase') )
@@ -507,7 +507,18 @@ function Test-TargetResource
         InstanceName = $InstanceName
     }
 
-    $loginInfo = Get-TargetResource @getParams
+    try
+    {
+        $loginInfo = Get-TargetResource @getParams
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if ( $Ensure -ne $loginInfo.Ensure )
     {

--- a/source/DSCResources/DSC_SqlLogin/en-US/DSC_SqlLogin.strings.psd1
+++ b/source/DSCResources/DSC_SqlLogin/en-US/DSC_SqlLogin.strings.psd1
@@ -2,6 +2,7 @@
 
 ConvertFrom-StringData @'
     GetLogin = Getting the login '{0}' from the instance '{1}\\{2}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     LoginCurrentState = The login '{0}' is {1} at the instance '{2}\\{3}'.
     SetPasswordExpirationEnabled = Setting password expiration enabled to '{0}' for the login '{1}' on the instance '{2}\\{3}'.
     SetPasswordPolicyEnforced = Setting password policy enforced to '{0}' for the login '{1}' on the instance '{2}\\{3}'.

--- a/source/DSCResources/DSC_SqlMaxDop/DSC_SqlMaxDop.psm1
+++ b/source/DSCResources/DSC_SqlMaxDop/DSC_SqlMaxDop.psm1
@@ -261,7 +261,18 @@ function Test-TargetResource
         ServerName   = $ServerName
     }
 
-    $getTargetResourceResult = Get-TargetResource @parameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $getMaxDop = $getTargetResourceResult.MaxDop
     $isMaxDopInDesiredState = $true

--- a/source/DSCResources/DSC_SqlMaxDop/en-US/DSC_SqlMaxDop.strings.psd1
+++ b/source/DSCResources/DSC_SqlMaxDop/en-US/DSC_SqlMaxDop.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetConfiguration = Getting the max degree of parallelism server configuration option for instance '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     SetConfiguration = Setting the max degree of parallelism server configuration option for instance '{0}'.
     DynamicMaxDop = The dynamically calculated value for max degree of parallelism is '{0}'.
     MaxDopParamMustBeNull = The parameter max degree of parallelism must be set to $null or not assigned if the parameter DynamicAlloc is set to $true.

--- a/source/DSCResources/DSC_SqlMemory/DSC_SqlMemory.psm1
+++ b/source/DSCResources/DSC_SqlMemory/DSC_SqlMemory.psm1
@@ -371,7 +371,18 @@ function Test-TargetResource
         ServerName   = $ServerName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $currentMinMemory = $getTargetResourceResult.MinMemory
     $currentMaxMemory = $getTargetResourceResult.MaxMemory

--- a/source/DSCResources/DSC_SqlMemory/en-US/DSC_SqlMemory.strings.psd1
+++ b/source/DSCResources/DSC_SqlMemory/en-US/DSC_SqlMemory.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetMemoryValues = Getting the current values for minimum and maximum SQL server memory for instance '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     SetNewValues = Setting the minimum and maximum memory that will be used by the instance '{0}'.
     MaxMemoryParamMustBeNull = The parameter MaxMemory must be null when the parameter DynamicAlloc is set to true or MaxMemoryPercent has a value.
     MaxMemoryPercentParamMustBeNull = The parameter MaxMemoryPercent must be null when the parameter DynamicAlloc is set to true or MaxMemory has a value.

--- a/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
+++ b/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
@@ -463,8 +463,17 @@ function Test-TargetResource
         $script:localizedData.TestDesiredState -f $protocolNameProperties.DisplayName, $InstanceName, $ServerName
     )
 
-    $propertyState = Compare-TargetResourceState @PSBoundParameters
-
+    try
+    {
+        $propertyState = Compare-TargetResourceState @PSBoundParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable -f $_
+        )
+        return $false
+    }
 
     if ($false -in $propertyState.InDesiredState)
     {
@@ -635,18 +644,7 @@ function Compare-TargetResourceState
         }
     }
 
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
     $propertiesToEvaluate = @(
         'Enabled'

--- a/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
+++ b/source/DSCResources/DSC_SqlProtocol/DSC_SqlProtocol.psm1
@@ -635,7 +635,18 @@ function Compare-TargetResourceState
         }
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $propertiesToEvaluate = @(
         'Enabled'

--- a/source/DSCResources/DSC_SqlProtocol/en-US/DSC_SqlProtocol.strings.psd1
+++ b/source/DSCResources/DSC_SqlProtocol/en-US/DSC_SqlProtocol.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetCurrentState = Getting the current state of the protocol '{0}' for the instance '{1}' on the server '{2}'. (SSP0001)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     SetDesiredState = Setting the desired state for the protocol '{0}' on the instance '{1}' on the server '{2}'. (SSP0002)
     ProtocolIsInDesiredState = The protocol '{0}' on the instance '{1}' is already in desired state. (SSP0002)
     ProtocolHasBeenEnabled = The protocol '{0}' has been enabled on the SQL Server instance '{1}'. (SSP0003)

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
@@ -538,8 +538,17 @@ function Test-TargetResource
         $script:localizedData.TestDesiredState -f $IpAddressGroup, $InstanceName, $ServerName
     )
 
-    $propertyState = Compare-TargetResourceState @PSBoundParameters
-
+    try
+    {
+        $propertyState = Compare-TargetResourceState @PSBoundParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable -f $_
+        )
+        return $false
+    }
 
     if ($false -in $propertyState.InDesiredState)
     {
@@ -691,18 +700,7 @@ function Compare-TargetResourceState
         }
     }
 
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
     # Get individual IP address group properties to evaluate.
     switch ($IpAddressGroup)

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/DSC_SqlProtocolTcpIp.psm1
@@ -691,7 +691,18 @@ function Compare-TargetResourceState
         }
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     # Get individual IP address group properties to evaluate.
     switch ($IpAddressGroup)

--- a/source/DSCResources/DSC_SqlProtocolTcpIp/en-US/DSC_SqlProtocolTcpIp.strings.psd1
+++ b/source/DSCResources/DSC_SqlProtocolTcpIp/en-US/DSC_SqlProtocolTcpIp.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetCurrentState = Getting the current state of the TCP/IP address group '{0}' for the instance '{1}' on the server '{2}'. (SSPTI0001)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     GetMissingIpAddressGroup = The specified IP address group '{0}' does not not exist, cannot determine current state. (SSPTI0002)
     TestDesiredState = Determining the current state of the TCP/IP address group '{0}' for the instance '{1}' on the server '{2}'. (SSPTI0003)
     NotInDesiredState = The TCP/IP address group '{0}' for the instance '{1}' is not in desired state. (SSPTI0004)

--- a/source/DSCResources/DSC_SqlRS/DSC_SqlRS.psm1
+++ b/source/DSCResources/DSC_SqlRS/DSC_SqlRS.psm1
@@ -770,7 +770,18 @@ function Test-TargetResource
         $getTargetResourceParameters.Encrypt = $Encrypt
     }
 
-    $currentConfig = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $currentConfig = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if (-not $currentConfig.IsInitialized)
     {

--- a/source/DSCResources/DSC_SqlRS/en-US/DSC_SqlRS.strings.psd1
+++ b/source/DSCResources/DSC_SqlRS/en-US/DSC_SqlRS.strings.psd1
@@ -4,6 +4,7 @@ ConvertFrom-StringData @'
     TestFailedAfterSet = Test-TargetResource function returned false when Set-TargetResource function verified the desired state. This indicates that the Set-TargetResource did not correctly set set the desired state, or that the function Test-TargetResource does not correctly evaluate the desired state.
     ReportingServicesNotFound = SQL Reporting Services instance '{0}' does not exist.
     GetConfiguration = Get the current reporting services configuration for the instance '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     RestartToFinishInitialization = Restarting Reporting Services to finish initialization.
     WaitingForServiceReady = Waiting {0} seconds for Reporting Services to be fully ready after restart. (DSC_SQLRS0001)
     ServiceNameIsNullOrEmpty = The Configuration.ServiceName property is null or empty for SQL Server Reporting Services instance '{0}'. This property is required to determine the service name for SQL Server version 14 and higher. (DSC_SQLRS0002)

--- a/source/DSCResources/DSC_SqlReplication/DSC_SqlReplication.psm1
+++ b/source/DSCResources/DSC_SqlReplication/DSC_SqlReplication.psm1
@@ -399,7 +399,18 @@ function Test-TargetResource
     )
 
     $result = $false
-    $state = Get-TargetResource @PSBoundParameters
+    try
+    {
+        $state = Get-TargetResource @PSBoundParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if ($Ensure -eq 'Absent' -and $state.Ensure -eq 'Absent')
     {

--- a/source/DSCResources/DSC_SqlReplication/en-US/DSC_SqlReplication.strings.psd1
+++ b/source/DSCResources/DSC_SqlReplication/en-US/DSC_SqlReplication.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetCurrentState = Get the current state of the server replication configuration for the instance '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     DistributorMode = The distributor mode is currently '{0}' for the instance '{1}'.
     NoDistributorMode = There are currently no distributor mode set for the instance '{0}'.
     NoRemoteDistributor = The parameter RemoteDistributor cannot be empty when DistributorMode is set to 'Remote'.

--- a/source/DSCResources/DSC_SqlRole/DSC_SqlRole.psm1
+++ b/source/DSCResources/DSC_SqlRole/DSC_SqlRole.psm1
@@ -397,7 +397,18 @@ function Test-TargetResource
         ServerRoleName = $ServerRoleName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
     $isServerRoleInDesiredState = $true
 
     switch ($Ensure)

--- a/source/DSCResources/DSC_SqlRole/en-US/DSC_SqlRole.strings.psd1
+++ b/source/DSCResources/DSC_SqlRole/en-US/DSC_SqlRole.strings.psd1
@@ -2,6 +2,7 @@
 
 ConvertFrom-StringData @'
     GetProperties = Getting properties of the SQL Server role '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     SetProperties = Setting properties of the SQL Server role '{0}'.
     TestProperties = Testing properties of the SQL Server role '{0}'.
     EnumMemberNamesServerRoleGetError = Failed to enumerate members of the server role named '{2}' on '{0}\\{1}'.

--- a/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
+++ b/source/DSCResources/DSC_SqlScript/DSC_SqlScript.psm1
@@ -469,9 +469,9 @@ function Test-TargetResource
 
         $result = Invoke-SqlScript @invokeParameters
     }
-    catch [Microsoft.SqlServer.Management.PowerShell.SqlPowerShellSqlExecutionException]
+    catch
     {
-        Write-Verbose $_
+        Write-Verbose -Message ($script:localizedData.SQLInstanceNotReachable -f $_)
         return $false
     }
 

--- a/source/DSCResources/DSC_SqlScript/en-US/DSC_SqlScript.strings.psd1
+++ b/source/DSCResources/DSC_SqlScript/en-US/DSC_SqlScript.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     ExecutingGetScript = Executing the Get script from the file path '{0}' on the instance '{1}' on the server '{2}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     ExecutingSetScript = Executing the Set script from the file path '{0}' on the instance '{1}' on the server '{2}'.
     ExecutingTestScript = Executing the Test script from the file path '{0}' on the instance '{1}' on the server '{2}'.
     TestingConfiguration = Determines if the configuration in the Set script is in desired state.

--- a/source/DSCResources/DSC_SqlScriptQuery/DSC_SqlScriptQuery.psm1
+++ b/source/DSCResources/DSC_SqlScriptQuery/DSC_SqlScriptQuery.psm1
@@ -447,9 +447,12 @@ function Test-TargetResource
 
         $result = Invoke-SqlScript @invokeParameters
     }
-    catch [Microsoft.SqlServer.Management.PowerShell.SqlPowerShellSqlExecutionException]
+    catch
     {
-        Write-Verbose $_
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
         return $false
     }
 

--- a/source/DSCResources/DSC_SqlScriptQuery/en-US/DSC_SqlScriptQuery.strings.psd1
+++ b/source/DSCResources/DSC_SqlScriptQuery/en-US/DSC_SqlScriptQuery.strings.psd1
@@ -5,4 +5,5 @@ ConvertFrom-StringData @'
     TestingConfiguration = Determines if the configuration in the Set query is in desired state.
     InDesiredState = The configuration is in desired state.
     NotInDesiredState = The configuration is not in desired state.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
 '@

--- a/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
+++ b/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
@@ -401,8 +401,7 @@ function Test-TargetResource
     catch
     {
         Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
+            $script:localizedData.SQLInstanceNotReachable -f $_
         )
         return $false
     }

--- a/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
+++ b/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
@@ -391,8 +391,7 @@ function Test-TargetResource
     }
 
     Write-Verbose -Message (
-        $script:localizedData.TestingConfiguration `
-            -f $InstanceName
+        $script:localizedData.TestingConfiguration -f $InstanceName
     )
 
     try

--- a/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
+++ b/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
@@ -262,18 +262,7 @@ function Set-TargetResource
         ServiceAccount  = $ServiceAccount
     }
 
-    try
-    {
-        $encryptionState = Get-TargetResource @parameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $encryptionState = Get-TargetResource @parameters
 
     if ($Ensure -eq 'Present')
     {
@@ -406,7 +395,18 @@ function Test-TargetResource
             -f $InstanceName
     )
 
-    $encryptionState = Get-TargetResource @parameters
+    try
+    {
+        $encryptionState = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     return $Ensure -eq $encryptionState.Ensure
 }

--- a/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
+++ b/source/DSCResources/DSC_SqlSecureConnection/DSC_SqlSecureConnection.psm1
@@ -262,7 +262,18 @@ function Set-TargetResource
         ServiceAccount  = $ServiceAccount
     }
 
-    $encryptionState = Get-TargetResource @parameters
+    try
+    {
+        $encryptionState = Get-TargetResource @parameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if ($Ensure -eq 'Present')
     {

--- a/source/DSCResources/DSC_SqlSecureConnection/en-US/DSC_SqlSecureConnection.strings.psd1
+++ b/source/DSCResources/DSC_SqlSecureConnection/en-US/DSC_SqlSecureConnection.strings.psd1
@@ -4,6 +4,7 @@
 
 ConvertFrom-StringData @'
     GetEncryptionSettings = Getting encryption settings for instance '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     CertificateSettings = Certificate permissions are {0}.
     EncryptedSettings = Found thumbprint of '{0}', with Force Encryption set to '{1}'.
     SetEncryptionSetting = Securing instance '{0}' with Thumbprint: '{1}' and Force Encryption: '{2}'.

--- a/source/DSCResources/DSC_SqlServiceAccount/DSC_SqlServiceAccount.psm1
+++ b/source/DSCResources/DSC_SqlServiceAccount/DSC_SqlServiceAccount.psm1
@@ -170,7 +170,18 @@ function Test-TargetResource
     }
 
     # Get the current state
-    $currentState = Get-TargetResource -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType -ServiceAccount $ServiceAccount -VersionNumber $VersionNumber
+    try
+    {
+        $currentState = Get-TargetResource -ServerName $ServerName -InstanceName $InstanceName -ServiceType $ServiceType -ServiceAccount $ServiceAccount -VersionNumber $VersionNumber
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
     Write-Verbose -Message ($script:localizedData.CurrentServiceAccount -f $currentState.ServiceAccountName, $ServerName, $InstanceName)
 
     return ($currentState.ServiceAccountName -ieq $ServiceAccount.UserName)

--- a/source/DSCResources/DSC_SqlServiceAccount/en-US/DSC_SqlServiceAccount.strings.psd1
+++ b/source/DSCResources/DSC_SqlServiceAccount/en-US/DSC_SqlServiceAccount.strings.psd1
@@ -12,4 +12,5 @@ ConvertFrom-StringData @'
     NotInstanceAware = Service type '{0}' is not instance aware.
     MissingParameter = Missing parameter detected for '{0}'!
     GetConfiguration = Get the current service account for the service '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
 '@

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -2317,8 +2317,7 @@ function Test-TargetResource
     catch
     {
         Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
+            $script:localizedData.SQLInstanceNotReachable -f $_
         )
         return $false
     }

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -1030,18 +1030,7 @@ function Set-TargetResource
         $getTargetResourceParameters.ServerName = $ServerName
     }
 
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
     $InstanceName = $InstanceName.ToUpper()
 

--- a/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
+++ b/source/DSCResources/DSC_SqlSetup/DSC_SqlSetup.psm1
@@ -1030,7 +1030,18 @@ function Set-TargetResource
         $getTargetResourceParameters.ServerName = $ServerName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $InstanceName = $InstanceName.ToUpper()
 
@@ -2310,7 +2321,18 @@ function Test-TargetResource
         $getTargetResourceParameters.ServerName = $ServerName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     if ($null -eq $getTargetResourceResult.Features -or $getTargetResourceResult.Features -eq '')
     {

--- a/source/DSCResources/DSC_SqlSetup/en-US/DSC_SqlSetup.strings.psd1
+++ b/source/DSCResources/DSC_SqlSetup/en-US/DSC_SqlSetup.strings.psd1
@@ -2,6 +2,7 @@
 
 ConvertFrom-StringData @'
     UsingPath = Using path '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     EvaluateReplicationFeature = Detecting replication feature.
     ReplicationFeatureFound = Replication feature detected.
     ReplicationFeatureNotFound = Replication feature not detected.

--- a/source/DSCResources/DSC_SqlSetup/sv-SE/DSC_SqlSetup.strings.psd1
+++ b/source/DSCResources/DSC_SqlSetup/sv-SE/DSC_SqlSetup.strings.psd1
@@ -2,6 +2,7 @@
 
 ConvertFrom-StringData @'
     UsingPath = Använder sökväg '{0}'.
+    SQLInstanceNotReachable = Kan inte ansluta till SQL-instansen eller hämta alternativet. Antar att resursen inte är i önskat tillstånd. Fel: {0}
     EvaluateReplicationFeature = Letar efter funktionen Replication.
     ReplicationFeatureFound = Replication funktionen hittad.
     ReplicationFeatureNotFound = Replication funktionen hittades inte.

--- a/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
+++ b/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
@@ -223,7 +223,18 @@ function Set-TargetResource
     }
     elseif ($PSBoundParameters.ContainsKey('TraceFlagsToInclude') -or $PSBoundParameters.ContainsKey('TraceFlagsToExclude'))
     {
-        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+        try
+        {
+            $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+        }
+        catch
+        {
+            Write-Verbose -Message (
+                $script:localizedData.SQLInstanceNotReachable `
+                    -f $_
+            )
+            return $false
+        }
 
         if ($null -ne $getTargetResourceResult.TraceFlags)
         {
@@ -439,7 +450,18 @@ function Test-TargetResource
         InstanceName = $InstanceName
     }
 
-    $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $isInDesiredState = $true
 

--- a/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
+++ b/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
@@ -223,18 +223,7 @@ function Set-TargetResource
     }
     elseif ($PSBoundParameters.ContainsKey('TraceFlagsToInclude') -or $PSBoundParameters.ContainsKey('TraceFlagsToExclude'))
     {
-        try
-        {
-            $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-        }
-        catch
-        {
-            Write-Verbose -Message (
-                $script:localizedData.SQLInstanceNotReachable `
-                    -f $_
-            )
-            return $false
-        }
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
         if ($null -ne $getTargetResourceResult.TraceFlags)
         {

--- a/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
+++ b/source/DSCResources/DSC_SqlTraceFlag/DSC_SqlTraceFlag.psm1
@@ -446,8 +446,7 @@ function Test-TargetResource
     catch
     {
         Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
+            $script:localizedData.SQLInstanceNotReachable -f $_
         )
         return $false
     }

--- a/source/DSCResources/DSC_SqlTraceFlag/en-US/DSC_SqlTraceFlag.strings.psd1
+++ b/source/DSCResources/DSC_SqlTraceFlag/en-US/DSC_SqlTraceFlag.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetConfiguration = Getting the current state for the instance {0}.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     SetConfiguration = Setting the desired state for the instance {0}.
     TestConfiguration = Determining the current state for the instance '{0}'.
     NotConnectedToComputerManagement = Was unable to connect to ComputerManagement '{0}'.

--- a/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
+++ b/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
@@ -296,8 +296,7 @@ function Test-TargetResource
     catch
     {
         Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
+            $script:localizedData.SQLInstanceNotReachable -f $_
         )
         return $false
     }

--- a/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
+++ b/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
@@ -189,7 +189,20 @@ function Set-TargetResource
 
     for ($forLoopCount = 0; $forLoopCount -lt $RetryCount; $forLoopCount++)
     {
-        $clusterGroupFound = (Get-TargetResource @getTargetResourceParameters).GroupExist
+        try
+        {
+            $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+        }
+        catch
+        {
+            Write-Verbose -Message (
+                $script:localizedData.SQLInstanceNotReachable `
+                    -f $_
+            )
+            return $false
+        }
+
+        $clusterGroupFound = $getTargetResourceResult.GroupExist
         if ($clusterGroupFound)
         {
             Write-Verbose -Message (
@@ -287,7 +300,20 @@ function Test-TargetResource
         RetryCount       = $RetryCount
     }
 
-    $clusterGroupFound = (Get-TargetResource @getTargetResourceParameters).GroupExist
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
+
+    $clusterGroupFound = $getTargetResourceResult.GroupExist
     if ($clusterGroupFound)
     {
         Write-Verbose -Message (

--- a/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
+++ b/source/DSCResources/DSC_SqlWaitForAG/DSC_SqlWaitForAG.psm1
@@ -189,18 +189,7 @@ function Set-TargetResource
 
     for ($forLoopCount = 0; $forLoopCount -lt $RetryCount; $forLoopCount++)
     {
-        try
-        {
-            $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-        }
-        catch
-        {
-            Write-Verbose -Message (
-                $script:localizedData.SQLInstanceNotReachable `
-                    -f $_
-            )
-            return $false
-        }
+        $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
         $clusterGroupFound = $getTargetResourceResult.GroupExist
         if ($clusterGroupFound)

--- a/source/DSCResources/DSC_SqlWaitForAG/en-US/DSC_SqlWaitForAG.strings.psd1
+++ b/source/DSCResources/DSC_SqlWaitForAG/en-US/DSC_SqlWaitForAG.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     GetCurrentState = Get the current state of the Always On Availability Group with the cluster group name '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     FoundClusterGroup = Found the cluster group '{0}'.
     MissingClusterGroup = Did not find the cluster group '{0}'.
     WaitingClusterGroup = Waiting for the Always On Availability Group with the cluster group name '{0}'. Will make {1} attempts during a total of {2} seconds.

--- a/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
+++ b/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
@@ -427,7 +427,18 @@ function Set-TargetResource
 
     $browserServiceName = 'SQLBrowser'
 
-    $getTargetResourceResult = Get-TargetResource -SourcePath $SourcePath -Features $Features -InstanceName $InstanceName
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource -SourcePath $SourcePath -Features $Features -InstanceName $InstanceName
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     foreach ($currentFeature in $getTargetResourceResult.Features.Split(','))
     {

--- a/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
+++ b/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
@@ -654,8 +654,7 @@ function Test-TargetResource
     catch
     {
         Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
+            $script:localizedData.SQLInstanceNotReachable -f $_
         )
         return $false
     }

--- a/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
+++ b/source/DSCResources/DSC_SqlWindowsFirewall/DSC_SqlWindowsFirewall.psm1
@@ -427,18 +427,7 @@ function Set-TargetResource
 
     $browserServiceName = 'SQLBrowser'
 
-    try
-    {
-        $getTargetResourceResult = Get-TargetResource -SourcePath $SourcePath -Features $Features -InstanceName $InstanceName
-    }
-    catch
-    {
-        Write-Verbose -Message (
-            $script:localizedData.SQLInstanceNotReachable `
-                -f $_
-        )
-        return $false
-    }
+    $getTargetResourceResult = Get-TargetResource -SourcePath $SourcePath -Features $Features -InstanceName $InstanceName
 
     foreach ($currentFeature in $getTargetResourceResult.Features.Split(','))
     {
@@ -658,7 +647,18 @@ function Test-TargetResource
         $script:localizedData.EvaluatingFirewallRules -f $InstanceName
     )
 
-    $getTargetResourceResult = Get-TargetResource -SourcePath $SourcePath -Features $Features -InstanceName $InstanceName
+    try
+    {
+        $getTargetResourceResult = Get-TargetResource -SourcePath $SourcePath -Features $Features -InstanceName $InstanceName
+    }
+    catch
+    {
+        Write-Verbose -Message (
+            $script:localizedData.SQLInstanceNotReachable `
+                -f $_
+        )
+        return $false
+    }
 
     $isInDesiredState = $getTargetResourceResult.Ensure -eq $Ensure
 

--- a/source/DSCResources/DSC_SqlWindowsFirewall/en-US/DSC_SqlWindowsFirewall.strings.psd1
+++ b/source/DSCResources/DSC_SqlWindowsFirewall/en-US/DSC_SqlWindowsFirewall.strings.psd1
@@ -1,5 +1,6 @@
 ConvertFrom-StringData @'
     EnumeratingFirewallRules = Enumerating firewall rules for instance '{0}'.
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0}
     ConnectUsingCredential = Connecting to the path '{0}' using the credential '{1}' through SMB.
     UsingPath = Using the executable at '{0}' to determine the SQL Server major version.
     MajorVersion = The SQL Server major version is '{0}'.

--- a/source/en-US/SqlAgentAlert.strings.psd1
+++ b/source/en-US/SqlAgentAlert.strings.psd1
@@ -13,4 +13,5 @@ ConvertFrom-StringData @'
     SqlAgentAlert_UpdatingAlert = Updating SQL Agent Alert '{0}'. (SAAA0006)
     SqlAgentAlert_RemovingAlert = Removing SQL Agent Alert '{0}'. (SAAA0007)
     SqlAgentAlert_NoChangesNeeded = No changes needed for SQL Agent Alert '{0}'. (SAAA0009)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0} (SAAA0010)
 '@

--- a/source/en-US/SqlAudit.strings.psd1
+++ b/source/en-US/SqlAudit.strings.psd1
@@ -18,4 +18,5 @@ ConvertFrom-StringData @'
     CannotCreateNewAudit = Cannot create a new audit because neither of the properties LogType or Path is specified. One of those properties must be specified to create a new audit. (SA0006)
     AuditOfWrongTypeForUseWithProperty = A property that is not in desired state is not compatible with the audit type '{0}'. (SA0007)
     AuditIsWrongType = The existing audit is of wrong type to be able to update the property that is not in desired state. If the audit should be re-created set Force to $true. (SA0008)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0} (SA0009)
 '@

--- a/source/en-US/SqlDatabase.strings.psd1
+++ b/source/en-US/SqlDatabase.strings.psd1
@@ -26,4 +26,5 @@ ConvertFrom-StringData @'
     IsLedgerCannotBeChanged = The property IsLedger cannot be changed after the database is created. (SD0015)
     FailedToEnableSnapshotIsolation = Failed to enable snapshot isolation for the database '{0}'. (SD0016)
     FailedToDisableSnapshotIsolation = Failed to disable snapshot isolation for the database '{0}'. (SD0017)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0} (SD0018)
 '@

--- a/source/en-US/SqlDatabasePermission.strings.psd1
+++ b/source/en-US/SqlDatabasePermission.strings.psd1
@@ -20,4 +20,5 @@ ConvertFrom-StringData @'
     MustAssignOnePermissionProperty = At least one of the properties 'Permission', 'PermissionToInclude', or 'PermissionToExclude' must be specified. (SDP0009)
     DuplicatePermissionBetweenState = One or more permission state specifies the same permission. It is only allowed to specify a specific permission in one permission state. (SDP0010)
     MustHaveMinimumOnePermissionInState = At least one state does not specify a permission in the property '{0}'. (SDP0011)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0} (SDP0012)
 '@

--- a/source/en-US/SqlPermission.strings.psd1
+++ b/source/en-US/SqlPermission.strings.psd1
@@ -20,4 +20,5 @@ ConvertFrom-StringData @'
     MustAssignOnePermissionProperty = At least one of the properties 'Permission', 'PermissionToInclude', or 'PermissionToExclude' must be specified. (SP0009)
     DuplicatePermissionBetweenState = One or more permission state specifies the same permission. It is only allowed to specify a specific permission in one permission state. (SP0010)
     MustHaveMinimumOnePermissionInState = At least one state does not specify a permission in the property '{0}'. (SP0011)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0} (SP0012)
 '@

--- a/source/en-US/SqlRSSetup.strings.psd1
+++ b/source/en-US/SqlRSSetup.strings.psd1
@@ -31,4 +31,5 @@ ConvertFrom-StringData @'
     CannotDetermineProductVersion = Could not determine the product version for the installed instance '{0}'. Run the command `Get-SqlDscRSSetupConfiguration -InstanceName '{0}'` to get the configuration for the instance and verify that it returns a valid product version. (SRSS0020)
     CannotDetermineEdition = Could not determine the edition for the installed instance '{0}'. Run the command `Get-SqlDscRSSetupConfiguration -InstanceName '{0}'` to get the configuration for the instance and verify that it returns a valid edition. (SRSS0021)
     NotDesiredEdition = The edition '{0}' is not the desired for the instance '{1}'. Desired edition in executable: '{2}'. (SRSS0022)
+    SQLInstanceNotReachable = Unable to connect to SQL instance or retrieve option. Assuming resource is not in desired state. Error: {0} (SRSS0023)
 '@

--- a/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
+++ b/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
@@ -2917,6 +2917,24 @@ REVERT'
                     Assert-MockCalled -CommandName Get-PrimaryReplicaServerObject -Scope It -Times 1 -Exactly -ParameterFilter { $AvailabilityGroup.PrimaryReplicaServerName -eq 'Server2' }
                 }
             }
+
+            Context 'When Get-TargetResource throws an exception' {
+                BeforeAll {
+                    Mock -CommandName Get-TargetResource -MockWith {
+                        throw 'Unable to connect to SQL instance'
+                    }
+                }
+
+                It 'Should return $false' {
+                    InModuleScope -ScriptBlock {
+                        Set-StrictMode -Version 1.0
+
+                        $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                        $result | Should -BeFalse
+                    }
+                }
+            }
         }
 
         Describe 'SqlAGDatabase\Get-DatabasesToAddToAvailabilityGroup' {

--- a/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
+++ b/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
@@ -2730,7 +2730,9 @@ REVERT'
                 Mock -CommandName Test-ActiveNode -MockWith {
                     return -not $mockProcessOnlyOnActiveNode
                 } -Verifiable
-
+                Mock -CommandName Get-TargetResource -MockWith {
+                    throw 'Unable to connect to SQL instance'
+                } -ModuleName $script:dscResourceName
 
             }
 
@@ -2919,12 +2921,6 @@ REVERT'
             }
 
             Context 'When Get-TargetResource throws an exception' {
-                BeforeAll {
-                    Mock -CommandName Get-TargetResource -MockWith {
-                        throw 'Unable to connect to SQL instance'
-                    }
-                }
-
                 It 'Should return $false' {
                     Set-StrictMode -Version 1.0
 

--- a/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
+++ b/tests/Unit/DSC_SqlAGDatabase.Tests.ps1
@@ -2926,13 +2926,11 @@ REVERT'
                 }
 
                 It 'Should return $false' {
-                    InModuleScope -ScriptBlock {
-                        Set-StrictMode -Version 1.0
+                    Set-StrictMode -Version 1.0
 
-                        $result = Test-TargetResource @mockTestTargetResourceParameters
+                    $result = Test-TargetResource @mockTestTargetResourceParameters
 
-                        $result | Should -BeFalse
-                    }
+                    $result | Should -BeFalse
                 }
             }
         }

--- a/tests/Unit/DSC_SqlAlias.Tests.ps1
+++ b/tests/Unit/DSC_SqlAlias.Tests.ps1
@@ -1067,6 +1067,24 @@ Describe 'SqlAlias\Test-TargetResource' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlAlias\Set-TargetResource' {

--- a/tests/Unit/DSC_SqlDatabaseMail.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseMail.Tests.ps1
@@ -260,15 +260,15 @@ Describe 'DSC_SqlDatabaseMail\Get-TargetResource' -Tag 'Get' {
 
             It 'Should return the correct values for the rest of the properties' {
                 $inModuleScopeParameters = @{
-                    MockAccountName       = $mockAccountName
-                    MockEmailAddress      = $mockEmailAddress
-                    MockMailServerName    = $mockMailServerName
-                    MockProfileName       = $mockProfileName
-                    MockLoggingLevel      = $mockLoggingLevelNormal
-                    MockDisplayName       = $mockDisplayName
-                    MockReplyToAddress    = $mockReplyToAddress
-                    MockDescription       = $mockDescription
-                    MockTcpPort           = $mockTcpPort
+                    MockAccountName           = $mockAccountName
+                    MockEmailAddress          = $mockEmailAddress
+                    MockMailServerName        = $mockMailServerName
+                    MockProfileName           = $mockProfileName
+                    MockLoggingLevel          = $mockLoggingLevelNormal
+                    MockDisplayName           = $mockDisplayName
+                    MockReplyToAddress        = $mockReplyToAddress
+                    MockDescription           = $mockDescription
+                    MockTcpPort               = $mockTcpPort
                     MockUseDefaultCredentials = $mockUseDefaultCredentials
                 }
 
@@ -643,7 +643,9 @@ Describe 'DSC_SqlDatabaseMail\Test-TargetResource' -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $result = Test-TargetResource @mockTestTargetResourceParameters
+                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
+
+                $result = Test-TargetResource @testTargetResourceParameters
 
                 $result | Should -BeFalse
             }
@@ -699,38 +701,38 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                 Add-Member -MemberType NoteProperty -Name 'ReplyToAddress' -Value $mockReplyToAddress -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'Description' -Value $mockDynamicDescription -PassThru |
                 Add-Member -MemberType ScriptProperty -Name 'MailServers' -Value {
-                return @(
-                    New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockMailServerName -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'Port' -Value $mockTcpPort -PassThru |
-                        Add-Member -MemberType NoteProperty -Name 'UseDefaultCredentials' -Value $mockUseDefaultCredentials -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name 'Rename' -Value {
-                            InModuleScope -ScriptBlock {
-                                $script:MailServerRenameMethodCallCount += 1
-                            }
+                    return @(
+                        New-Object -TypeName Object |
+                            Add-Member -MemberType NoteProperty -Name 'Name' -Value $mockMailServerName -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'Port' -Value $mockTcpPort -PassThru |
+                            Add-Member -MemberType NoteProperty -Name 'UseDefaultCredentials' -Value $mockUseDefaultCredentials -PassThru |
+                            Add-Member -MemberType ScriptMethod -Name 'Rename' -Value {
+                                InModuleScope -ScriptBlock {
+                                    $script:MailServerRenameMethodCallCount += 1
+                                }
+                            } -PassThru |
+                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                InModuleScope -ScriptBlock {
+                                    $script:MailServerAlterMethodCallCount += 1
+                                }
+                            } -PassThru -Force
+                        )
                     } -PassThru |
-                        Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                            InModuleScope -ScriptBlock {
-                                $script:MailServerAlterMethodCallCount += 1
-                            }
+                    Add-Member -MemberType ScriptMethod -Name 'Create' -Value {
+                        InModuleScope -ScriptBlock {
+                            $script:MailAccountCreateMethodCallCount += 1
+                        }
+                    } -PassThru |
+                    Add-Member -MemberType ScriptMethod -Name 'Drop' -Value {
+                        InModuleScope -ScriptBlock {
+                            $script:MailAccountDropMethodCallCount += 1
+                        }
+                    } -PassThru |
+                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                        InModuleScope -ScriptBlock {
+                            $script:MailAccountAlterMethodCallCount += 1
+                        }
                     } -PassThru -Force
-                )
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name 'Create' -Value {
-                    InModuleScope -ScriptBlock {
-                        $script:MailAccountCreateMethodCallCount += 1
-                    }
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name 'Drop' -Value {
-                    InModuleScope -ScriptBlock {
-                        $script:MailAccountDropMethodCallCount += 1
-                    }
-            } -PassThru |
-                Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                    InModuleScope -ScriptBlock {
-                        $script:MailAccountAlterMethodCallCount += 1
-                    }
-                } -PassThru -Force
         }
 
         $mockNewObject_MailAccount = {
@@ -747,12 +749,12 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                         InModuleScope -ScriptBlock {
                             $script:MailProfileCreateMethodCallCount += 1
                         }
-                } -PassThru |
+                    } -PassThru |
                     Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
                         InModuleScope -ScriptBlock {
                             $script:MailProfileAlterMethodCallCount += 1
                         }
-                } -PassThru |
+                    } -PassThru |
                     Add-Member -MemberType ScriptMethod -Name 'Drop' -Value {
                         InModuleScope -ScriptBlock {
                             $script:MailProfileDropMethodCallCount += 1
@@ -762,12 +764,12 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
                         InModuleScope -ScriptBlock {
                             $script:MailProfileAddPrincipalMethodCallCount += 1
                         }
-                } -PassThru |
+                    } -PassThru |
                     Add-Member -MemberType ScriptMethod -Name 'AddAccount' -Value {
                         InModuleScope -ScriptBlock {
                             $script:MailProfileAddAccountMethodCallCount += 1
                         }
-                } -PassThru -Force
+                    } -PassThru -Force
             )
         }
 
@@ -779,44 +781,44 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
         $mockConnectSQL = {
             return New-Object -TypeName Object |
                 Add-Member -MemberType ScriptProperty -Name 'Configuration' -Value {
-                return New-Object -TypeName Object |
-                    Add-Member -MemberType ScriptProperty -Name 'DatabaseMailEnabled' -Value {
                     return New-Object -TypeName Object |
-                        Add-Member -MemberType NoteProperty -Name 'RunValue' -Value $mockDynamicDatabaseMailEnabledRunValue -PassThru -Force
-                } -PassThru -Force
-            } -PassThru |
-                Add-Member -MemberType ScriptProperty -Name 'Mail' -Value {
-                return New-Object -TypeName Object |
-                    Add-Member -MemberType ScriptProperty -Name 'Accounts' -Value {
-                    # This executes the variable that contains the mock
-                    return @( & $mailAccountObject )
-                } -PassThru |
-                    Add-Member -MemberType ScriptProperty -Name 'ConfigurationValues' -Value {
-                    return @{
-                        'LoggingLevel' = New-Object -TypeName Object |
-                            Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicLoggingLevelValue -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                                InModuleScope -ScriptBlock {
-                                    $script:LoggingLevelAlterMethodCallCount += 1
-                                }
-                        } -PassThru -Force
-                    }
-                } -PassThru |
-                    Add-Member -MemberType ScriptProperty -Name 'Profiles' -Value {
-                    # This executes the variable that contains the mock
-                    return @( & $mailProfileObject )
-                } -PassThru -Force
-            } -PassThru |
-                Add-Member -MemberType ScriptProperty -Name 'JobServer' -Value {
-                return New-Object -TypeName Object |
-                    Add-Member -MemberType NoteProperty -Name 'AgentMailType' -Value $mockDynamicAgentMailType -PassThru |
-                    Add-Member -MemberType NoteProperty -Name 'DatabaseMailProfile' -Value $mockDynamicDatabaseMailProfile -PassThru |
-                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                        InModuleScope -ScriptBlock {
-                            $script:JobServerAlterMethodCallCount += 1
-                        }
-                } -PassThru -Force
-            } -PassThru -Force
+                        Add-Member -MemberType ScriptProperty -Name 'DatabaseMailEnabled' -Value {
+                            return New-Object -TypeName Object |
+                                Add-Member -MemberType NoteProperty -Name 'RunValue' -Value $mockDynamicDatabaseMailEnabledRunValue -PassThru -Force
+                            } -PassThru -Force
+                        } -PassThru |
+                        Add-Member -MemberType ScriptProperty -Name 'Mail' -Value {
+                            return New-Object -TypeName Object |
+                                Add-Member -MemberType ScriptProperty -Name 'Accounts' -Value {
+                                    # This executes the variable that contains the mock
+                                    return @( & $mailAccountObject )
+                                } -PassThru |
+                                Add-Member -MemberType ScriptProperty -Name 'ConfigurationValues' -Value {
+                                    return @{
+                                        'LoggingLevel' = New-Object -TypeName Object |
+                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value $mockDynamicLoggingLevelValue -PassThru |
+                                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                                InModuleScope -ScriptBlock {
+                                                    $script:LoggingLevelAlterMethodCallCount += 1
+                                                }
+                                            } -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptProperty -Name 'Profiles' -Value {
+                                        # This executes the variable that contains the mock
+                                        return @( & $mailProfileObject )
+                                    } -PassThru -Force
+                                } -PassThru |
+                                Add-Member -MemberType ScriptProperty -Name 'JobServer' -Value {
+                                    return New-Object -TypeName Object |
+                                        Add-Member -MemberType NoteProperty -Name 'AgentMailType' -Value $mockDynamicAgentMailType -PassThru |
+                                        Add-Member -MemberType NoteProperty -Name 'DatabaseMailProfile' -Value $mockDynamicDatabaseMailProfile -PassThru |
+                                        Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                            InModuleScope -ScriptBlock {
+                                                $script:JobServerAlterMethodCallCount += 1
+                                            }
+                                        } -PassThru -Force
+                                    } -PassThru -Force
         }
 
         $mockDynamicDatabaseMailEnabledRunValue = $mockDatabaseMailEnabledConfigValue
@@ -828,8 +830,8 @@ Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {
         InModuleScope -ScriptBlock {
             # Default parameters that are used for the It-blocks.
             $script:mockDefaultParameters = @{
-                InstanceName = 'MSSQLSERVER'
-                ServerName   = 'localhost'
+                InstanceName   = 'MSSQLSERVER'
+                ServerName     = 'localhost'
                 AccountName    = 'MyMail'
                 EmailAddress   = 'NoReply@company.local'
                 MailServerName = 'mail.company.local'

--- a/tests/Unit/DSC_SqlDatabaseMail.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseMail.Tests.ps1
@@ -631,6 +631,24 @@ Describe 'DSC_SqlDatabaseMail\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'DSC_SqlDatabaseMail\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseObjectPermission.Tests.ps1
@@ -674,6 +674,24 @@ Describe 'SqlDatabaseObjectPermission\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlDatabaseObjectPermission\Compare-TargetResourceState' -Tag 'Compare' {

--- a/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
+++ b/tests/Unit/DSC_SqlDatabaseUser.Tests.ps1
@@ -591,6 +591,24 @@ Describe 'SqlDatabaseUser\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'DSC_SqlDatabaseUser\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlEndpoint.Tests.ps1
+++ b/tests/Unit/DSC_SqlEndpoint.Tests.ps1
@@ -993,6 +993,24 @@ Describe 'DSC_SqlEndpoint\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 

--- a/tests/Unit/DSC_SqlEndpoint.Tests.ps1
+++ b/tests/Unit/DSC_SqlEndpoint.Tests.ps1
@@ -1001,6 +1001,13 @@ Describe 'DSC_SqlEndpoint\Test-TargetResource' -Tag 'Test' {
             }
         }
 
+        BeforeEach {
+            InModuleScope -ScriptBlock {
+                $mockTestTargetResourceParameters.EndpointName = 'DefaultEndpointMirror'
+                $mockTestTargetResourceParameters.EndpointType = 'DatabaseMirroring'
+            }
+        }
+
         It 'Should return $false' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0

--- a/tests/Unit/DSC_SqlLogin.Tests.ps1
+++ b/tests/Unit/DSC_SqlLogin.Tests.ps1
@@ -670,6 +670,12 @@ Describe 'SqlLogin\Test-TargetResource' -Tag 'Test' {
             }
         }
 
+        BeforeEach {
+            InModuleScope -ScriptBlock {
+                $mockTestTargetResourceParameters.Name = 'Windows\Login1'
+            }
+        }
+
         It 'Should return $false' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0

--- a/tests/Unit/DSC_SqlLogin.Tests.ps1
+++ b/tests/Unit/DSC_SqlLogin.Tests.ps1
@@ -662,6 +662,24 @@ Describe 'SqlLogin\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlLogin\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlMaxDop.Tests.ps1
+++ b/tests/Unit/DSC_SqlMaxDop.Tests.ps1
@@ -103,16 +103,16 @@ Describe 'SqlMaxDop\Get-TargetResource' -Tag 'Get' {
                                     return @(
                                         (New-Object -TypeName 'Object' |
                                             Add-Member -MemberType 'ScriptProperty' -Name 'MaxDegreeOfParallelism' -Value {
-                                            return @(
-                                                (New-Object -TypeName Object |
-                                                    Add-Member -MemberType 'NoteProperty' -Name 'DisplayName' -Value 'max degree of parallelism' -PassThru |
-                                                    Add-Member -MemberType 'NoteProperty' -Name 'Description' -Value 'maximum degree of parallelism' -PassThru |
-                                                    Add-Member -MemberType 'NoteProperty' -Name 'RunValue' -Value 4 -PassThru |
-                                                    Add-Member -MemberType 'NoteProperty' -Name 'ConfigValue' -Value 4 -PassThru -Force)
-                                                )
-                                            } -PassThru -Force)
-                                    )
-                                } -PassThru -Force
+                                                return @(
+                                                    (New-Object -TypeName Object |
+                                                        Add-Member -MemberType 'NoteProperty' -Name 'DisplayName' -Value 'max degree of parallelism' -PassThru |
+                                                        Add-Member -MemberType 'NoteProperty' -Name 'Description' -Value 'maximum degree of parallelism' -PassThru |
+                                                        Add-Member -MemberType 'NoteProperty' -Name 'RunValue' -Value 4 -PassThru |
+                                                        Add-Member -MemberType 'NoteProperty' -Name 'ConfigValue' -Value 4 -PassThru -Force)
+                                                    )
+                                                } -PassThru -Force)
+                                            )
+                                        } -PassThru -Force
                         )
                     )
                 }
@@ -192,8 +192,8 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 0
-                        IsActiveNode            = $null
+                        MaxDop       = 0
+                        IsActiveNode = $null
                     }
                 }
             }
@@ -215,8 +215,8 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 4
-                        IsActiveNode            = $null
+                        MaxDop       = 4
+                        IsActiveNode = $null
                     }
                 }
             }
@@ -242,8 +242,8 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
 
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 4
-                        IsActiveNode            = $null
+                        MaxDop       = 4
+                        IsActiveNode = $null
                     }
                 }
             }
@@ -252,7 +252,7 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
                 InModuleScope -ScriptBlock {
                     Set-StrictMode -Version 1.0
 
-                    $mockTestTargetResourceParameters.DynamicAlloc =  $true
+                    $mockTestTargetResourceParameters.DynamicAlloc = $true
 
                     $result = Test-TargetResource @mockTestTargetResourceParameters
 
@@ -265,7 +265,7 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 4
+                        MaxDop = 4
                     }
                 }
             }
@@ -275,7 +275,7 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
                     Set-StrictMode -Version 1.0
 
                     $mockTestTargetResourceParameters.MaxDop = 4
-                    $mockTestTargetResourceParameters.DynamicAlloc =  $true
+                    $mockTestTargetResourceParameters.DynamicAlloc = $true
 
                     $mockErrorMessage = '{0} (Parameter ''MaxDop'')' -f $script:localizedData.MaxDopParamMustBeNull
 
@@ -290,8 +290,8 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 0
-                        IsActiveNode            = $false
+                        MaxDop       = 0
+                        IsActiveNode = $false
                     }
                 }
             }
@@ -314,8 +314,8 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 0
-                        IsActiveNode            = $null
+                        MaxDop       = 0
+                        IsActiveNode = $null
                     }
                 }
             }
@@ -341,8 +341,8 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
 
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 0
-                        IsActiveNode            = $null
+                        MaxDop       = 0
+                        IsActiveNode = $null
                     }
                 }
             }
@@ -364,8 +364,8 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        MaxDop                  = 4
-                        IsActiveNode            = $null
+                        MaxDop       = 4
+                        IsActiveNode = $null
                     }
                 }
             }
@@ -435,7 +435,7 @@ Describe 'SqlMaxDop\Set-TargetResource' -Tag 'Set' {
                 Set-StrictMode -Version 1.0
 
                 $mockSetTargetResourceParameters.MaxDop = 4
-                $mockSetTargetResourceParameters.DynamicAlloc =  $true
+                $mockSetTargetResourceParameters.DynamicAlloc = $true
 
                 $mockErrorMessage = '{0} (Parameter ''MaxDop'')' -f $script:localizedData.MaxDopParamMustBeNull
 
@@ -671,7 +671,8 @@ Describe 'Get-SqlDscDynamicMaxDop' -Tag 'Helper' {
     BeforeAll {
         # Inject a stub in the module scope to support testing cross-plattform
         InModuleScope -ScriptBlock {
-            function script:Get-CimInstance {
+            function script:Get-CimInstance
+            {
                 param
                 (
                     $ClassName

--- a/tests/Unit/DSC_SqlMaxDop.Tests.ps1
+++ b/tests/Unit/DSC_SqlMaxDop.Tests.ps1
@@ -383,6 +383,26 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $mockTestTargetResourceParameters.MaxDop = 4
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlMaxDop\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlMemory.Tests.ps1
+++ b/tests/Unit/DSC_SqlMemory.Tests.ps1
@@ -722,6 +722,26 @@ Describe 'SqlMaxDop\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $mockTestTargetResourceParameters.DynamicAlloc = $true
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlMaxDop\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlProtocol.Tests.ps1
+++ b/tests/Unit/DSC_SqlProtocol.Tests.ps1
@@ -364,6 +364,11 @@ Describe 'SqlProtocol\Test-TargetResource' -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
+                $testTargetResourceParameters = @{
+                    InstanceName = 'DSCTEST'
+                    ProtocolName = 'SharedMemory'
+                }
+
                 $result = Test-TargetResource @testTargetResourceParameters
 
                 $result | Should -BeFalse
@@ -837,16 +842,16 @@ Describe 'SqlProtocol\Set-TargetResource' -Tag 'Set' {
                                 return @{
                                     ListenOnAllIPs = New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
-                                    KeepAlive  = New-Object -TypeName PSObject |
-                                        Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
-                                }
-                            } -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                                # This is used to verify so that method Alter() is actually called or not.
-                                InModuleScope -ScriptBlock {
-                                    $script:wasMethodAlterCalled = $true
-                                }
-                            } -PassThru -Force
+                                        KeepAlive  = New-Object -TypeName PSObject |
+                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        InModuleScope -ScriptBlock {
+                                            $script:wasMethodAlterCalled = $true
+                                        }
+                                    } -PassThru -Force
                     }
                 }
 
@@ -898,16 +903,16 @@ Describe 'SqlProtocol\Set-TargetResource' -Tag 'Set' {
                                 return @{
                                     ListenOnAllIPs = New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
-                                    KeepAlive  = New-Object -TypeName PSObject |
-                                        Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
-                                }
-                            } -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                                # This is used to verify so that method Alter() is actually called or not.
-                                InModuleScope -ScriptBlock {
-                                    $script:wasMethodAlterCalled = $true
-                                }
-                            } -PassThru -Force
+                                        KeepAlive  = New-Object -TypeName PSObject |
+                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        InModuleScope -ScriptBlock {
+                                            $script:wasMethodAlterCalled = $true
+                                        }
+                                    } -PassThru -Force
                     }
                 }
 
@@ -957,16 +962,16 @@ Describe 'SqlProtocol\Set-TargetResource' -Tag 'Set' {
                                 return @{
                                     ListenOnAllIPs = New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
-                                    KeepAlive = New-Object -TypeName PSObject |
-                                        Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
-                                }
-                            } -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                                # This is used to verify so that method Alter() is actually called or not.
-                                InModuleScope -ScriptBlock {
-                                    $script:wasMethodAlterCalled = $true
-                                }
-                            } -PassThru -Force
+                                        KeepAlive  = New-Object -TypeName PSObject |
+                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        InModuleScope -ScriptBlock {
+                                            $script:wasMethodAlterCalled = $true
+                                        }
+                                    } -PassThru -Force
                     }
                 }
 
@@ -1022,16 +1027,16 @@ Describe 'SqlProtocol\Set-TargetResource' -Tag 'Set' {
                                 return @{
                                     ListenOnAllIPs = New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
-                                    KeepAlive  = New-Object -TypeName PSObject |
-                                        Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
-                                }
-                            } -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                                # This is used to verify so that method Alter() is actually called or not.
-                                InModuleScope -ScriptBlock {
-                                    $script:wasMethodAlterCalled = $true
-                                }
-                            } -PassThru -Force
+                                        KeepAlive  = New-Object -TypeName PSObject |
+                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        InModuleScope -ScriptBlock {
+                                            $script:wasMethodAlterCalled = $true
+                                        }
+                                    } -PassThru -Force
                     }
                 }
 
@@ -1083,16 +1088,16 @@ Describe 'SqlProtocol\Set-TargetResource' -Tag 'Set' {
                                 return @{
                                     ListenOnAllIPs = New-Object -TypeName PSObject |
                                         Add-Member -MemberType NoteProperty -Name 'Value' -Value $false -PassThru -Force
-                                    KeepAlive  = New-Object -TypeName PSObject |
-                                        Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
-                                }
-                            } -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
-                                # This is used to verify so that method Alter() is actually called or not.
-                                InModuleScope -ScriptBlock {
-                                    $script:wasMethodAlterCalled = $true
-                                }
-                            } -PassThru -Force
+                                        KeepAlive  = New-Object -TypeName PSObject |
+                                            Add-Member -MemberType NoteProperty -Name 'Value' -Value 30000 -PassThru -Force
+                                        }
+                                    } -PassThru |
+                                    Add-Member -MemberType ScriptMethod -Name 'Alter' -Value {
+                                        # This is used to verify so that method Alter() is actually called or not.
+                                        InModuleScope -ScriptBlock {
+                                            $script:wasMethodAlterCalled = $true
+                                        }
+                                    } -PassThru -Force
                     }
                 }
 

--- a/tests/Unit/DSC_SqlProtocol.Tests.ps1
+++ b/tests/Unit/DSC_SqlProtocol.Tests.ps1
@@ -352,6 +352,24 @@ Describe 'SqlProtocol\Test-TargetResource' -Tag 'Test' {
             Should -Invoke -CommandName Compare-TargetResourceState -Exactly -Times 1 -Scope It
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @testTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlProtocol\Compare-TargetResourceState' -Tag 'Compare' {

--- a/tests/Unit/DSC_SqlRS.Tests.ps1
+++ b/tests/Unit/DSC_SqlRS.Tests.ps1
@@ -1376,4 +1376,28 @@ Describe 'SqlRS\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $testParameters = @{
+                    InstanceName         = 'INSTANCE'
+                    DatabaseServerName   = 'MockDatabaseServer'
+                    DatabaseInstanceName = 'MockDatabaseInstance'
+                }
+
+                $result = Test-TargetResource @testParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }

--- a/tests/Unit/DSC_SqlRole.Tests.ps1
+++ b/tests/Unit/DSC_SqlRole.Tests.ps1
@@ -643,6 +643,24 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             Should -Invoke -CommandName Connect-SQL -Exactly -Times 1 -Scope It
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {

--- a/tests/Unit/DSC_SqlRole.Tests.ps1
+++ b/tests/Unit/DSC_SqlRole.Tests.ps1
@@ -62,23 +62,23 @@ BeforeAll {
 
     $mockConnectSQL = {
         $mockServerObjectHashtable = @{
-            InstanceName = 'MSSQLSERVER'
+            InstanceName                = 'MSSQLSERVER'
             ComputerNamePhysicalNetBIOS = 'localhost'
-            Name = 'localhost\MSSQLSERVER'
+            Name                        = 'localhost\MSSQLSERVER'
         }
 
         if ($mockPrincipalsAsArrays)
         {
             $mockServerObjectHashtable += @{
                 Logins = @()
-                Roles = @()
+                Roles  = @()
             }
         }
         else
         {
             $mockServerObjectHashtable += @{
                 Logins = @{}
-                Roles = @{}
+                Roles  = @{}
             }
         }
 
@@ -103,56 +103,56 @@ BeforeAll {
                     $mockEnumMemberNames
                 }
             } -PassThru |
-            Add-Member -MemberType ScriptMethod -Name Drop -Value {
-                if ($mockInvalidOperationForDropMethod)
-                {
-                    throw 'Mock Drop Method was called with invalid operation'
-                }
+                Add-Member -MemberType ScriptMethod -Name Drop -Value {
+                    if ($mockInvalidOperationForDropMethod)
+                    {
+                        throw 'Mock Drop Method was called with invalid operation'
+                    }
 
-                if ( $this.Name -ne 'ServerRoleToDrop' )
-                {
-                    throw "Called mocked drop() method without dropping the right server role. Expected '{0}'. But was '{1}'." `
-                        -f 'ServerRoleToDrop', $this.Name
-                }
-            } -PassThru |
-            Add-Member -MemberType ScriptMethod -Name AddMember -Value {
-                param
-                (
-                    [Parameter(Mandatory = $true)]
-                    [String]
-                    $memberName
-                )
+                    if ( $this.Name -ne 'ServerRoleToDrop' )
+                    {
+                        throw "Called mocked drop() method without dropping the right server role. Expected '{0}'. But was '{1}'." `
+                            -f 'ServerRoleToDrop', $this.Name
+                    }
+                } -PassThru |
+                Add-Member -MemberType ScriptMethod -Name AddMember -Value {
+                    param
+                    (
+                        [Parameter(Mandatory = $true)]
+                        [String]
+                        $memberName
+                    )
 
-                if ($mockInvalidOperationForAddMemberMethod)
-                {
-                    throw 'Mock AddMember Method was called with invalid operation'
-                }
+                    if ($mockInvalidOperationForAddMemberMethod)
+                    {
+                        throw 'Mock AddMember Method was called with invalid operation'
+                    }
 
-                if ($mockExpectedMemberToAdd -ne $memberName)
-                {
-                    throw "Called mocked AddMember() method without adding the right login. Expected '{0}'. But was '{1}'." `
-                        -f $mockExpectedMemberToAdd, $memberName
-                }
-            } -PassThru |
-            Add-Member -MemberType ScriptMethod -Name DropMember -Value {
-                param
-                (
-                    [Parameter(Mandatory = $true)]
-                    [String]
-                    $memberName
-                )
+                    if ($mockExpectedMemberToAdd -ne $memberName)
+                    {
+                        throw "Called mocked AddMember() method without adding the right login. Expected '{0}'. But was '{1}'." `
+                            -f $mockExpectedMemberToAdd, $memberName
+                    }
+                } -PassThru |
+                Add-Member -MemberType ScriptMethod -Name DropMember -Value {
+                    param
+                    (
+                        [Parameter(Mandatory = $true)]
+                        [String]
+                        $memberName
+                    )
 
-                if ($mockInvalidOperationForDropMemberMethod)
-                {
-                    throw 'Mock DropMember Method was called with invalid operation'
-                }
+                    if ($mockInvalidOperationForDropMemberMethod)
+                    {
+                        throw 'Mock DropMember Method was called with invalid operation'
+                    }
 
-                if ($mockExpectedMemberToDrop -ne $memberName)
-                {
-                    throw "Called mocked DropMember() method without removing the right login. Expected '{0}'. But was '{1}'." `
-                        -f $mockExpectedMemberToDrop, $memberName
+                    if ($mockExpectedMemberToDrop -ne $memberName)
+                    {
+                        throw "Called mocked DropMember() method without removing the right login. Expected '{0}'. But was '{1}'." `
+                            -f $mockExpectedMemberToDrop, $memberName
+                    }
                 }
-            }
 
             # Add the mock role to the roles collection
             if ($mockServerObject.Roles -is [array])
@@ -169,7 +169,7 @@ BeforeAll {
         foreach ($mockLoginName in @('CONTOSO\John', 'CONTOSO\Kelly', 'CONTOSO\Lucy', 'CONTOSO\Steve'))
         {
             $mockLoginObject = [PSCustomObject] @{
-                Name = $mockLoginName
+                Name      = $mockLoginName
                 LoginType = 'WindowsUser'
             }
 
@@ -206,7 +206,7 @@ AfterAll {
     Remove-Item -Path 'env:SqlServerDscCI'
 }
 
-Describe "DSC_SqlRole\Get-TargetResource" -Tag 'Get' {
+Describe 'DSC_SqlRole\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL
 
@@ -333,7 +333,7 @@ Describe "DSC_SqlRole\Get-TargetResource" -Tag 'Get' {
     }
 }
 
-Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
+Describe 'DSC_SqlRole\Test-TargetResource' -Tag 'Test' {
     BeforeAll {
         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL
 
@@ -359,7 +359,7 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure         = 'Absent'
+                $mockTestParameters.Ensure = 'Absent'
                 $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -382,7 +382,7 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure         = 'Absent'
+                $mockTestParameters.Ensure = 'Absent'
                 $mockTestParameters.ServerRoleName = 'newServerRole'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -405,7 +405,7 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure         = 'Present'
+                $mockTestParameters.Ensure = 'Present'
                 $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -428,7 +428,7 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure         = 'Present'
+                $mockTestParameters.Ensure = 'Present'
                 $mockTestParameters.ServerRoleName = 'newServerRole'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -451,9 +451,9 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure         = 'Present'
+                $mockTestParameters.Ensure = 'Present'
                 $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
-                $mockTestParameters.Members        = @('CONTOSO\Lucy', 'CONTOSO\Steve')
+                $mockTestParameters.Members = @('CONTOSO\Lucy', 'CONTOSO\Steve')
 
                 $script:result = Test-TargetResource @mockTestParameters
             }
@@ -475,9 +475,9 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
-                $mockTestParameters.Members          = @('CONTOSO\John', 'CONTOSO\Kelly')
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
+                $mockTestParameters.Members = @('CONTOSO\John', 'CONTOSO\Kelly')
                 $mockTestParameters.MembersToInclude = 'CONTOSO\Lucy'
 
                 $mockErrorMessage = $script:localizedData.MembersToIncludeAndExcludeParamMustBeNull
@@ -496,8 +496,8 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToInclude = 'CONTOSO\Kelly'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -520,8 +520,8 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'RoleNotExist'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'RoleNotExist'
                 $mockTestParameters.MembersToInclude = 'CONTOSO\Lucy'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -545,19 +545,19 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
                 return @{
                     MembersToExclude = $null
                     MembersToInclude = $null
-                    Ensure = 'Present'
-                    InstanceName = 'MSSQLSERVER'
-                    ServerRoleName = 'RoleNotExist'
-                    Members = @('CONTOSO\Lucy')
-                    ServerName = 'localhost'
+                    Ensure           = 'Present'
+                    InstanceName     = 'MSSQLSERVER'
+                    ServerRoleName   = 'RoleNotExist'
+                    Members          = @('CONTOSO\Lucy')
+                    ServerName       = 'localhost'
                 }
             }
 
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'RoleNotExist'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'RoleNotExist'
                 $mockTestParameters.MembersToInclude = @('CONTOSO\Lucy', 'CONTOSO\NewUser')
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -580,9 +580,9 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
-                $mockTestParameters.Members          = @('CONTOSO\John', 'CONTOSO\Kelly')
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
+                $mockTestParameters.Members = @('CONTOSO\John', 'CONTOSO\Kelly')
                 $mockTestParameters.MembersToExclude = 'CONTOSO\Kelly'
 
                 $mockErrorMessage = $script:localizedData.MembersToIncludeAndExcludeParamMustBeNull
@@ -601,8 +601,8 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToExclude = 'CONTOSO\Lucy'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -625,8 +625,8 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToExclude = 'CONTOSO\Kelly'
 
                 $script:result = Test-TargetResource @mockTestParameters
@@ -655,7 +655,7 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $result = Test-TargetResource @mockTestTargetResourceParameters
+                $result = Test-TargetResource @mockTestParameters
 
                 $result | Should -BeFalse
             }
@@ -663,7 +663,7 @@ Describe "DSC_SqlRole\Test-TargetResource" -Tag 'Test' {
     }
 }
 
-Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
+Describe 'DSC_SqlRole\Set-TargetResource' -Tag 'Set' {
     BeforeAll {
         Mock -CommandName Connect-SQL -MockWith $mockConnectSQL
 
@@ -748,7 +748,7 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
 
                 $mockInvalidOperationForDropMethod = $true
 
-                $mockTestParameters.Ensure         = 'Absent'
+                $mockTestParameters.Ensure = 'Absent'
                 $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
 
 
@@ -770,7 +770,7 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
                 $mockSqlServerRoleAdd = 'ServerRoleToAdd'
                 $mockExpectedServerRoleToCreate = 'ServerRoleToAdd'
 
-                $mockTestParameters.Ensure         = 'Present'
+                $mockTestParameters.Ensure = 'Present'
                 $mockTestParameters.ServerRoleName = $mockSqlServerRoleAdd
 
                 $null = Set-TargetResource @mockTestParameters -ErrorAction 'Stop'
@@ -798,7 +798,7 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
                 $mockSqlServerRoleAdd = 'ServerRoleToAdd'
                 $mockExpectedServerRoleToCreate = 'ServerRoleToAdd'
 
-                $mockTestParameters.Ensure         = 'Present'
+                $mockTestParameters.Ensure = 'Present'
                 $mockTestParameters.ServerRoleName = $mockSqlServerRoleAdd
 
                 $mockErrorMessage = $script:localizedData.CreateServerRoleSetError `
@@ -822,9 +822,9 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure          = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
-                $mockTestParameters.Members          = @('CONTOSO\John', 'CONTOSO\Kelly')
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
+                $mockTestParameters.Members = @('CONTOSO\John', 'CONTOSO\Kelly')
                 $mockTestParameters.MembersToInclude = 'CONTOSO\Lucy'
 
                 { Set-TargetResource @mockTestParameters } | Should -Throw -ExpectedMessage '*(DRC0010)*'
@@ -841,9 +841,9 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
-                $mockTestParameters.Members          = @('CONTOSO\John', 'CONTOSO\Kelly')
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
+                $mockTestParameters.Members = @('CONTOSO\John', 'CONTOSO\Kelly')
                 $mockTestParameters.MembersToExclude = 'CONTOSO\Kelly'
 
                 $errorMessage = $script:localizedData.MembersToIncludeAndExcludeParamMustBeNull
@@ -864,8 +864,8 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToInclude = 'CONTOSO\Lucy'
 
                 $null = Set-TargetResource @mockTestParameters -ErrorAction 'Stop'
@@ -885,8 +885,8 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToInclude = 'CONTOSO\Lucy'
 
                 $mockErrorMessage = $script:localizedData.AddMemberServerRoleSetError `
@@ -908,8 +908,8 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToInclude = 'KingJulian'
 
                 $mockErrorMessage = $script:localizedData.AddMemberServerRoleSetError -f (
@@ -937,8 +937,8 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
 
                 $mockExpectedMemberToDrop = 'CONTOSO\Kelly'
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToExclude = 'CONTOSO\Kelly'
 
                 $null = Set-TargetResource @mockTestParameters -ErrorAction 'Stop'
@@ -958,8 +958,8 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToExclude = 'CONTOSO\Kelly'
 
                 $mockErrorMessage = $script:localizedData.DropMemberServerRoleSetError `
@@ -982,8 +982,8 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure           = 'Present'
-                $mockTestParameters.ServerRoleName   = 'AdminSqlForBI'
+                $mockTestParameters.Ensure = 'Present'
+                $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
                 $mockTestParameters.MembersToExclude = 'KingJulian'
 
                 $mockErrorMessage = $script:localizedData.DropMemberServerRoleSetError -f (
@@ -1009,9 +1009,9 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure         = 'Present'
+                $mockTestParameters.Ensure = 'Present'
                 $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
-                $mockTestParameters.Members        = @('KingJulian', 'CONTOSO\John', 'CONTOSO\Lucy')
+                $mockTestParameters.Members = @('KingJulian', 'CONTOSO\John', 'CONTOSO\Lucy')
 
                 $mockErrorMessage = $script:localizedData.AddMemberServerRoleSetError -f (
                     'localhost',
@@ -1037,9 +1037,9 @@ Describe "DSC_SqlRole\Set-TargetResource" -Tag 'Set' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $mockTestParameters.Ensure         = 'Present'
+                $mockTestParameters.Ensure = 'Present'
                 $mockTestParameters.ServerRoleName = 'AdminSqlForBI'
-                $mockTestParameters.Members        = @('CONTOSO\John', 'CONTOSO\Lucy')
+                $mockTestParameters.Members = @('CONTOSO\John', 'CONTOSO\Lucy')
 
                 $null = Set-TargetResource @mockTestParameters -ErrorAction 'Stop'
             }
@@ -1204,7 +1204,7 @@ Describe 'DSC_SqlRole\Test-SqlSecurityPrincipal' -Tag 'Helper' {
                 $mockSecurityPrincipal = 'Nabrond'
 
                 $mockTestParameters = @{
-                    SqlServerObject = $testSqlServerObject
+                    SqlServerObject   = $testSqlServerObject
                     SecurityPrincipal = $mockSecurityPrincipal
                 }
 
@@ -1224,7 +1224,7 @@ Describe 'DSC_SqlRole\Test-SqlSecurityPrincipal' -Tag 'Helper' {
                 Set-StrictMode -Version 1.0
 
                 $mockTestParameters = @{
-                    SqlServerObject = $testSqlServerObject
+                    SqlServerObject   = $testSqlServerObject
                     SecurityPrincipal = 'CONTOSO\John'
                 }
 
@@ -1237,7 +1237,7 @@ Describe 'DSC_SqlRole\Test-SqlSecurityPrincipal' -Tag 'Helper' {
                 Set-StrictMode -Version 1.0
 
                 $mockTestParameters = @{
-                    SqlServerObject = $testSqlServerObject
+                    SqlServerObject   = $testSqlServerObject
                     SecurityPrincipal = 'CONTOSO\John'.ToUpper()
                 }
 
@@ -1250,7 +1250,7 @@ Describe 'DSC_SqlRole\Test-SqlSecurityPrincipal' -Tag 'Helper' {
                 Set-StrictMode -Version 1.0
 
                 $mockTestParameters = @{
-                    SqlServerObject = $testSqlServerObject
+                    SqlServerObject   = $testSqlServerObject
                     SecurityPrincipal = 'AdminSqlForBI'
                 }
 
@@ -1263,7 +1263,7 @@ Describe 'DSC_SqlRole\Test-SqlSecurityPrincipal' -Tag 'Helper' {
                 Set-StrictMode -Version 1.0
 
                 $mockTestParameters = @{
-                    SqlServerObject = $testSqlServerObject
+                    SqlServerObject   = $testSqlServerObject
                     SecurityPrincipal = 'AdminSqlForBI'.ToUpper()
                 }
 
@@ -1280,8 +1280,8 @@ Describe 'DSC_SqlRole\Get-CorrectedMemberParameters' -Tag 'Helper' {
                 Set-StrictMode -Version 1.0
 
                 $mockTestParameters = @{
-                    ServerRoleName   = 'AdminSqlForBI'
-                    Members          = @(
+                    ServerRoleName = 'AdminSqlForBI'
+                    Members        = @(
                         'CONTOSO\John',
                         'CONTOSO\Kelly'
                     )
@@ -1320,8 +1320,8 @@ Describe 'DSC_SqlRole\Get-CorrectedMemberParameters' -Tag 'Helper' {
                 Set-StrictMode -Version 1.0
 
                 $mockTestParameters = @{
-                    ServerRoleName   = 'sysadmin'
-                    Members          = @(
+                    ServerRoleName = 'sysadmin'
+                    Members        = @(
                         'CONTOSO\John',
                         'CONTOSO\Kelly',
                         'SA'
@@ -1362,8 +1362,8 @@ Describe 'DSC_SqlRole\Get-CorrectedMemberParameters' -Tag 'Helper' {
                 Set-StrictMode -Version 1.0
 
                 $mockTestParameters = @{
-                    ServerRoleName   = 'sysadmin'
-                    Members          = @(
+                    ServerRoleName = 'sysadmin'
+                    Members        = @(
                         'CONTOSO\John',
                         'CONTOSO\Kelly'
                     )

--- a/tests/Unit/DSC_SqlRole.Tests.ps1
+++ b/tests/Unit/DSC_SqlRole.Tests.ps1
@@ -119,7 +119,7 @@ BeforeAll {
                     param
                     (
                         [Parameter(Mandatory = $true)]
-                        [String]
+                        [System.String]
                         $memberName
                     )
 
@@ -138,7 +138,7 @@ BeforeAll {
                     param
                     (
                         [Parameter(Mandatory = $true)]
-                        [String]
+                        [System.String]
                         $memberName
                     )
 
@@ -654,6 +654,9 @@ Describe 'DSC_SqlRole\Test-TargetResource' -Tag 'Test' {
         It 'Should return $false' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
+
+                $mockTestParameters.ServerRoleName = 'TestRole'
+                $mockTestParameters.Ensure = 'Present'
 
                 $result = Test-TargetResource @mockTestParameters
 

--- a/tests/Unit/DSC_SqlScript.Tests.ps1
+++ b/tests/Unit/DSC_SqlScript.Tests.ps1
@@ -191,7 +191,9 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $result = Test-TargetResource @mockTestTargetResourceParameters
+                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
+
+                $result = Test-TargetResource @testTargetResourceParameters
 
                 $result | Should -BeFalse
             }
@@ -403,13 +405,13 @@ Describe 'SqlScript\Test-TargetResource' {
                 }
             }
 
-            It 'Should throw the correct error from Invoke-Sqlcmd' {
+            It 'Should return false' {
                 InModuleScope -ScriptBlock {
                     Set-StrictMode -Version 1.0
 
-                    $mockErrorMessage = 'Failed to run SQL Script'
+                    $result = Test-TargetResource @mockTestTargetResourceParameters
 
-                    { Test-TargetResource @mockTestTargetResourceParameters } | Should -Throw -ExpectedMessage $mockErrorMessage
+                    $result | Should -BeFalse
                 }
             }
         }

--- a/tests/Unit/DSC_SqlScript.Tests.ps1
+++ b/tests/Unit/DSC_SqlScript.Tests.ps1
@@ -179,26 +179,6 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
             }
         }
     }
-
-    Context 'When Get-TargetResource throws an exception' {
-        BeforeAll {
-            Mock -CommandName Get-TargetResource -MockWith {
-                throw 'Unable to connect to SQL instance'
-            }
-        }
-
-        It 'Should return $false' {
-            InModuleScope -ScriptBlock {
-                Set-StrictMode -Version 1.0
-
-                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
-
-                $result = Test-TargetResource @testTargetResourceParameters
-
-                $result | Should -BeFalse
-            }
-        }
-    }
 }
 
 Describe 'SqlScript\Set-TargetResource' -Tag 'Set' {
@@ -315,6 +295,26 @@ Describe 'SqlScript\Test-TargetResource' {
     BeforeEach {
         InModuleScope -ScriptBlock {
             $script:mockTestTargetResourceParameters = $script:mockDefaultParameters.Clone()
+        }
+    }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
+
+                $result = Test-TargetResource @testTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
         }
     }
 

--- a/tests/Unit/DSC_SqlScript.Tests.ps1
+++ b/tests/Unit/DSC_SqlScript.Tests.ps1
@@ -179,6 +179,24 @@ Describe 'SqlScript\Get-TargetResource' -Tag 'Get' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlScript\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlScriptQuery.Tests.ps1
+++ b/tests/Unit/DSC_SqlScriptQuery.Tests.ps1
@@ -81,9 +81,9 @@ Describe 'SqlScriptQuery\Get-TargetResource' -Tag 'Get' {
                 Id           = 'Unit_Test'
                 InstanceName = 'MSSQLSERVER'
                 ServerName   = 'localhost'
-                GetQuery     = "GetQuery;"
-                TestQuery    = "TestQuery;"
-                SetQuery     = "SetQuery;"
+                GetQuery     = 'GetQuery;'
+                TestQuery    = 'TestQuery;'
+                SetQuery     = 'SetQuery;'
                 Encrypt      = 'Optional'
             }
         }
@@ -172,7 +172,9 @@ Describe 'SqlScriptQuery\Get-TargetResource' -Tag 'Get' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $result = Test-TargetResource @mockTestTargetResourceParameters
+                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
+
+                $result = Test-TargetResource @testTargetResourceParameters
 
                 $result | Should -BeFalse
             }
@@ -188,9 +190,9 @@ Describe 'SqlScriptQuery\Set-TargetResource' -Tag 'Set' {
                 Id           = 'Unit_Test'
                 InstanceName = 'MSSQLSERVER'
                 ServerName   = 'localhost'
-                GetQuery     = "GetQuery;"
-                TestQuery    = "TestQuery;"
-                SetQuery     = "SetQuery;"
+                GetQuery     = 'GetQuery;'
+                TestQuery    = 'TestQuery;'
+                SetQuery     = 'SetQuery;'
                 Encrypt      = 'Optional'
             }
         }
@@ -264,9 +266,9 @@ Describe 'SqlScriptQuery\Test-TargetResource' {
                 Id           = 'Unit_Test'
                 InstanceName = 'MSSQLSERVER'
                 ServerName   = 'localhost'
-                GetQuery     = "GetQuery;"
-                TestQuery    = "TestQuery;"
-                SetQuery     = "SetQuery;"
+                GetQuery     = 'GetQuery;'
+                TestQuery    = 'TestQuery;'
+                SetQuery     = 'SetQuery;'
                 Encrypt      = 'Optional'
             }
         }
@@ -360,13 +362,13 @@ Describe 'SqlScriptQuery\Test-TargetResource' {
                 }
             }
 
-            It 'Should throw the correct error from Invoke-Sqlcmd' {
+            It 'Should return false' {
                 InModuleScope -ScriptBlock {
                     Set-StrictMode -Version 1.0
 
-                    $mockErrorMessage = 'Failed to run SQL Script'
+                    $result = Test-TargetResource @mockTestTargetResourceParameters
 
-                    { Test-TargetResource @mockTestTargetResourceParameters } | Should -Throw -ExpectedMessage $mockErrorMessage
+                    $result | Should -BeFalse
                 }
             }
         }

--- a/tests/Unit/DSC_SqlScriptQuery.Tests.ps1
+++ b/tests/Unit/DSC_SqlScriptQuery.Tests.ps1
@@ -160,26 +160,6 @@ Describe 'SqlScriptQuery\Get-TargetResource' -Tag 'Get' {
             }
         }
     }
-
-    Context 'When Get-TargetResource throws an exception' {
-        BeforeAll {
-            Mock -CommandName Get-TargetResource -MockWith {
-                throw 'Unable to connect to SQL instance'
-            }
-        }
-
-        It 'Should return $false' {
-            InModuleScope -ScriptBlock {
-                Set-StrictMode -Version 1.0
-
-                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
-
-                $result = Test-TargetResource @testTargetResourceParameters
-
-                $result | Should -BeFalse
-            }
-        }
-    }
 }
 
 Describe 'SqlScriptQuery\Set-TargetResource' -Tag 'Set' {
@@ -277,6 +257,26 @@ Describe 'SqlScriptQuery\Test-TargetResource' {
     BeforeEach {
         InModuleScope -ScriptBlock {
             $script:mockTestTargetResourceParameters = $script:mockDefaultParameters.Clone()
+        }
+    }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
+
+                $result = Test-TargetResource @testTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
         }
     }
 

--- a/tests/Unit/DSC_SqlScriptQuery.Tests.ps1
+++ b/tests/Unit/DSC_SqlScriptQuery.Tests.ps1
@@ -160,6 +160,24 @@ Describe 'SqlScriptQuery\Get-TargetResource' -Tag 'Get' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlScriptQuery\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlSecureConnection.Tests.ps1
+++ b/tests/Unit/DSC_SqlSecureConnection.Tests.ps1
@@ -340,6 +340,24 @@ Describe 'SqlSecureConnection\Get-TargetResource' -Tag 'Get' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlSecureConnection\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlSecureConnection.Tests.ps1
+++ b/tests/Unit/DSC_SqlSecureConnection.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'SqlSecureConnection\Get-TargetResource' -Tag 'Get' {
         InModuleScope -ScriptBlock {
             # Default parameters that are used for the It-blocks.
             $script:mockDefaultParameters = @{
-                InstanceName = 'INSTANCE'
+                InstanceName    = 'INSTANCE'
                 Thumbprint      = '2A11AB1AB1A11111A1111AB111111AB11ABCDEFB'
                 ServiceAccount  = 'SqlSvc'
                 ForceEncryption = $true
@@ -352,7 +352,9 @@ Describe 'SqlSecureConnection\Get-TargetResource' -Tag 'Get' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
-                $result = Test-TargetResource @mockTestTargetResourceParameters
+                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
+
+                $result = Test-TargetResource @testTargetResourceParameters
 
                 $result | Should -BeFalse
             }
@@ -365,7 +367,7 @@ Describe 'SqlSecureConnection\Set-TargetResource' -Tag 'Set' {
         InModuleScope -ScriptBlock {
             # Default parameters that are used for the It-blocks.
             $script:mockDefaultParameters = @{
-                InstanceName = 'INSTANCE'
+                InstanceName    = 'INSTANCE'
                 Thumbprint      = '2A11AB1AB1A11111A1111AB111111AB11ABCDEFB'
                 ServiceAccount  = 'SqlSvc'
                 ForceEncryption = $true
@@ -392,8 +394,8 @@ Describe 'SqlSecureConnection\Set-TargetResource' -Tag 'Set' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        InstanceName    = 'INSTANCE'
-                        Thumbprint      = '2A11AB1AB1A11111A1111AB111111AB11ABCDEFB'.ToUpper()
+                        InstanceName = 'INSTANCE'
+                        Thumbprint   = '2A11AB1AB1A11111A1111AB111111AB11ABCDEFB'.ToUpper()
                     }
                 }
             }
@@ -417,8 +419,8 @@ Describe 'SqlSecureConnection\Set-TargetResource' -Tag 'Set' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        InstanceName    = 'INSTANCE'
-                        Thumbprint      = '2A11AB1AB1A11111A1111AB111111AB11ABCDEFB'.ToUpper()
+                        InstanceName = 'INSTANCE'
+                        Thumbprint   = '2A11AB1AB1A11111A1111AB111111AB11ABCDEFB'.ToUpper()
                     }
                 }
             }
@@ -569,7 +571,7 @@ Describe 'SqlSecureConnection\Test-TargetResource' -Tag 'Test' {
         InModuleScope -ScriptBlock {
             # Default parameters that are used for the It-blocks.
             $script:mockDefaultParameters = @{
-                InstanceName = 'INSTANCE'
+                InstanceName    = 'INSTANCE'
                 Thumbprint      = '2A11AB1AB1A11111A1111AB111111AB11ABCDEFB'
                 ServiceAccount  = 'SqlSvc'
                 ForceEncryption = $true

--- a/tests/Unit/DSC_SqlSecureConnection.Tests.ps1
+++ b/tests/Unit/DSC_SqlSecureConnection.Tests.ps1
@@ -340,26 +340,6 @@ Describe 'SqlSecureConnection\Get-TargetResource' -Tag 'Get' {
             }
         }
     }
-
-    Context 'When Get-TargetResource throws an exception' {
-        BeforeAll {
-            Mock -CommandName Get-TargetResource -MockWith {
-                throw 'Unable to connect to SQL instance'
-            }
-        }
-
-        It 'Should return $false' {
-            InModuleScope -ScriptBlock {
-                Set-StrictMode -Version 1.0
-
-                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
-
-                $result = Test-TargetResource @testTargetResourceParameters
-
-                $result | Should -BeFalse
-            }
-        }
-    }
 }
 
 Describe 'SqlSecureConnection\Set-TargetResource' -Tag 'Set' {
@@ -584,6 +564,26 @@ Describe 'SqlSecureConnection\Test-TargetResource' -Tag 'Test' {
     BeforeEach {
         InModuleScope -ScriptBlock {
             $script:mockTestTargetResourceParameters = $script:mockDefaultParameters.Clone()
+        }
+    }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $testTargetResourceParameters = $script:mockDefaultParameters.Clone()
+
+                $result = Test-TargetResource @testTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
         }
     }
 

--- a/tests/Unit/DSC_SqlServiceAccount.Tests.ps1
+++ b/tests/Unit/DSC_SqlServiceAccount.Tests.ps1
@@ -460,6 +460,31 @@ Describe 'SqlServerServiceAccount\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $testTargetResourceParameters = @{
+                    ServerName     = 'TestServer'
+                    InstanceName   = 'TestInstance'
+                    ServiceType    = 'DatabaseEngine'
+                    ServiceAccount = (New-Object -TypeName System.Management.Automation.PSCredential 'CONTOSO\sql.service', (New-Object -TypeName System.Security.SecureString))
+                }
+
+                $result = Test-TargetResource @testTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlServerServiceAccount\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlSetup.Tests.ps1
+++ b/tests/Unit/DSC_SqlSetup.Tests.ps1
@@ -2082,6 +2082,29 @@ Describe 'SqlSetup\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $mockTestTargetResourceParameters.Features = 'SQLENGINE'
+                $mockTestTargetResourceParameters.InstanceName = 'MSSQLSERVER'
+                $mockTestTargetResourceParameters.SourceCredential = $null
+                $mockTestTargetResourceParameters.SourcePath = $TestDrive
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlSetup\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlTraceFlag.Tests.ps1
+++ b/tests/Unit/DSC_SqlTraceFlag.Tests.ps1
@@ -730,6 +730,26 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $mockTestTargetResourceParameters.TraceFlags = @('3226')
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'DSC_SqlTraceFlag\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlTraceFlag.Tests.ps1
+++ b/tests/Unit/DSC_SqlTraceFlag.Tests.ps1
@@ -78,8 +78,8 @@ Describe 'DSC_SqlTraceFlag\Get-TargetResource' -Tag 'Get' {
             $mockServerInstances.Add('INST00') | Out-Null
 
             $mockServerObjectHashtable = @{
-                State = 'Existing'
-                Name = 'TestServer'
+                State           = 'Existing'
+                Name            = 'TestServer'
                 ServerInstances = $mockServerInstances
             }
 
@@ -253,7 +253,7 @@ Describe 'DSC_SqlTraceFlag\Get-TargetResource' -Tag 'Get' {
                 $mockErrorMessage = $script:localizedData.NotConnectedToComputerManagement -f 'FakeServer'
 
                 { Get-TargetResource @mockGetTargetResourceParameters } |
-                    Should -Throw -ExpectedMessage ('*' + $mockErrorMessage)            }
+                    Should -Throw -ExpectedMessage ('*' + $mockErrorMessage) }
         }
     }
 }
@@ -280,9 +280,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @()
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @()
                     }
                 }
             }
@@ -308,9 +308,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -340,9 +340,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -368,9 +368,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -396,9 +396,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @()
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @()
                     }
                 }
             }
@@ -424,9 +424,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -455,9 +455,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -483,9 +483,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -511,9 +511,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -539,9 +539,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -567,9 +567,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @()
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @()
                     }
                 }
             }
@@ -595,9 +595,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -623,9 +623,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @()
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @()
                     }
                 }
             }
@@ -651,9 +651,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -679,9 +679,9 @@ Describe 'DSC_SqlTraceFlag\Test-TargetResource' -Tag 'Test' {
             BeforeAll {
                 Mock -CommandName Get-TargetResource -MockWith {
                     return @{
-                        ServerName          = 'TestServer'
-                        InstanceName        = 'MSSQLSERVER'
-                        TraceFlags          = @('1802', '3226')
+                        ServerName   = 'TestServer'
+                        InstanceName = 'MSSQLSERVER'
+                        TraceFlags   = @('1802', '3226')
                     }
                 }
             }
@@ -760,8 +760,8 @@ Describe 'DSC_SqlTraceFlag\Set-TargetResource' -Tag 'Set' {
             $mockServerInstances.Add('INST00') | Out-Null
 
             $mockServerObjectHashtable = @{
-                State = 'Existing'
-                Name = 'TestServer'
+                State           = 'Existing'
+                Name            = 'TestServer'
                 ServerInstances = $mockServerInstances
             }
 
@@ -778,11 +778,11 @@ Describe 'DSC_SqlTraceFlag\Set-TargetResource' -Tag 'Set' {
             $service1.Name = 'MSSQLSERVER'
             $service1.ServiceState = 'Running'
 
-            $service1.StartupParameters = @"
+            $service1.StartupParameters = @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3226;-T1802
-"@
+'@
 
             $Services.Add($service1) | Out-Null
 
@@ -797,11 +797,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3226;-T1802
             $service3.Name = 'MSSQL$INST00'
             $service3.ServiceState = 'Running'
 
-            $service3.StartupParameters = @"
+            $service3.StartupParameters = @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf
-"@
+'@
 
             $Services.Add($service3) | Out-Null
 
@@ -886,11 +886,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf
 
                     $script:mockMethodAlterRan | Should -BeTrue -Because 'method Alter() should run'
 
-                    $script:mockMethodAlterValue | Should -Be @"
+                    $script:mockMethodAlterValue | Should -Be @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf
-"@ -Because 'Alter must change the value correct'
+'@ -Because 'Alter must change the value correct'
                 }
 
                 Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It
@@ -908,11 +908,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf
 
                     $script:mockMethodAlterRan | Should -BeTrue -Because 'method Alter() should run'
 
-                    $script:mockMethodAlterValue | Should -Be @"
+                    $script:mockMethodAlterValue | Should -Be @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3228
-"@ -Because 'Alter must change the value correct'
+'@ -Because 'Alter must change the value correct'
                 }
 
                 Should -Invoke -CommandName New-Object -Exactly -Times 1 -Scope It
@@ -931,11 +931,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3228
 
                     $script:mockMethodAlterRan | Should -BeTrue -Because 'method Alter() should run'
 
-                    $script:mockMethodAlterValue | Should -Be @"
+                    $script:mockMethodAlterValue | Should -Be @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3228
-"@
+'@
                 }
 
                 # New-Object is also called in Get-TargetResource since there is no mock for Get-TargetResource.
@@ -954,11 +954,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3228
 
                     $script:mockMethodAlterRan | Should -BeTrue -Because 'method Alter() should run'
 
-                    $script:mockMethodAlterValue | Should -Be @"
+                    $script:mockMethodAlterValue | Should -Be @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3226;-T1802;-T3228
-"@
+'@
                 }
 
                 # New-Object is also called in Get-TargetResource since there is no mock for Get-TargetResource.
@@ -977,11 +977,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3226;-T1802;-T3228
 
                     $script:mockMethodAlterRan | Should -BeTrue -Because 'method Alter() should run'
 
-                    $script:mockMethodAlterValue | Should -Be @"
+                    $script:mockMethodAlterValue | Should -Be @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3226
-"@
+'@
                 }
 
                 # New-Object is also called in Get-TargetResource since there is no mock for Get-TargetResource.
@@ -1000,11 +1000,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T3226
 
                     $script:mockMethodAlterRan | Should -BeTrue -Because 'method Alter() should run'
 
-                    $script:mockMethodAlterValue | Should -Be @"
+                    $script:mockMethodAlterValue | Should -Be @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf
-"@
+'@
                 }
 
                 # New-Object is also called in Get-TargetResource since there is no mock for Get-TargetResource.
@@ -1024,11 +1024,11 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf
 
                     $script:mockMethodAlterRan | Should -BeTrue -Because 'method Alter() should run'
 
-                    $script:mockMethodAlterValue | Should -Be @"
+                    $script:mockMethodAlterValue | Should -Be @'
 -dC:\Program Files\Microsoft SQL Server\MSSQL15.INST00\MSSQL\DATA\master.mdf;-eC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\Log\ERRORLOG;-lC:\Program Files\Microsoft SQL
 Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T4199
-"@
+'@
                 }
 
                 # New-Object is also called in Get-TargetResource since there is no mock for Get-TargetResource.
@@ -1073,16 +1073,15 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T4199
     }
 
     Context 'For a nonexistent instance' {
-        It 'Should throw for incorrect parameters' {
+        It 'Should return $false for incorrect parameters' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
                 $mockSetTargetResourceParameters.InstanceName = 'INST01'
 
-                $mockErrorMessage = $script:localizedData.NotConnectedToWMI -f 'INST01', 'TestServer'
+                $result = Test-TargetResource @mockSetTargetResourceParameters
 
-                { Test-TargetResource @mockSetTargetResourceParameters } |
-                    Should -Throw -ExpectedMessage ('*' + $mockErrorMessage)
+                $result | Should -BeFalse
             }
         }
     }
@@ -1096,17 +1095,17 @@ Server\MSSQL15.INST00\MSSQL\DATA\mastlog.ldf;-T4199
             }
         }
 
-        It 'Should throw for incorrect parameters' {
+        It 'Should return $false for incorrect parameters' {
             InModuleScope -ScriptBlock {
                 Set-StrictMode -Version 1.0
 
                 $mockSetTargetResourceParameters.ServerName = 'FakeServer'
                 $mockSetTargetResourceParameters.InstanceName = 'INST00' # Instance exist
 
-                $mockErrorMessage = $script:localizedData.NotConnectedToComputerManagement -f 'FakeServer'
+                $result = Test-TargetResource @mockSetTargetResourceParameters
 
-                { Test-TargetResource @mockSetTargetResourceParameters } |
-                    Should -Throw -ExpectedMessage ('*' + $mockErrorMessage)            }
+                $result | Should -BeFalse
+            }
         }
     }
 }

--- a/tests/Unit/DSC_SqlWaitForAG.Tests.ps1
+++ b/tests/Unit/DSC_SqlWaitForAG.Tests.ps1
@@ -377,6 +377,24 @@ Describe 'SqlWaitForAG\Test-TargetResource' -Tag 'Test' {
             Should -Invoke -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlWaitForAG\Set-TargetResource' -Tag 'Set' {

--- a/tests/Unit/DSC_SqlWindowsFirewall.Tests.ps1
+++ b/tests/Unit/DSC_SqlWindowsFirewall.Tests.ps1
@@ -1852,6 +1852,24 @@ Describe 'SqlWindowsFirewall\Test-TargetResource' -Tag 'Test' {
             }
         }
     }
+
+    Context 'When Get-TargetResource throws an exception' {
+        BeforeAll {
+            Mock -CommandName Get-TargetResource -MockWith {
+                throw 'Unable to connect to SQL instance'
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
+
+                $result = Test-TargetResource @mockTestTargetResourceParameters
+
+                $result | Should -BeFalse
+            }
+        }
+    }
 }
 
 Describe 'SqlWindowsFirewall\Set-TargetResource' -Tag 'Set' {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where Test-TargetResource would throw an unhandled exception if the target SQL Server instance was not installed, the service was stopped, or the instance was otherwise unreachable.

This behavior caused Azure Arc Guest Configuration (and standard DSC) to fail immediately with DscConfigurationExecutionFailed, preventing Set-TargetResource from ever running to apply the configuration.

#### This Pull Request (PR) fixes the following issues
- Fixes #2451

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2452)
<!-- Reviewable:end -->
