### PR TITLE
SqlServerDsc: Fix Pester 6 syntax in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SqlServerDsc
   - Several integration tests wrongly said that the command `Test-DscConfiguration`
     return `$true` when it is in fact return the string value `'True'`.
+  - Some integration tests still wasn't converted correctly to Pester 6 syntax
 - DSC_SqlRS and DSC_SqlWindowsFirewall
   - Fixed a duplicated word in localized `TestFailedAfterSet` messages.
 - SqlServerDsc

--- a/tests/Integration/Resources/DSC_SqlRS_Default.Integration.Tests.ps1
+++ b/tests/Integration/Resources/DSC_SqlRS_Default.Integration.Tests.ps1
@@ -229,7 +229,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
                 }
             }
 
-            $webRequestStatusCode | Should-BeString -CaseSensitive 200
+            $webRequestStatusCode | Should-Be 200
         }
 
         It 'Should be able to access the Reports site without any error' {
@@ -291,7 +291,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
                 }
             }
 
-            $webRequestStatusCode | Should-BeString -CaseSensitive 200
+            $webRequestStatusCode | Should-Be 200
         }
     }
 
@@ -473,7 +473,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
                 }
             }
 
-            $webRequestStatusCode | Should-BeString -CaseSensitive 200
+            $webRequestStatusCode | Should-Be 200
         }
 
         It 'Should be able to access the Reports site without any error' {
@@ -535,7 +535,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
                 }
             }
 
-            $webRequestStatusCode | Should-BeString -CaseSensitive 200
+            $webRequestStatusCode | Should-Be 200
         }
     }
 

--- a/tests/Integration/Resources/DSC_SqlRole.Integration.Tests.ps1
+++ b/tests/Integration/Resources/DSC_SqlRole.Integration.Tests.ps1
@@ -207,7 +207,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
 
             $resourceCurrentState.Ensure | Should-Be 'Present'
             $resourceCurrentState.ServerRoleName | Should-Be $ConfigurationData.AllNodes.Role3Name
-            $resourceCurrentState.Members | Should-Be @(
+            $resourceCurrentState.Members | Should-BeCollection @(
                 $ConfigurationData.AllNodes.User1Name
                 $ConfigurationData.AllNodes.User2Name
             )
@@ -265,7 +265,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             $resourceCurrentState.Ensure | Should-Be 'Present'
             $resourceCurrentState.ServerRoleName | Should-Be $ConfigurationData.AllNodes.Role1Name
 
-            $resourceCurrentState.Members | Should-Be @(
+            $resourceCurrentState.Members | Should-BeCollection @(
                 $ConfigurationData.AllNodes.User1Name
                 $ConfigurationData.AllNodes.User2Name
             )
@@ -324,7 +324,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             $resourceCurrentState.Ensure | Should-Be 'Present'
             $resourceCurrentState.ServerRoleName | Should-Be $ConfigurationData.AllNodes.Role2Name
 
-            $resourceCurrentState.Members | Should-Be @(
+            $resourceCurrentState.Members | Should-BeCollection @(
                 $ConfigurationData.AllNodes.User1Name
                 $ConfigurationData.AllNodes.User2Name
                 $ConfigurationData.AllNodes.User4Name
@@ -509,7 +509,7 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             }
 
             $currentState.Ensure | Should-Be 'Present'
-            $currentState.Members | Should-Be @($testMemberName)
+            $currentState.Members | Should-BeCollection @($testMemberName)
             $currentState.MembersToInclude | Should-BeFalsy
             $currentState.MembersToExclude | Should-BeFalsy
         }

--- a/tests/Integration/Resources/DSC_SqlWindowsFirewall.Integration.Tests.ps1
+++ b/tests/Integration/Resources/DSC_SqlWindowsFirewall.Integration.Tests.ps1
@@ -135,9 +135,9 @@ Describe "$($script:dscResourceName)_Integration" -Tag @('Integration_SQL2016', 
             $resourceCurrentState.SourcePath | Should-Be $ConfigurationData.AllNodes.SourcePath
             $resourceCurrentState.DatabaseEngineFirewall | Should-BeTrue
             $resourceCurrentState.BrowserFirewall | Should-BeTrue
-            $resourceCurrentState.ReportingServicesFirewall | Should-BeFalse
-            $resourceCurrentState.AnalysisServicesFirewall | Should-BeFalse
-            $resourceCurrentState.IntegrationServicesFirewall | Should-BeFalse
+            $resourceCurrentState.ReportingServicesFirewall | Should-BeNull
+            $resourceCurrentState.AnalysisServicesFirewall | Should-BeFalsy
+            $resourceCurrentState.IntegrationServicesFirewall | Should-BeFalsy
         }
 
         It 'Should return True when Test-DscConfiguration is run' {


### PR DESCRIPTION

#### Pull Request (PR) description
- SqlServerDsc
  - Some integration tests still wasn't converted correctly to Pester 6 syntax

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list of the issues using a GitHub closing keyword, e.g.:

- Fixes #123
- Fixes #124
-->

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SqlServerDsc/2468)
<!-- Reviewable:end -->
