### PR TITLE
Fix duplicate word in localized strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- DSC_SqlRS and DSC_SqlWindowsFirewall
+  - Fixed a duplicated word in localized `TestFailedAfterSet` messages.
 - SqlScript
   - Fixed logic in `Get-TargetResource` and `Set-TargetResource` to throw an error
     when the SQL script file is missing, instead of incorrectly reporting success

--- a/source/DSCResources/DSC_SqlRS/en-US/DSC_SqlRS.strings.psd1
+++ b/source/DSCResources/DSC_SqlRS/en-US/DSC_SqlRS.strings.psd1
@@ -1,7 +1,7 @@
 ConvertFrom-StringData @'
     Restart = Restarting Reporting Services.
     SuppressRestart = Suppressing restart of Reporting Services.
-    TestFailedAfterSet = Test-TargetResource function returned false when Set-TargetResource function verified the desired state. This indicates that the Set-TargetResource did not correctly set set the desired state, or that the function Test-TargetResource does not correctly evaluate the desired state.
+    TestFailedAfterSet = Test-TargetResource function returned false when Set-TargetResource function verified the desired state. This indicates that the Set-TargetResource did not correctly set the desired state, or that the function Test-TargetResource does not correctly evaluate the desired state.
     ReportingServicesNotFound = SQL Reporting Services instance '{0}' does not exist.
     GetConfiguration = Get the current reporting services configuration for the instance '{0}'.
     RestartToFinishInitialization = Restarting Reporting Services to finish initialization.

--- a/source/DSCResources/DSC_SqlWindowsFirewall/en-US/DSC_SqlWindowsFirewall.strings.psd1
+++ b/source/DSCResources/DSC_SqlWindowsFirewall/en-US/DSC_SqlWindowsFirewall.strings.psd1
@@ -4,7 +4,7 @@ ConvertFrom-StringData @'
     UsingPath = Using the executable at '{0}' to determine the SQL Server major version.
     MajorVersion = The SQL Server major version is '{0}'.
     ModifyFirewallRules = Modifying firewall rules for instance '{0}'.
-    TestFailedAfterSet = Test-TargetResource function returned false when Set-TargetResource function verified the desired state. This indicates that the Set-TargetResource did not correctly set set the desired state, or that the function Test-TargetResource does not correctly evaluate the desired state.
+    TestFailedAfterSet = Test-TargetResource function returned false when Set-TargetResource function verified the desired state. This indicates that the Set-TargetResource did not correctly set the desired state, or that the function Test-TargetResource does not correctly evaluate the desired state.
     EvaluatingFirewallRules = Determines if the firewall rules are in desired state for the instance '{0}'.
     InDesiredState = The firewall rules are in desired state.
     NotInDesiredState = The firewall rules are not in desired state.


### PR DESCRIPTION
## Summary
- Remove duplicate "set" from the `TestFailedAfterSet` localized string in `DSC_SqlWindowsFirewall`.
- Remove the same duplicate word from the `TestFailedAfterSet` localized string in `DSC_SqlRS`.

## Why
While checking the typo reported in #1419, I found the `DSC_SqlSetup` string is already fixed on `main`, but the same wording issue still exists in two related resource strings.

Related to #1419.

## Validation
- Loaded both updated string files with `Import-LocalizedData` and verified `TestFailedAfterSet` is present.
- Confirmed the exact typo `set set the desired state` no longer appears under `source` or `tests`.
- Ran `git diff --check HEAD~1..HEAD`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2463)
<!-- Reviewable:end -->
